### PR TITLE
make Makefile note robust when build dir != src dir.

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ $ ./configure
 Modify `src/Makefile` to read:
 
 ``` makefile
-LIBS_SYSTEM=-L../rust_src/target/debug -lremacs -ldl
+LIBS_SYSTEM=-L$(top_srcdir)/rust_src/target/debug -lremacs -ldl
 ```
 
 Then compile Emacs:


### PR DESCRIPTION
I often do my builds outside of the source tree.

I think this is the way to fix the note in the README.md so that someone who keeps their build directory elsewhere can still make forward progress.

(I am otherwise running into issues like #17 so I have not actually tested this change end-to-end, but it seems solid to me.)