### PR TITLE
Fix LispMisc type.

### DIFF
--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -36,7 +36,6 @@ use marker::{LispMarker, marker_position};
 
 include!(concat!(env!("OUT_DIR"), "/definitions.rs"));
 /// These are an example of the casual case.
-
 #[cfg(dummy = "impossible")]
 pub type EmacsInt = isize;
 #[cfg(dummy = "impossible")]
@@ -224,8 +223,8 @@ unsafe impl Sync for LispSubr {}
 macro_rules! defun {
     ($lisp_name:expr, $fname:ident, $sname:ident, $min_args:expr, $max_args:expr, $intspec:expr, $docstring:expr) => {
         lazy_static! {
-            // TODO: this is blindly hoping we have the correct alignment.
-            // We should ensure we have GCALIGNMENT (8 bytes).
+// TODO: this is blindly hoping we have the correct alignment.
+// We should ensure we have GCALIGNMENT (8 bytes).
             pub static ref $sname: LispSubr = LispSubr {
                 header: VectorLikeHeader {
                     size: ((PvecType::PVEC_SUBR as libc::c_int) <<
@@ -445,12 +444,8 @@ pub struct LispFloatChain {
     chain: *const LispFloat,
 }
 
-// lisp.h uses a union for Lisp_Misc, which we emulate with an opaque
-// struct.
-#[repr(C)]
-pub struct LispMisc {
-    _ignored: i64,
-}
+/// lisp.h uses a union for `Lisp_Misc`, which we emulate with a `*mut libc::c_void`
+pub type LispMisc = *mut libc::c_void;
 
 // Supertype of all Misc types.
 #[repr(C)]


### PR DESCRIPTION
There are a couple of errors when compiling for a 32 bits architecture.
This commit solves these errors.