### PR TITLE
Properly define the emacs integer types.

### DIFF
--- a/rust_src/Cargo.toml
+++ b/rust_src/Cargo.toml
@@ -2,9 +2,13 @@
 authors = ["Wilfred Hughes <me@wilfred.me.uk>"]
 name = "remacs"
 version = "0.1.0"
+build = "build.rs"
 
 [dependencies]
 lazy_static = "0.2.2"
+libc = "0.2.17"
+
+[build-dependencies]
 libc = "0.2.17"
 
 [lib]

--- a/rust_src/build.rs
+++ b/rust_src/build.rs
@@ -1,0 +1,50 @@
+extern crate libc;
+
+use std::env;
+use std::io::Write;
+use std::fs::File;
+use std::path::PathBuf;
+use std::mem::size_of;
+
+#[cfg(feature = "wide-emacs-int")]
+const WIDE_EMACS_INT: bool = true;
+
+#[cfg(not(feature = "wide-emacs-int"))]
+const WIDE_EMACS_INT: bool = false;
+
+fn emacs_int_max<T>() -> String {
+    match size_of::<T>() {
+        1 => "0x7F_i8".to_owned(),
+        2 => "0x7FFF_i16".to_owned(),
+        4 => "0x7FFFFFFF_i32".to_owned(),
+        8 => "0x7FFFFFFFFFFFFFFF_i64".to_owned(),
+        16 => "0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF_i128".to_owned(),
+        _ => panic!("nonstandard int size {}", size_of::<T>()),
+    }
+}
+
+fn emacs_int_types() -> (String, String, String) {
+    if size_of::<libc::intptr_t>() <= size_of::<libc::c_int>() && !WIDE_EMACS_INT {
+        return ("libc::c_int".to_owned(), "libc::c_uint".to_owned(), emacs_int_max::<libc::c_int>());
+    }
+
+    if size_of::<libc::intptr_t>() <= size_of::<libc::c_long>() && !WIDE_EMACS_INT {
+        return ("libc::c_long".to_owned(), "libc::c_ulong".to_owned(), emacs_int_max::<libc::c_long>());
+    }
+
+    if size_of::<libc::intptr_t>() <= size_of::<libc::c_longlong>() {
+        return ("libc::c_longlong".to_owned(), "libc::c_ulonglong".to_owned(), emacs_int_max::<libc::c_longlong>());
+    }
+
+    panic!("build.rs: intptr_t is too large!");
+}
+
+fn main() {
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap()).join("definitions.rs");
+    let mut file = File::create(out_path).expect("Failed to create definition file");
+    let (type1, type2, max1) = emacs_int_types();
+    write!(&mut file, "pub type EmacsInt = {};\n", type1).expect("Write error!");
+    write!(&mut file, "pub type EmacsUint = {};\n", type2).expect("Write error!");
+    write!(&mut file, "pub const EMACS_INT_MAX: EmacsInt = {};\n", max1).expect("Write error!");
+    
+}

--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -26,16 +26,23 @@ use marker::{LispMarker, marker_position};
 /// `EmacsInt` represents an integer big enough to hold our tagged
 /// pointer representation.
 ///
-/// In Emacs C, this is `EMACS_INT`, which is defined as `long int`.
-pub type EmacsInt = libc::c_long;
+/// In Emacs C, this is `EMACS_INT`.
+///
+/// `EmacsUint` represents the unsigned equivalent of `EmacsInt`.
+/// In Emacs C, this is `EMACS_UINT`.
+///
+/// Their definition are determined in a way consistent with Emacs C.
+/// Under casual systems, they're the type isize and usize respectively.
 
-/// Unsigned equivalent of `EmacsInt`. In Emacs C, this is
-/// `EMACS_UINT`, which is defined as `unsigned long`.
-pub type EmacsUint = libc::c_ulong;
+include!(concat!(env!("OUT_DIR"), "/definitions.rs"));
+/// These are an example of the casual case.
 
-// 2**63 - 1, which is the value of LONG_MAX in limits.h in the C
-// stdlib.
-pub const EMACS_INT_MAX: EmacsInt = 9223372036854775807;
+#[cfg(dummy = "impossible")]
+pub type EmacsInt = isize;
+#[cfg(dummy = "impossible")]
+pub type EmacsUint = usize;
+#[cfg(dummy = "impossible")]
+pub const EMACS_INT_MAX: EmacsInt = std::isize::MAX;
 
 // This is dependent on CHECK_LISP_OBJECT_TYPE, a compile time flag,
 // but it's usually false.


### PR DESCRIPTION
Hi, according to lisp.h, this should be the correct definition of the emacs integer types. (Auto generated from build.rs)

With or without the patch, remacs still crashes during the bootstrapping phrase on my Windows machine. Will investigate more about this later.