### PR TITLE
Ports the atom function to Rust

### DIFF
--- a/rust_src/src/atom.rs
+++ b/rust_src/src/atom.rs
@@ -1,0 +1,20 @@
+use std::os::raw::c_char;
+use std::ptr;
+
+extern crate libc;
+
+use cons::CONSP;
+use lisp::{LispObject, LispSubr, Qnil, Qt, VectorLikeHeader, PvecType,
+           PSEUDOVECTOR_AREA_BITS};
+
+
+fn Fatom(object: LispObject) -> LispObject {
+    if CONSP(object) {
+        Qnil
+    } else {
+        unsafe { Qt }
+    }
+}
+
+defun!("atom", Fatom, Satom, 1, 1, ptr::null(),
+"Return t if OBJECT is not a cons cell.  This includes nil.");

--- a/rust_src/src/cons.rs
+++ b/rust_src/src/cons.rs
@@ -13,7 +13,7 @@ extern "C" {
     static Qlistp: LispObject;
 }
 
-fn CONSP(x: LispObject) -> bool {
+pub fn CONSP(x: LispObject) -> bool {
     XTYPE(x) == LispType::Lisp_Cons
 }
 

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -15,6 +15,7 @@ mod cons;
 mod strings;
 mod symbols;
 mod globals;
+mod atom;
 
 use lisp::LispSubr;
 
@@ -38,6 +39,7 @@ extern "C" {
 #[no_mangle]
 pub extern "C" fn rust_init_syms() {
     unsafe {
+        defsubr(&*atom::Satom);
         defsubr(&*math::Smod);
         defsubr(&*math::Splus);
         defsubr(&*math::Sminus);

--- a/src/data.c
+++ b/src/data.c
@@ -249,16 +249,6 @@ for example, (type-of 1) returns `integer'.  */)
     }
 }
 
-DEFUN ("atom", Fatom, Satom, 1, 1, 0,
-       doc: /* Return t if OBJECT is not a cons cell.  This includes nil.  */
-       attributes: const)
-  (Lisp_Object object)
-{
-  if (CONSP (object))
-    return Qnil;
-  return Qt;
-}
-
 DEFUN ("listp", Flistp, Slistp, 1, 1, 0,
        doc: /* Return t if OBJECT is a list, that is, a cons cell or nil.
 Otherwise, return nil.  */
@@ -3332,7 +3322,6 @@ syms_of_data (void)
   defsubr (&Stype_of);
   defsubr (&Slistp);
   defsubr (&Snlistp);
-  defsubr (&Satom);
   defsubr (&Sintegerp);
   defsubr (&Sinteger_or_marker_p);
   defsubr (&Snumberp);

--- a/src/lisp.h
+++ b/src/lisp.h
@@ -1276,6 +1276,7 @@ CDR_SAFE (Lisp_Object c)
 Lisp_Object Fsetcar(Lisp_Object, Lisp_Object);
 Lisp_Object Fsetcdr(Lisp_Object, Lisp_Object);
 Lisp_Object Fcar(Lisp_Object);
+Lisp_Object Fatom(Lisp_Object, Lisp_Object);
 
 /* In a string or vector, the sign bit of the `size' is the gc mark bit.  */
 


### PR DESCRIPTION
Converts the `atom` function to Rust.

This required the use of `CONSP`, so I made it public in `cons.rs`, not sure if this is a reasonable thing to do.

Look forward to feedback