### PR TITLE
missprint in the example code: NUMBERP->SYMBOLP

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ We can see we need to define a `Snumberp` and a `Fnumberp`. `Qt` and
 // This is the function that gets called when 
 // we call numberp in elisp.
 fn Fnumberp(object: LispObject) -> LispObject {
-    if lisp::SYMBOLP(object) {
+    if lisp::NUMBERP(object) {
         unsafe {
             Qt
         }


### PR DESCRIPTION
In the front-page README.md , there is a mistake in the tutorial example. C-function `Fnumberp` uses `NUMBERP` predicate, while the corresponding Rust implementation uses `SYMBOLP` for some reason.