### PR TITLE
Integrate cargo with autoconf

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,6 @@ rust:
   - nightly
 
 script:
-  # Test and build the Rust code.
-  - cd rust_src
-  - cargo test
-  - cargo build
-  - cd ..
-
   # Configure Emacs for building
   - ./autogen.sh
   # TODO: set up makeinfo on travis.

--- a/Makefile.in
+++ b/Makefile.in
@@ -84,6 +84,12 @@ AWK = @AWK@
 
 EXEEXT=@EXEEXT@
 
+RUSTFLAGS=@RUSTFLAGS@
+CARGO_BUILD=@CARGO_BUILD@
+CARGO_CLEAN=@CARGO_CLEAN@
+CARGO_TEST=@CARGO_TEST@
+CARGO_FLAGS=@CARGO_FLAGS@
+
 ### These help us choose version- and architecture-specific directories
 ### to install files in.
 
@@ -202,6 +208,10 @@ icondir=$(datarootdir)/icons
 # The source directory for the icon files.
 iconsrcdir=$(srcdir)/etc/images/icons
 
+# Root of rust src tree (where Cargo.toml is located).
+rust_srcdir=$(srcdir)/rust_src
+cargo_manifest=$(rust_srcdir)/Cargo.toml
+
 # ==================== Emacs-specific directories ====================
 
 # These variables hold the values Emacs will actually use.  They are
@@ -290,7 +300,7 @@ EMACS = ${EMACS_NAME}${EXEEXT}
 EMACSFULL = `echo emacs-${version} | sed '$(TRANSFORM)'`${EXEEXT}
 
 # Subdirectories to make recursively.
-SUBDIR = $(NTDIR) lib lib-src src lisp
+SUBDIR = $(NTDIR) lib lib-src rust-src src lisp
 
 # The subdir makefiles created by config.status.
 SUBDIR_MAKEFILES_IN = @SUBDIR_MAKEFILES_IN@
@@ -369,11 +379,16 @@ epaths-force-w32:
 	  -e "/^.*#/s|@SRC@|$${w32srcdir}|g") &&		\
 	${srcdir}/build-aux/move-if-change epaths.h.$$$$ src/epaths.h
 
+.PHONY: rust-src
+rust-src:
+	RUSTFLAGS=${RUSTFLAGS} \
+	$(CARGO_BUILD) $(CARGO_FLAGS) --manifest-path ${cargo_manifest}
+
 # If lib/Makefile would build files in '.', then build them before
 # building 'lib', to avoid races with parallel makes.
 lib: am--refresh
 
-lib-src src: $(NTDIR) lib
+lib-src src: $(NTDIR) lib rust-src
 
 src: lib-src
 
@@ -837,6 +852,7 @@ clean: $(clean_dirs:=_clean)
 	-rm -f *.tmp etc/*.tmp*
 	-rm -rf info-dir.*
 	-rm -rf *.elc
+	-$(CARGO_CLEAN) --manifest-path ${cargo_manifest}
 
 ### 'bootclean'
 ###      Delete all files that need to be remade for a clean bootstrap.
@@ -932,6 +948,9 @@ check check-expensive: all
 	  echo "Maybe you are using a release tarfile, rather than a repository checkout."; \
 	else \
 	  $(MAKE) -C test/automated $@; \
+	  echo "\nRUNNING RUST_SRC TESTS"; \
+	  echo "------------------------"; \
+	  $(CARGO_TEST) --manifest-path ${cargo_manifest}; \
 	fi
 
 dist:

--- a/README.md
+++ b/README.md
@@ -168,16 +168,8 @@ supports a wider range of languages and we recommend it instead.
 ## Building Remacs
 
 ```
-$ cd rust_src
-$ cargo build
-$ cd ..
 $ ./autogen.sh
 $ ./configure
-```
-
-Then compile Emacs:
-
-```
 $ make
 ```
 
@@ -189,18 +181,23 @@ You can then run your shiny new Remacs:
 $ RUST_BACKTRACE=1 src/remacs -q
 ```
 
-### Release builds
+### Debug builds
 
-As above, but invoke Cargo with:
+As above but with an additional argument to configure:
 
 ``` bash
-$ cargo build --release
+$ ./autogen.sh
+$ ./configure --enable-rust-debug
+$ make
 ```
 
-and modify `src/Makefile`, replacing the blank initialization of `LIBS_SYSTEM` to read:
+The Makefile obeys cargo's RUSTFLAGS variable and options can be passed to
+cargo with CARGO_FLAGS
 
-``` makefile
-LIBS_SYSTEM=-L../rust_src/target/release -lremacs -ldl
+For example:
+
+``` bash
+$ make CARGO_FLAGS="-vv" RUSTFLAGS="-Zunstable-options --pretty"
 ```
 
 ### Rustdoc builds

--- a/configure.ac
+++ b/configure.ac
@@ -5096,6 +5096,42 @@ gl_INIT
 CFLAGS=$SAVE_CFLAGS
 LIBS=$SAVE_LIBS
 
+# Add Rust variables, libs and utilities
+
+RUSTFLAGS=
+
+AC_SUBST(RUSTFLAGS)
+
+CARGO="cargo"
+CARGO_BUILD="$CARGO build"
+CARGO_CLEAN="$CARGO clean"
+CARGO_TEST="$CARGO test"
+
+AC_SUBST(CARGO_BUILD)
+AC_SUBST(CARGO_CLEAN)
+AC_SUBST(CARGO_TEST)
+
+AC_ARG_ENABLE(rust-debug,
+[AS_HELP_STRING([--enable-rust-debug],
+[build rust-src in debug mode
+Useful for debugging rust component of Remacs.])],
+[ac_enable_rust_debug="${enableval}"],[])
+if test x$ac_enable_rust_debug != x ; then
+CARGO_FLAGS=
+else
+CARGO_FLAGS="--release"
+fi
+
+AC_SUBST(CARGO_FLAGS)
+
+LIB_REMACS="-lremacs -ldl"
+
+LDFLAGS_REMACS="-L../$srcdir/rust_src/target/\${CARGO_BUILD_DIR}"
+
+LDFLAGS="$LDFLAGS $LDFLAGS_REMACS"
+
+AC_SUBST(LIB_REMACS)
+
 if test "${opsys}" = "mingw32"; then
   CPPFLAGS="$CPPFLAGS -DUSE_CRT_DLL=1 -I \${abs_top_srcdir}/nt/inc"
   # Remove unneeded switches from the value of CC that goes to Makefiles

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -36,6 +36,8 @@ CC = @CC@
 CFLAGS = @CFLAGS@
 CPPFLAGS = @CPPFLAGS@
 LDFLAGS = @LDFLAGS@
+CARGO_FLAGS = @CARGO_FLAGS@
+RUSTFLAGS = @RUSTFLAGS@
 EXEEXT = @EXEEXT@
 version = @version@
 # Substitute an assignment for the MAKE variable, because
@@ -47,6 +49,7 @@ MKDIR_P = @MKDIR_P@
 # LIBS = @LIBS@
 LIBOBJS = @LIBOBJS@
 
+rust_srcdir=$(srcdir)/rust_src
 lispsource = $(top_srcdir)/lisp
 lib = ../lib
 libsrc = ../lib-src
@@ -119,7 +122,7 @@ PAXCTL_dumped = @PAXCTL_dumped@
 PAXCTL_notdumped = @PAXCTL_notdumped@
 
 ## Some systems define this to request special libraries.
-LIBS_SYSTEM=-L$(top_srcdir)/rust_src/target/debug -lremacs -ldl
+LIBS_SYSTEM=@LIBS_SYSTEM@
 
 ## -lm, or empty.
 LIB_MATH=@LIB_MATH@
@@ -307,6 +310,8 @@ LIBSELINUX_LIBS = @LIBSELINUX_LIBS@
 LIBGNUTLS_LIBS = @LIBGNUTLS_LIBS@
 LIBGNUTLS_CFLAGS = @LIBGNUTLS_CFLAGS@
 
+LIB_REMACS = @LIB_REMACS@
+
 INTERVALS_H = dispextern.h intervals.h composite.h
 
 GETLOADAVG_LIBS = @GETLOADAVG_LIBS@
@@ -339,6 +344,13 @@ AM_V_at = $(am__v_at_@AM_V@)
 am__v_at_ = $(am__v_at_@AM_DEFAULT_V@)
 am__v_at_0 = @
 am__v_at_1 =
+
+
+ifeq ($(findstring --release,$(CARGO_FLAGS)),--release)
+CARGO_BUILD_DIR=release
+else
+CARGO_BUILD_DIR=debug
+endif
 
 DEPDIR=deps
 AUTO_DEPEND = @AUTO_DEPEND@
@@ -483,7 +495,7 @@ LIBES = $(LIBS) $(W32_LIBS) $(LIBS_GNUSTEP) $(LIBX_BASE) $(LIBIMAGE) \
    $(LIBXML2_LIBS) $(LIBGPM) $(LIBRESOLV) $(LIBS_SYSTEM) $(CAIRO_LIBS) \
    $(LIBS_TERMCAP) $(GETLOADAVG_LIBS) $(SETTINGS_LIBS) $(LIBSELINUX_LIBS) \
    $(FREETYPE_LIBS) $(FONTCONFIG_LIBS) $(LIBOTF_LIBS) $(M17N_FLT_LIBS) \
-   $(LIBGNUTLS_LIBS) $(LIB_PTHREAD) \
+   $(LIBGNUTLS_LIBS) $(LIB_PTHREAD) $(LIB_REMACS) \
    $(NOTIFY_LIBS) $(LIB_MATH) $(LIBZ) $(LIBMODULES)
 
 $(leimdir)/leim-list.el: bootstrap-emacs$(EXEEXT)
@@ -582,6 +594,11 @@ gl-stamp: $(libsrc)/make-docfile$(EXEEXT) $(GLOBAL_SOURCES)
 
 globals.h: gl-stamp; @true
 
+$(top_srcdir)/rust_src/target/.rustflags : FORCE
+	echo "$(CARGO_FLAGS) $(RUSTFLAGS)" > $@.tmp
+	diff -q $@ $@.tmp || cp $@.tmp $@
+	rm -f $@.tmp
+
 $(ALLOBJS): globals.h
 
 $(lib)/libgnu.a: $(config_h)
@@ -592,6 +609,7 @@ $(lib)/libgnu.a: $(config_h)
 ## This goes on to affect various things, and the emacs binary fails
 ## to start if Vinstallation_directory has the wrong value.
 temacs$(EXEEXT): $(LIBXMENU) $(ALLOBJS) \
+	         $(top_srcdir)/rust_src/target/.rustflags \
 	         $(lib)/libgnu.a $(EMACSRES) ${charsets} ${charscript}
 	$(AM_V_CCLD)$(CC) $(ALL_CFLAGS) $(TEMACS_LDFLAGS) $(LDFLAGS) \
 	  -o temacs $(ALLOBJS) $(lib)/libgnu.a $(W32_RES_LINK) $(LIBES)

--- a/test/automated/Makefile.in
+++ b/test/automated/Makefile.in
@@ -37,7 +37,7 @@ SEPCHAR = @SEPCHAR@
 # We never change directory before running Emacs, so a relative file
 # name is fine, and makes life easier.  If we need to change
 # directory, we can use emacs --chdir.
-EMACS = ../../src/emacs
+EMACS = ../../src/remacs
 
 EMACS_EXTRAOPT=
 


### PR DESCRIPTION
Adds appropriate rules and dependencies to the existing autoconf/make
based build system. This includes the build process itself, ie make, make
clean and make check, obviating the need to manually edit the
makefiles to account for different build configurations.

The default optimisation level is --release, in line with the C
components. A configure option (--enable-rust-debug) has been added
that clears the arguments to cargo build, but leaves the C flags as is
(This matches the current "debug build" behaviour).

Arguments may be passed to cargo via the CARGO_FLAGS variable.

The RUSTFLAGS environment variable is also explicitly passed when
cargo build is invoked.