### PR TITLE
Correct path for `make check`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ script:
   - ./configure --without-makeinfo --with-xpm=no --with-gif=no
   - make -j 3
 
-  - make check || echo 'make check failed'
+  - make check
 
 notifications:
   fast_finish: true

--- a/test/automated/Makefile.in
+++ b/test/automated/Makefile.in
@@ -37,7 +37,7 @@ SEPCHAR = @SEPCHAR@
 # We never change directory before running Emacs, so a relative file
 # name is fine, and makes life easier.  If we need to change
 # directory, we can use emacs --chdir.
-EMACS = ../../src/emacs
+EMACS = ../../src/remacs
 
 EMACS_EXTRAOPT=
 


### PR DESCRIPTION
The current setup doesn't correctly run the tests and the Travis file causes normal exit even if tests fail.

This just sets the correct path and ensure that `make clean` will fail if tests fail