### PR TITLE
add rust implementation of CHECK_MARKER()

### DIFF
--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -32,6 +32,9 @@ pub use cons::Fsetcar;
 pub use cons::Fsetcdr;
 pub use cons::Fcar;
 
+// These need to be exported as marker.c depends upon them.
+pub use marker::CHECK_MARKER;
+
 extern "C" {
     fn defsubr(sname: *const LispSubr);
 }

--- a/rust_src/src/marker.rs
+++ b/rust_src/src/marker.rs
@@ -1,13 +1,21 @@
 extern crate libc;
 
 use std::ptr;
-use lisp::{LispObject, LispMiscType, XMARKER};
+use lisp::{LispObject, LispMiscType, XMARKER, CHECK_TYPE, MARKERP};
 
 extern "C" {
     // defined in eval.c, where it can actually take an arbitrary
     // number of arguments.
     // TODO: define a Rust version of this that uses Rust strings.
     fn error(m: *const u8, ...);
+    pub static Qmarkerp: LispObject;
+}
+
+/// Raise an error if `x` is not marker.
+#[allow(non_snake_case)]
+#[no_mangle]
+pub extern "C" fn CHECK_MARKER(x: LispObject) {
+    CHECK_TYPE(MARKERP(x), unsafe { Qmarkerp }, x)
 }
 
 // TODO: write a docstring based on the docs in lisp.h.

--- a/src/marker.c
+++ b/src/marker.c
@@ -127,11 +127,8 @@ clear_charpos_cache (struct buffer *b)
     }									\
 }
 
-static void
-CHECK_MARKER (Lisp_Object x)
-{
-  CHECK_TYPE (MARKERP (x), Qmarkerp, x);
-}
+/* exported from rust code (marker.rs) */
+void CHECK_MARKER (Lisp_Object x);
 
 /* Return the byte position corresponding to CHARPOS in B.  */
 


### PR DESCRIPTION
Hello @Wilfred,

here is implementation of `CHECK_MARKER()` from `src/marker.c`. 