### PR TITLE
Implementation of CHECK_STRING()

### DIFF
--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -38,6 +38,9 @@ pub use floatfns::fmod_float;
 // These need to be exported as marker.c depends upon them.
 pub use marker::CHECK_MARKER;
 
+// Defined in lisp.h and widely used in the C codebase.
+pub use lisp::CHECK_STRING;
+
 extern "C" {
     fn defsubr(sname: *const LispSubr);
 }

--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -60,6 +60,7 @@ extern "C" {
     pub static Qnumber_or_marker_p: LispObject;
     pub static Qnumberp: LispObject;
     pub static Qfloatp: LispObject;
+    pub static Qstringp: LispObject;
     fn make_float(float_value: f64) -> LispObject;
 }
 
@@ -364,6 +365,11 @@ impl LispObject {
     pub fn is_number(self) -> bool {
         self.is_integer() || self.is_float()
     }
+
+    #[inline]
+    pub fn is_string(self) -> bool {
+        XTYPE(self) == LispType::Lisp_String
+    }
 }
 
 
@@ -649,6 +655,12 @@ mod deprecated {
         x.is_number()
     }
 
+    /// Is this LispObject a string?
+    #[allow(non_snake_case)]
+    pub fn STRINGP(x: LispObject) -> bool {
+        x.is_string()
+    }
+
     #[test]
     fn test_numberp() {
         assert!(!NUMBERP(Qnil));
@@ -712,9 +724,12 @@ pub fn CHECK_TYPE(ok: bool, predicate: LispObject, x: LispObject) {
     }
 }
 
-
-
-
+/// Raise an error if `x` is not lisp string.
+#[allow(non_snake_case)]
+#[no_mangle]
+pub extern "C" fn CHECK_STRING(x: LispObject) {
+    CHECK_TYPE(STRINGP(x), unsafe { Qstringp }, x);
+}
 
 #[allow(non_snake_case)]
 pub fn MARKERP(a: LispObject) -> bool {

--- a/rust_src/src/strings.rs
+++ b/rust_src/src/strings.rs
@@ -3,14 +3,10 @@ use std::ptr;
 
 extern crate libc;
 
-use lisp::{XTYPE, LispObject, LispType, LispSubr, Qnil};
+use lisp::{LispObject, LispSubr, Qnil, STRINGP};
 
 extern "C" {
     static Qt: LispObject;
-}
-
-fn STRINGP(value: LispObject) -> bool {
-    XTYPE(value) == LispType::Lisp_String
 }
 
 fn Fstringp(object: LispObject) -> LispObject {

--- a/src/lisp.h
+++ b/src/lisp.h
@@ -1271,12 +1271,6 @@ STRINGP (Lisp_Object x)
   return XTYPE (x) == Lisp_String;
 }
 
-INLINE void
-CHECK_STRING (Lisp_Object x)
-{
-  CHECK_TYPE (STRINGP (x), Qstringp, x);
-}
-
 INLINE struct Lisp_String *
 XSTRING (Lisp_Object a)
 {
@@ -2767,6 +2761,9 @@ INLINE void
 {
   lisp_h_CHECK_NUMBER (x);
 }
+
+/* exported from rust code (lisp.rs) */
+void CHECK_STRING (Lisp_Object x);
 
 INLINE void
 CHECK_STRING_CAR (Lisp_Object x)


### PR DESCRIPTION
Additionally `STRINGP` moved to `lisp::deprecated` to be consistent with `FLOATP`, `NUMBERP` and etc..