### PR TITLE
Find rust functions

### DIFF
--- a/lisp/emacs-lisp/find-func.el
+++ b/lisp/emacs-lisp/find-func.el
@@ -419,8 +419,8 @@ If TYPE is nil, look for a function definition.
 Otherwise, TYPE specifies the kind of definition,
 and it is interpreted via `find-function-regexp-alist'.
 The search is done in the source for library LIBRARY."
-  (if (null library)
-      (error "Don't know where `%s' is defined" symbol))
+  (unless library
+    (error "Don't know where `%s' is defined" symbol))
   ;; Some functions are defined as part of the construct
   ;; that defines something else.
   (while (and (symbolp symbol) (get symbol 'definition-name))

--- a/test/automated/find-func-tests.el
+++ b/test/automated/find-func-tests.el
@@ -1,0 +1,95 @@
+;;; find-func-tests.el --- Test suite for find-func library.  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2017 Free Software Foundation, Inc.
+
+;; Author: Chris Barrett <chris+emacs@walrus.cool>
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;;; Code:
+
+(require 'ert)
+(require 'subr-x)
+(require 'find-func)
+
+(defun find-func-tests-set-up-point-for-buf (bufname &rest body)
+  "Move point to the start of the buffer for each test run.
+BUFNAME is the name of the buffer to reset.
+BODY forms will be executed after point has been repositioned."
+  (declare (indent 1))
+  `(save-excursion
+     (when-let (buf (get-buffer ,bufname))
+       (with-current-buffer buf
+         (goto-char (point-min))))
+     ,@body))
+
+(ert-deftest find-func-tests-error-if-rust-source-does-not-exist ()
+  "Check an error is raised if the specified Rust source file does not exist."
+  (should-error (find-function-search-for-symbol 'setcar nil "rust_src/foo.rs")))
+
+(ert-deftest find-func-tests-error-if-function-not-defined ()
+  "Check an error is raised if there is no such defun in the target file."
+  (should-error (find-function-search-for-symbol 'foo nil "rust_src/cons.rs")))
+
+(ert-deftest find-func-tests-finds-function-def-in-rust-source-file ()
+  "Check that the definition location can be found for Rust functions."
+  (find-func-tests-set-up-point-for-buf "cons.rs"
+    (let* ((result (find-function-search-for-symbol 'setcar nil "rust_src/src/cons.rs"))
+           (buffer (car result))
+           (location (cdr result)))
+
+      (should (equal "cons.rs" (buffer-name buffer)))
+      (should (numberp location))
+
+      (with-current-buffer buffer
+        (goto-char location)
+        (let ((line (buffer-substring-no-properties (point) (line-end-position))))
+          (should (string-match-p (rx bol "defun!(\"setcar\"") line)))))))
+
+(ert-deftest find-func-tests-finds-function-def-in-C-source-file ()
+  "Check that the definition location can be found for C functions.
+If the function being tested is ported to Rust, this test will need to be updated."
+  (find-func-tests-set-up-point-for-buf "eval.c"
+    (let* ((result (find-function-search-for-symbol 'setq nil "src/eval.c"))
+           (buffer (car result))
+           (location (cdr result)))
+
+      (should (equal "eval.c" (buffer-name buffer)))
+      (should (numberp location))
+
+      (with-current-buffer buffer
+        (goto-char location)
+        (let ((line (buffer-substring-no-properties (point) (line-end-position))))
+          (should (string-match-p (rx bol "DEFUN" (* space) "(\"setq\"") line)))))))
+
+(ert-deftest find-func-tests-finds-function-def-in-lisp-source-file ()
+  "Check that the definition location can be found for lisp functions."
+  (find-func-tests-set-up-point-for-buf "find-func.el"
+    (let* ((result (find-function-search-for-symbol 'find-function nil "find-func.el"))
+           (buffer (car result))
+           (location (cdr result)))
+
+      (should (string-match-p (rx "find-func.el" (? ".gz")) (buffer-name buffer)))
+      (should (numberp location))
+
+      (with-current-buffer buffer
+        (goto-char location)
+        (let ((line (buffer-substring-no-properties (point) (line-end-position))))
+          (should (string-match-p (rx bol "(defun" (+ space) "find-function") line)))))))
+
+(provide 'find-func-tests)
+
+;;; find-func-tests.el ends here


### PR DESCRIPTION
Teaches `find-function-search-for-symbol` how to resolve definitions from Rust sources, provided the definition file ends in `.rs`. 

I'm having trouble building the repo so it's unproven, but I've included a test suite. Hopefully someone can verify this PR while I try to figure this out.

Resolves #34.