### PR TITLE
add dead_code attribute for XFLOAT_DATA for now

### DIFF
--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -638,6 +638,7 @@ mod deprecated {
     }
 
     #[allow(non_snake_case)]
+    #[allow(dead_code)]
     pub fn XFLOAT_DATA(f: LispObject) -> f64 {
         unsafe { f.get_float_data_unchecked() }
     }


### PR DESCRIPTION
In other way we will get warning:

```
warning: function is never used: `XFLOAT_DATA`,

   --> rust_src/src/lisp.rs:641:5

    |

641 |     pub fn XFLOAT_DATA(f: LispObject) -> f64 {

    |     ^
```