### PR TITLE
Improve makefile rust dependencies

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -311,7 +311,7 @@ EMACS = ${EMACS_NAME}${EXEEXT}
 EMACSFULL = `echo emacs-${version} | sed '$(TRANSFORM)'`${EXEEXT}
 
 # Subdirectories to make recursively.
-SUBDIR = $(NTDIR) lib lib-src rust-src src lisp
+SUBDIR = $(NTDIR) lib lib-src src lisp
 
 # The subdir makefiles created by config.status.
 SUBDIR_MAKEFILES_IN = @SUBDIR_MAKEFILES_IN@
@@ -397,7 +397,7 @@ rust-src:
 
 # If lib/Makefile would build files in '.', then build them before
 # building 'lib', to avoid races with parallel makes.
-lib: am--refresh
+lib: am--refresh rust-src
 
 lib-src src: $(NTDIR) lib rust-src
 


### PR DESCRIPTION
This change ensures that the rust build is a dependency of all of
emacs' C code rather than just the src and lib-src directories