### PR TITLE
Feature/port number helpers

### DIFF
--- a/rust_src/src/floatfns.rs
+++ b/rust_src/src/floatfns.rs
@@ -3,7 +3,7 @@ extern crate libc;
 use std::os::raw::c_char;
 use std::ptr;
 
-use lisp::{LispObject, LispSubr, Qnumberp, Qfloatp, EmacsDouble, CHECK_TYPE};
+use lisp::{LispObject, LispSubr,  Qnumberp, Qfloatp, EmacsDouble, CHECK_TYPE};
 
 pub fn init_float_syms() {
     unsafe {

--- a/rust_src/src/floatfns.rs
+++ b/rust_src/src/floatfns.rs
@@ -3,7 +3,7 @@ extern crate libc;
 use std::os::raw::c_char;
 use std::ptr;
 
-use lisp::{LispObject, LispSubr,  Qnumberp, Qfloatp, EmacsDouble, CHECK_TYPE};
+use lisp::{LispObject, LispSubr, Qnumberp, Qfloatp, EmacsDouble, CHECK_TYPE};
 
 pub fn init_float_syms() {
     unsafe {

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -26,6 +26,7 @@ pub use math::Ftimes;
 pub use math::Fmax;
 pub use math::Fmin;
 pub use math::Fquo;
+pub use numbers::Fintegerp;
 pub use numbers::Ffloatp;
 
 // Widely used in the C codebase.
@@ -63,6 +64,7 @@ pub extern "C" fn rust_init_syms() {
         defsubr(&*math::Slogxor);
         defsubr(&*math::Smax);
         defsubr(&*math::Smin);
+        defsubr(&*numbers::Sintegerp);
         defsubr(&*numbers::Sfloatp);
         defsubr(&*symbols::Ssymbolp);
         defsubr(&*lists::Sconsp);

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -26,12 +26,6 @@ pub use math::Ftimes;
 pub use math::Fmax;
 pub use math::Fmin;
 pub use math::Fquo;
-pub use numbers::Fintegerp;
-pub use numbers::Finteger_or_marker_p;
-pub use numbers::Ffloatp;
-pub use numbers::Fnatnump;
-pub use numbers::Fnumberp;
-pub use numbers::Fnumber_or_marker_p;
 
 // Widely used in the C codebase.
 pub use lists::Fsetcar;

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -27,6 +27,7 @@ pub use math::Fmax;
 pub use math::Fmin;
 pub use math::Fquo;
 pub use numbers::Fintegerp;
+pub use numbers::Finteger_or_marker_p;
 pub use numbers::Ffloatp;
 pub use numbers::Fnatnump;
 pub use numbers::Fnumberp;
@@ -67,6 +68,7 @@ pub extern "C" fn rust_init_syms() {
         defsubr(&*math::Smax);
         defsubr(&*math::Smin);
         defsubr(&*numbers::Sintegerp);
+        defsubr(&*numbers::Sinteger_or_marker_p);
         defsubr(&*numbers::Sfloatp);
         defsubr(&*numbers::Snatnump);
         defsubr(&*numbers::Snumberp);

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -31,6 +31,7 @@ pub use numbers::Finteger_or_marker_p;
 pub use numbers::Ffloatp;
 pub use numbers::Fnatnump;
 pub use numbers::Fnumberp;
+pub use numbers::Fnumber_or_marker_p;
 
 // Widely used in the C codebase.
 pub use lists::Fsetcar;
@@ -71,6 +72,7 @@ pub extern "C" fn rust_init_syms() {
         defsubr(&*numbers::Sinteger_or_marker_p);
         defsubr(&*numbers::Sfloatp);
         defsubr(&*numbers::Snatnump);
+        defsubr(&*numbers::Snumber_or_marker_p);
         defsubr(&*numbers::Snumberp);
         defsubr(&*symbols::Ssymbolp);
         defsubr(&*lists::Sconsp);

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -29,6 +29,7 @@ pub use math::Fquo;
 pub use numbers::Fintegerp;
 pub use numbers::Ffloatp;
 pub use numbers::Fnatnump;
+pub use numbers::Fnumberp;
 
 // Widely used in the C codebase.
 pub use lists::Fsetcar;
@@ -68,6 +69,7 @@ pub extern "C" fn rust_init_syms() {
         defsubr(&*numbers::Sintegerp);
         defsubr(&*numbers::Sfloatp);
         defsubr(&*numbers::Snatnump);
+        defsubr(&*numbers::Snumberp);
         defsubr(&*symbols::Ssymbolp);
         defsubr(&*lists::Sconsp);
         defsubr(&*lists::Ssetcar);

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -12,6 +12,7 @@ mod marker;
 mod eval;
 mod floatfns;
 mod math;
+mod numbers;
 mod strings;
 mod symbols;
 mod globals;
@@ -25,6 +26,7 @@ pub use math::Ftimes;
 pub use math::Fmax;
 pub use math::Fmin;
 pub use math::Fquo;
+pub use numbers::Ffloatp;
 
 // Widely used in the C codebase.
 pub use lists::Fsetcar;
@@ -61,6 +63,7 @@ pub extern "C" fn rust_init_syms() {
         defsubr(&*math::Slogxor);
         defsubr(&*math::Smax);
         defsubr(&*math::Smin);
+        defsubr(&*numbers::Sfloatp);
         defsubr(&*symbols::Ssymbolp);
         defsubr(&*lists::Sconsp);
         defsubr(&*lists::Ssetcar);

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -28,6 +28,7 @@ pub use math::Fmin;
 pub use math::Fquo;
 pub use numbers::Fintegerp;
 pub use numbers::Ffloatp;
+pub use numbers::Fnatnump;
 
 // Widely used in the C codebase.
 pub use lists::Fsetcar;
@@ -66,6 +67,7 @@ pub extern "C" fn rust_init_syms() {
         defsubr(&*math::Smin);
         defsubr(&*numbers::Sintegerp);
         defsubr(&*numbers::Sfloatp);
+        defsubr(&*numbers::Snatnump);
         defsubr(&*symbols::Ssymbolp);
         defsubr(&*lists::Sconsp);
         defsubr(&*lists::Ssetcar);

--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -638,6 +638,16 @@ mod deprecated {
     }
 
     #[allow(non_snake_case)]
+    pub fn NATNUMP(a: LispObject) -> bool {
+        INTEGERP(a) && 0 <= XINT(a)
+    }
+
+    #[test]
+    fn test_natnump() {
+        assert!(!NATNUMP(Qnil));
+    }
+
+    #[allow(non_snake_case)]
     #[allow(dead_code)]
     pub fn XFLOAT(a: LispObject) -> LispFloatRef {
         debug_assert!(FLOATP(a));

--- a/rust_src/src/numbers.rs
+++ b/rust_src/src/numbers.rs
@@ -5,8 +5,7 @@ use std::ptr;
 
 use lisp::{LispObject, LispSubr, Qnil, Qt, INTEGERP, FLOATP, MARKERP, NATNUMP, NUMBERP};
 
-#[no_mangle]
-pub fn Ffloatp(object: LispObject) -> LispObject {
+fn Ffloatp(object: LispObject) -> LispObject {
     if FLOATP(object) {
         unsafe { Qt }
     } else {
@@ -23,8 +22,7 @@ defun!("floatp",
 
 (fn OBJECT)");
 
-#[no_mangle]
-pub fn Fintegerp(object: LispObject) -> LispObject {
+fn Fintegerp(object: LispObject) -> LispObject {
     if INTEGERP(object) {
         unsafe { Qt }
     } else {
@@ -41,7 +39,7 @@ defun!("integerp",
 
 (fn OBJECT)");
 
-pub fn Finteger_or_marker_p(object: LispObject) -> LispObject {
+fn Finteger_or_marker_p(object: LispObject) -> LispObject {
     if MARKERP(object) || INTEGERP(object) {
         unsafe { Qt }
     } else {
@@ -58,8 +56,7 @@ defun!("integer-or-marker-p",
 
 (fn OBJECT)");
 
-#[no_mangle]
-pub fn Fnatnump(object: LispObject) -> LispObject {
+fn Fnatnump(object: LispObject) -> LispObject {
     if NATNUMP(object) {
         unsafe { Qt }
     } else {
@@ -76,8 +73,7 @@ defun!("natnump",
 
 (fn OBJECT)");
 
-#[no_mangle]
-pub fn Fnumberp(object: LispObject) -> LispObject {
+fn Fnumberp(object: LispObject) -> LispObject {
     if NUMBERP(object) {
         unsafe { Qt }
     } else {
@@ -94,8 +90,7 @@ defun!("numberp",
 
 (fn OBJECT)");
 
-#[no_mangle]
-pub fn Fnumber_or_marker_p(object: LispObject) -> LispObject {
+fn Fnumber_or_marker_p(object: LispObject) -> LispObject {
     if NUMBERP(object) || MARKERP(object) {
         unsafe { Qt }
     } else {

--- a/rust_src/src/numbers.rs
+++ b/rust_src/src/numbers.rs
@@ -3,7 +3,7 @@ extern crate libc;
 use std::os::raw::c_char;
 use std::ptr;
 
-use lisp::{LispObject, LispSubr, Qnil, Qt, FLOATP};
+use lisp::{LispObject, LispSubr, Qnil, Qt, INTEGERP, FLOATP};
 
 #[no_mangle]
 pub fn Ffloatp(object: LispObject) -> LispObject {
@@ -20,5 +20,23 @@ defun!("floatp",
        1, 1,
        ptr::null(),
        "Return t if OBJECT is a floating point number.
+
+(fn OBJECT)");
+
+#[no_mangle]
+pub fn Fintegerp(object: LispObject) -> LispObject {
+    if INTEGERP(object) {
+        unsafe { Qt }
+    } else {
+        Qnil
+    }
+}
+
+defun!("integerp",
+       Fintegerp,
+       Sintegerp,
+       1, 1,
+       ptr::null(),
+       "Return t if OBJECT is an integer.
 
 (fn OBJECT)");

--- a/rust_src/src/numbers.rs
+++ b/rust_src/src/numbers.rs
@@ -93,3 +93,21 @@ defun!("numberp",
        "Return t if OBJECT is a number (floating point or integer).
 
 (fn OBJECT)");
+
+#[no_mangle]
+pub fn Fnumber_or_marker_p(object: LispObject) -> LispObject {
+    if NUMBERP(object) || MARKERP(object) {
+        unsafe { Qt }
+    } else {
+        Qnil
+    }
+}
+
+defun!("number-or-marker-p",
+       Fnumber_or_marker_p,
+       Snumber_or_marker_p,
+       1, 1,
+       ptr::null(),
+       "Return t if OBJECT is a number or a marker (editor pointer).
+
+(fn OBJECT)");

--- a/rust_src/src/numbers.rs
+++ b/rust_src/src/numbers.rs
@@ -1,0 +1,24 @@
+extern crate libc;
+
+use std::os::raw::c_char;
+use std::ptr;
+
+use lisp::{LispObject, LispSubr, Qnil, Qt, FLOATP};
+
+#[no_mangle]
+pub fn Ffloatp(object: LispObject) -> LispObject {
+    if FLOATP(object) {
+        unsafe { Qt }
+    } else {
+        Qnil
+    }
+}
+
+defun!("floatp",
+       Ffloatp,
+       Sfloatp,
+       1, 1,
+       ptr::null(),
+       "Return t if OBJECT is a floating point number.
+
+(fn OBJECT)");

--- a/rust_src/src/numbers.rs
+++ b/rust_src/src/numbers.rs
@@ -3,7 +3,7 @@ extern crate libc;
 use std::os::raw::c_char;
 use std::ptr;
 
-use lisp::{LispObject, LispSubr, Qnil, Qt, INTEGERP, FLOATP, NATNUMP};
+use lisp::{LispObject, LispSubr, Qnil, Qt, INTEGERP, FLOATP, NATNUMP, NUMBERP};
 
 #[no_mangle]
 pub fn Ffloatp(object: LispObject) -> LispObject {
@@ -57,5 +57,23 @@ defun!("natnump",
        1, 1,
        ptr::null(),
        "Return t if OBJECT is a non-negative integer.
+
+(fn OBJECT)");
+
+#[no_mangle]
+pub fn Fnumberp(object: LispObject) -> LispObject {
+    if NUMBERP(object) {
+        unsafe { Qt }
+    } else {
+        Qnil
+    }
+}
+
+defun!("numberp",
+       Fnumberp,
+       Snumberp,
+       1, 1,
+       ptr::null(),
+       "Return t if OBJECT is a number (floating point or integer).
 
 (fn OBJECT)");

--- a/rust_src/src/numbers.rs
+++ b/rust_src/src/numbers.rs
@@ -3,7 +3,7 @@ extern crate libc;
 use std::os::raw::c_char;
 use std::ptr;
 
-use lisp::{LispObject, LispSubr, Qnil, Qt, INTEGERP, FLOATP, NATNUMP, NUMBERP};
+use lisp::{LispObject, LispSubr, Qnil, Qt, INTEGERP, FLOATP, MARKERP, NATNUMP, NUMBERP};
 
 #[no_mangle]
 pub fn Ffloatp(object: LispObject) -> LispObject {
@@ -41,6 +41,23 @@ defun!("integerp",
 
 (fn OBJECT)");
 
+pub fn Finteger_or_marker_p(object: LispObject) -> LispObject {
+    if MARKERP(object) || INTEGERP(object) {
+        unsafe { Qt }
+    } else {
+        Qnil
+    }
+}
+
+defun!("integer-or-marker-p",
+       Finteger_or_marker_p,
+       Sinteger_or_marker_p,
+       1, 1,
+       ptr::null(),
+       "Return t if OBJECT is an integer or a marker (editor pointer).
+
+(fn OBJECT)");
+
 #[no_mangle]
 pub fn Fnatnump(object: LispObject) -> LispObject {
     if NATNUMP(object) {
@@ -49,7 +66,6 @@ pub fn Fnatnump(object: LispObject) -> LispObject {
         Qnil
     }
 }
-
 
 defun!("natnump",
        Fnatnump,

--- a/rust_src/src/numbers.rs
+++ b/rust_src/src/numbers.rs
@@ -3,7 +3,7 @@ extern crate libc;
 use std::os::raw::c_char;
 use std::ptr;
 
-use lisp::{LispObject, LispSubr, Qnil, Qt, INTEGERP, FLOATP};
+use lisp::{LispObject, LispSubr, Qnil, Qt, INTEGERP, FLOATP, NATNUMP};
 
 #[no_mangle]
 pub fn Ffloatp(object: LispObject) -> LispObject {
@@ -38,5 +38,24 @@ defun!("integerp",
        1, 1,
        ptr::null(),
        "Return t if OBJECT is an integer.
+
+(fn OBJECT)");
+
+#[no_mangle]
+pub fn Fnatnump(object: LispObject) -> LispObject {
+    if NATNUMP(object) {
+        unsafe { Qt }
+    } else {
+        Qnil
+    }
+}
+
+
+defun!("natnump",
+       Fnatnump,
+       Snatnump,
+       1, 1,
+       ptr::null(),
+       "Return t if OBJECT is a non-negative integer.
 
 (fn OBJECT)");

--- a/src/data.c
+++ b/src/data.c
@@ -395,16 +395,6 @@ DEFUN ("char-or-string-p", Fchar_or_string_p, Schar_or_string_p, 1, 1, 0,
   return Qnil;
 }
 
-DEFUN ("number-or-marker-p", Fnumber_or_marker_p,
-       Snumber_or_marker_p, 1, 1, 0,
-       doc: /* Return t if OBJECT is a number or a marker.  */)
-  (Lisp_Object object)
-{
-  if (NUMBERP (object) || MARKERP (object))
-    return Qt;
-  return Qnil;
-}
-
 DEFUN ("threadp", Fthreadp, Sthreadp, 1, 1, 0,
        doc: /* Return t if OBJECT is a thread.  */)
   (Lisp_Object object)
@@ -3326,7 +3316,6 @@ syms_of_data (void)
   defsubr (&Sindirect_variable);
   defsubr (&Sinteractive_form);
   defsubr (&Stype_of);
-  defsubr (&Snumber_or_marker_p);
   defsubr (&Skeywordp);
   defsubr (&Smultibyte_string_p);
   defsubr (&Svectorp);

--- a/src/data.c
+++ b/src/data.c
@@ -404,16 +404,7 @@ DEFUN ("integer-or-marker-p", Finteger_or_marker_p, Sinteger_or_marker_p, 1, 1, 
   return Qnil;
 }
 
-DEFUN ("numberp", Fnumberp, Snumberp, 1, 1, 0,
-       doc: /* Return t if OBJECT is a number (floating point or integer).  */
-       attributes: const)
-  (Lisp_Object object)
-{
-  if (NUMBERP (object))
-    return Qt;
-  else
-    return Qnil;
-}
+
 
 DEFUN ("number-or-marker-p", Fnumber_or_marker_p,
        Snumber_or_marker_p, 1, 1, 0,
@@ -3347,7 +3338,6 @@ syms_of_data (void)
   defsubr (&Sinteractive_form);
   defsubr (&Stype_of);
   defsubr (&Sinteger_or_marker_p);
-  defsubr (&Snumberp);
   defsubr (&Snumber_or_marker_p);
   defsubr (&Skeywordp);
   defsubr (&Smultibyte_string_p);

--- a/src/data.c
+++ b/src/data.c
@@ -395,17 +395,6 @@ DEFUN ("char-or-string-p", Fchar_or_string_p, Schar_or_string_p, 1, 1, 0,
   return Qnil;
 }
 
-DEFUN ("integer-or-marker-p", Finteger_or_marker_p, Sinteger_or_marker_p, 1, 1, 0,
-       doc: /* Return t if OBJECT is an integer or a marker (editor pointer).  */)
-  (register Lisp_Object object)
-{
-  if (MARKERP (object) || INTEGERP (object))
-    return Qt;
-  return Qnil;
-}
-
-
-
 DEFUN ("number-or-marker-p", Fnumber_or_marker_p,
        Snumber_or_marker_p, 1, 1, 0,
        doc: /* Return t if OBJECT is a number or a marker.  */)
@@ -3337,7 +3326,6 @@ syms_of_data (void)
   defsubr (&Sindirect_variable);
   defsubr (&Sinteractive_form);
   defsubr (&Stype_of);
-  defsubr (&Sinteger_or_marker_p);
   defsubr (&Snumber_or_marker_p);
   defsubr (&Skeywordp);
   defsubr (&Smultibyte_string_p);

--- a/src/data.c
+++ b/src/data.c
@@ -394,16 +394,6 @@ DEFUN ("char-or-string-p", Fchar_or_string_p, Schar_or_string_p, 1, 1, 0,
     return Qt;
   return Qnil;
 }
-
-DEFUN ("integerp", Fintegerp, Sintegerp, 1, 1, 0,
-       doc: /* Return t if OBJECT is an integer.  */
-       attributes: const)
-  (Lisp_Object object)
-{
-  if (INTEGERP (object))
-    return Qt;
-  return Qnil;
-}
 
 DEFUN ("integer-or-marker-p", Finteger_or_marker_p, Sinteger_or_marker_p, 1, 1, 0,
        doc: /* Return t if OBJECT is an integer or a marker (editor pointer).  */)
@@ -3366,7 +3356,6 @@ syms_of_data (void)
   defsubr (&Sindirect_variable);
   defsubr (&Sinteractive_form);
   defsubr (&Stype_of);
-  defsubr (&Sintegerp);
   defsubr (&Sinteger_or_marker_p);
   defsubr (&Snumberp);
   defsubr (&Snumber_or_marker_p);

--- a/src/data.c
+++ b/src/data.c
@@ -445,16 +445,6 @@ DEFUN ("number-or-marker-p", Fnumber_or_marker_p,
   return Qnil;
 }
 
-DEFUN ("floatp", Ffloatp, Sfloatp, 1, 1, 0,
-       doc: /* Return t if OBJECT is a floating point number.  */
-       attributes: const)
-  (Lisp_Object object)
-{
-  if (FLOATP (object))
-    return Qt;
-  return Qnil;
-}
-
 DEFUN ("threadp", Fthreadp, Sthreadp, 1, 1, 0,
        doc: /* Return t if OBJECT is a thread.  */)
   (Lisp_Object object)
@@ -3380,7 +3370,6 @@ syms_of_data (void)
   defsubr (&Sinteger_or_marker_p);
   defsubr (&Snumberp);
   defsubr (&Snumber_or_marker_p);
-  defsubr (&Sfloatp);
   defsubr (&Snatnump);
   defsubr (&Skeywordp);
   defsubr (&Smultibyte_string_p);

--- a/src/data.c
+++ b/src/data.c
@@ -404,16 +404,6 @@ DEFUN ("integer-or-marker-p", Finteger_or_marker_p, Sinteger_or_marker_p, 1, 1, 
   return Qnil;
 }
 
-DEFUN ("natnump", Fnatnump, Snatnump, 1, 1, 0,
-       doc: /* Return t if OBJECT is a nonnegative integer.  */
-       attributes: const)
-  (Lisp_Object object)
-{
-  if (NATNUMP (object))
-    return Qt;
-  return Qnil;
-}
-
 DEFUN ("numberp", Fnumberp, Snumberp, 1, 1, 0,
        doc: /* Return t if OBJECT is a number (floating point or integer).  */
        attributes: const)
@@ -3359,7 +3349,6 @@ syms_of_data (void)
   defsubr (&Sinteger_or_marker_p);
   defsubr (&Snumberp);
   defsubr (&Snumber_or_marker_p);
-  defsubr (&Snatnump);
   defsubr (&Skeywordp);
   defsubr (&Smultibyte_string_p);
   defsubr (&Svectorp);


### PR DESCRIPTION
Port a bunch of number helpers to Rust

- [x] integerp
- [x] natnump
- [x] numberp
- [x] integer-or-marker-p
- [x] number-or-marker-p