### PR TITLE
(Fix for os_x_build_on_travis branch) add --with-gnutls=no to travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ script:
   # Configure Emacs for building
   - ./autogen.sh
   # TODO: set up makeinfo on travis.
-  - ./configure --without-makeinfo --with-xpm=no --with-gif=no
+  - ./configure --without-makeinfo --with-xpm=no --with-gif=no --with-gnutls=no
   - make -j 3
 
   - make check || echo 'make check failed'


### PR DESCRIPTION
With this change travis successfully builds temacs

Now the failure is "emacs: Invalid function: cdr", which looks like an actual bug somewhere.

Question: Should mac and linux be given different configure args?

