### PR TITLE
Add temacs make rule dep on libremacs.a

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -596,11 +596,13 @@ gl-stamp: $(libsrc)/make-docfile$(EXEEXT) $(GLOBAL_SOURCES)
 
 globals.h: gl-stamp; @true
 
-$(top_srcdir)/rust_src/target/.rustflags : FORCE
+RUSTFLAGS_FILE=$(top_srcdir)/rust_src/target/.rustflags
+$(RUSTFLAGS_FILE) : FORCE
 	echo "$(CARGO_FLAGS) $(RUSTFLAGS)" > $@.tmp
 	diff -q $@ $@.tmp || cp $@.tmp $@
 	rm -f $@.tmp
 
+LIBREMACS_ARCHIVE=$(top_srcdir)/rust_src/target/$(CARGO_BUILD_DIR)/libremacs.a
 $(ALLOBJS): globals.h
 
 LIBEGNU_ARCHIVE = $(lib)/lib$(if $(HYBRID_MALLOC),e)gnu.a
@@ -613,7 +615,7 @@ $(LIBEGNU_ARCHIVE): $(config_h)
 ## This goes on to affect various things, and the emacs binary fails
 ## to start if Vinstallation_directory has the wrong value.
 temacs$(EXEEXT): $(LIBXMENU) $(ALLOBJS) \
-	         $(top_srcdir)/rust_src/target/.rustflags \
+	         $(LIBREMACS_ARCHIVE) $(RUSTFLAGS_FILE) \
 	         $(LIBEGNU_ARCHIVE) $(EMACSRES) ${charsets} ${charscript}
 	$(AM_V_CCLD)$(CC) $(ALL_CFLAGS) $(TEMACS_LDFLAGS) $(LDFLAGS) \
 	  -o temacs $(ALLOBJS) $(LIBEGNU_ARCHIVE) $(W32_RES_LINK) $(LIBES)


### PR DESCRIPTION
This ensures temacs is relinked if a new libremacs.a is present, ie if
rust-src has changed.

In my original patch I somehow left this out... Anyway, this makes sure
temacs is relinked if the cargo is rerun with different flags OR if the
libremacs.a archive file is updated.

Previously it only depended on cargo having been rerun with different
flags without changing the libremacs.a archive that temacs had been
built with. ie I handled the edge case and forgot about the rest... 🤦‍ 