### PR TITLE
Fix Fabs to handle numberp

### DIFF
--- a/rust_src/src/floatfns.rs
+++ b/rust_src/src/floatfns.rs
@@ -17,7 +17,6 @@ pub fn init_float_syms() {
         ::defsubr(&*Slog);
 
         ::defsubr(&*Ssqrt);
-        ::defsubr(&*Sabs);
         ::defsubr(&*Sexp);
         ::defsubr(&*Sffloor);
         ::defsubr(&*Sfceiling);
@@ -91,7 +90,6 @@ simple_float_op!("tan",  Ftan,  Stan,  tan, "Return the tangent of ARG.");
 
 simple_float_op!("exp",  Fexp,  Sexp,  exp,  "Return the exponential base e of ARG.");
 simple_float_op!("sqrt", Fsqrt, Ssqrt, sqrt, "Return the square root of ARG.");
-simple_float_op!("abs",  Fabs,  Sabs,  abs,  "Return the absolute value of ARG.");
 
 simple_float_op!("fceiling", Ffceiling, Sfceiling, ceil,
     "Return the smallest integer no less than ARG, as a float.

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -65,6 +65,7 @@ pub extern "C" fn rust_init_syms() {
         defsubr(&*math::Slogxor);
         defsubr(&*math::Smax);
         defsubr(&*math::Smin);
+        defsubr(&*math::Sabs);
         defsubr(&*numbers::Sintegerp);
         defsubr(&*numbers::Sinteger_or_marker_p);
         defsubr(&*numbers::Sfloatp);

--- a/rust_src/src/math.rs
+++ b/rust_src/src/math.rs
@@ -8,7 +8,8 @@ use std::ptr;
 use std::slice;
 use libc::ptrdiff_t;
 
-use lisp::{LispSubr, MANY, LispObject, Qarith_error, XINT, make_number, EmacsInt};
+use lisp::{LispSubr, MANY, LispObject, Qarith_error, XINT, make_number,
+           EmacsInt, CHECK_TYPE, Qnumberp, LispType};
 use eval::xsignal0;
 
 fn Fmod(x: LispObject, y: LispObject) -> LispObject {
@@ -274,3 +275,18 @@ defun!("min", Fmin, Smin, 1, MANY, ptr::null(), "Return smallest of all the argu
 The value is always a number; markers are converted to numbers.
 
 (fn NUMBER-OR-MARKER &rest NUMBERS-OR-MARKERS)");
+
+
+fn Fabs(obj: LispObject) -> LispObject {
+    CHECK_TYPE(obj.is_number(), unsafe { Qnumberp }, obj); // does not return on failure
+
+    match obj.get_type(){
+        LispType::Lisp_Float => LispObject::from_float(obj.to_float().unwrap().abs()),
+        _ => make_number(obj.to_fixnum().unwrap().abs() as EmacsInt)
+    }
+
+}
+
+defun!("abs", Fabs, Sabs, 1, 1, ptr::null(), "Return the absolute value of ARG.
+
+(fn ARG)");


### PR DESCRIPTION
Change the definition of Fabs to accurately reflect the behaviour of the
C version of the function. The previous version assumed that it's
argument was always a float, the C version works on both floats and ints