### PR TITLE
Refactor and lsb

### DIFF
--- a/rust_src/build.rs
+++ b/rust_src/build.rs
@@ -13,46 +13,75 @@ const WIDE_EMACS_INT: bool = true;
 #[cfg(not(feature = "wide-emacs-int"))]
 const WIDE_EMACS_INT: bool = false;
 
-fn emacs_int_max<T>() -> String {
-    match size_of::<T>() {
-        1 => "0x7F_i8".to_owned(),
-        2 => "0x7FFF_i16".to_owned(),
-        4 => "0x7FFFFFFF_i32".to_owned(),
-        8 => "0x7FFFFFFFFFFFFFFF_i64".to_owned(),
-        16 => "0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF_i128".to_owned(),
-        _ => panic!("nonstandard int size {}", size_of::<T>()),
+fn integer_max_constant(len: usize) -> &'static str {
+    match len {
+        1 => "0x7F_i8",
+        2 => "0x7FFF_i16",
+        4 => "0x7FFFFFFF_i32",
+        8 => "0x7FFFFFFFFFFFFFFF_i64",
+        16 => "0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF_i128",
+        _ => panic!("nonstandard int size {}", len),
     }
-}
-
-fn emacs_int_types() -> (String, String, String) {
-    if size_of::<libc::intptr_t>() <= size_of::<libc::c_int>() && !WIDE_EMACS_INT {
-        return ("libc::c_int".to_owned(), "libc::c_uint".to_owned(), emacs_int_max::<libc::c_int>());
-    }
-
-    if size_of::<libc::intptr_t>() <= size_of::<libc::c_long>() && !WIDE_EMACS_INT {
-        return ("libc::c_long".to_owned(), "libc::c_ulong".to_owned(), emacs_int_max::<libc::c_long>());
-    }
-
-    if size_of::<libc::intptr_t>() <= size_of::<libc::c_longlong>() {
-        return ("libc::c_longlong".to_owned(), "libc::c_ulonglong".to_owned(), emacs_int_max::<libc::c_longlong>());
-    }
-
-    panic!("build.rs: intptr_t is too large!");
-}
-
-fn emacs_float_types() -> (String, usize) {
-    ("f64".to_owned(), size_of::<f64>())
 }
 
 fn main() {
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap()).join("definitions.rs");
     let mut file = File::create(out_path).expect("Failed to create definition file");
-    let (type1, type2, max1) = emacs_int_types();
-    write!(&mut file, "pub type EmacsInt = {};\n", type1).expect("Write error!");
-    write!(&mut file, "pub type EmacsUint = {};\n", type2).expect("Write error!");
-    write!(&mut file, "pub const EMACS_INT_MAX: EmacsInt = {};\n", max1).expect("Write error!");
 
-    let (type1, size1) = emacs_float_types();
-    write!(&mut file, "pub type EmacsDouble = {};\n", type1).expect("Write error!");
-    write!(&mut file, "pub const EMACS_LISP_FLOAT_SIZE: EmacsInt = {};\n", max(size1, size_of::<libc::intptr_t>())).expect("Write error!");
+    // signed and unsigned size shall be the same.
+    let integer_types = [("libc::c_int", "libc::c_uint", size_of::<libc::c_int>()),
+                         ("libc::c_long", "libc::c_ulong", size_of::<libc::c_long>()),
+                         ("libc::c_longlong", "libc::c_ulonglong", size_of::<libc::c_longlong>())];
+    let actual_ptr_size = size_of::<libc::intptr_t>();
+    let usable_integers_narrow = ["libc::c_int", "libc::c_long", "libc::c_longlong"];
+    let usable_integers_wide = ["libc::c_longlong"];
+    let usable_integers = if !WIDE_EMACS_INT {
+        usable_integers_narrow.as_ref()
+    } else {
+        usable_integers_wide.as_ref()
+    };
+    let integer_type_item = integer_types.iter()
+        .find(|&&(n, _, l)| {
+            actual_ptr_size <= l && usable_integers.iter().find(|&x| x == &n).is_some()
+        })
+        .expect("build.rs: intptr_t is too large!");
+
+    let float_types = [("f64", size_of::<f64>())];
+
+    let float_type_item = &float_types[0];
+
+    write!(&mut file, "pub type EmacsInt = {};\n", integer_type_item.0).expect("Write error!");
+    write!(&mut file, "pub type EmacsUint = {};\n", integer_type_item.1).expect("Write error!");
+    write!(&mut file,
+           "pub const EMACS_INT_MAX: EmacsInt = {};\n",
+           integer_max_constant(integer_type_item.2))
+        .expect("Write error!");
+
+    write!(&mut file,
+           "pub const EMACS_INT_SIZE: EmacsInt = {};\n",
+           integer_type_item.2)
+        .expect("Write error!");
+    
+    write!(&mut file, "pub type EmacsDouble = {};\n", float_type_item.0).expect("Write error!");
+    write!(&mut file,
+           "pub const EMACS_FLOAT_SIZE: EmacsInt = {};\n",
+           max(float_type_item.1, actual_ptr_size))
+        .expect("Write error!");
+
+    let bits = 8; // bits in a byte.
+    let gc_type_bits = 3;
+    write!(&mut file,
+           "pub const GCTYPEBITS: EmacsInt = {};\n",
+           gc_type_bits)
+        .expect("Write error!");
+
+    let uint_max_len = integer_type_item.2 * bits;
+    let int_max_len = uint_max_len - 1;
+    let val_max_len = int_max_len - (gc_type_bits - 1);
+    let use_lsb_tag = val_max_len - 1 < int_max_len;
+    write!(&mut file,
+           "pub const USE_LSB_TAG: bool = {};\n",
+           if use_lsb_tag { "true" } else { "false" })
+        .expect("Write error!");
+
 }

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -87,3 +87,8 @@ pub extern "C" fn rust_init_syms() {
         floatfns::init_float_syms();
     }
 }
+
+#[no_mangle]
+pub extern "C" fn rust_print_lisp_object(v: lisp::LispObject) {
+    println!("{:?}", v)
+}

--- a/rust_src/src/strings.rs
+++ b/rust_src/src/strings.rs
@@ -20,11 +20,7 @@ extern "C" {
 static MIME_LINE_LENGTH: isize = 76;
 
 fn Fstringp(object: LispObject) -> LispObject {
-    if STRINGP(object) {
-        LispObject::constant_t()
-    } else {
-        Qnil
-    }
+    LispObject::from_bool(object.is_string())
 }
 
 defun!("stringp",
@@ -38,11 +34,7 @@ defun!("stringp",
 (fn OBJECT)");
 
 fn Feq(firstObject: LispObject, secondObject: LispObject) -> LispObject {
-    if firstObject == secondObject {
-        LispObject::constant_t()
-    } else {
-        Qnil
-    }
+    LispObject::from_bool(firstObject == secondObject)
 }
 
 defun!("eq",
@@ -56,11 +48,7 @@ defun!("eq",
 (fn OBJECT OBJECT)");
 
 fn Fnull(object: LispObject) -> LispObject {
-    if object == Qnil {
-        LispObject::constant_t()
-    } else {
-        Qnil
-    }
+    LispObject::from_bool(object == Qnil)
 }
 
 defun!("null",

--- a/rust_src/src/symbols.rs
+++ b/rust_src/src/symbols.rs
@@ -3,25 +3,10 @@ use std::ptr;
 
 extern crate libc;
 
-use lisp::{XTYPE, LispObject, LispType, LispSubr, Qnil};
-
-/// Is this LispObject a symbol?
-#[allow(non_snake_case)]
-pub fn SYMBOLP(a: LispObject) -> bool {
-    XTYPE(a) == LispType::Lisp_Symbol
-}
-
-#[test]
-fn test_symbolp() {
-    assert!(SYMBOLP(Qnil));
-}
+use lisp::{LispObject, LispSubr};
 
 fn Fsymbolp(object: LispObject) -> LispObject {
-    if SYMBOLP(object) {
-        LispObject::constant_t()
-    } else {
-        Qnil
-    }
+    LispObject::from_bool(object.is_symbol())
 }
 
 defun!("symbolp",


### PR DESCRIPTION
This does some refactoring and implement the non lsb tag case for lisp object. Resolves #74 