### PR TITLE
Make CHECK_STRING use LispObject::is_string.

### DIFF
--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -89,7 +89,11 @@ impl LispObject {
 
     #[inline]
     pub fn from_bool(v: bool) -> LispObject {
-        if v { unsafe { Qt } } else { Qnil }
+        if v {
+            unsafe { Qt }
+        } else {
+            Qnil
+        }
     }
 
     #[inline]
@@ -423,7 +427,7 @@ pub struct LispString {
 impl LispObject {
     #[inline]
     pub fn is_string(self) -> bool {
-        XTYPE(self) == LispType::Lisp_String
+        self.get_type() == LispType::Lisp_String
     }
 }
 
@@ -568,7 +572,8 @@ impl Debug for LispObject {
             write!(f,
                    "#<INVALID-OBJECT @ {:#X}: VAL({:#X})>",
                    self_ptr,
-                   self.to_raw())?;
+                   self.to_raw())
+                ?;
             return Ok(());
         }
         match ty {
@@ -585,7 +590,8 @@ impl Debug for LispObject {
                 write!(f,
                        "#<VECTOR-LIKE @ {:#X}: VAL({:#X})>",
                        self_ptr,
-                       self.to_raw())?;
+                       self.to_raw())
+                    ?;
             }
             LispType::Lisp_Int0 |
             LispType::Lisp_Int1 => {
@@ -865,7 +871,7 @@ pub fn CHECK_TYPE(ok: bool, predicate: LispObject, x: LispObject) {
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C" fn CHECK_STRING(x: LispObject) {
-    CHECK_TYPE(STRINGP(x), unsafe { Qstringp }, x);
+    CHECK_TYPE(x.is_string(), unsafe { Qstringp }, x);
 }
 
 #[allow(non_snake_case)]


### PR DESCRIPTION
# Rationale
When debugging a lot of redundant calls are made, in somy way makes debugging more defficient.

This:
```
#0  0x0822ba17 in remacs::lisp::LispObject::get_type (self=...) at /home/jeandudey/rust-projects/remacs/rust_src/src/lisp.rs:174
#1  0x0822da3c in remacs::lisp::deprecated::XTYPE (a=...) at /home/jeandudey/rust-projects/remacs/rust_src/src/lisp.rs:714
#2  0x0822c35c in remacs::lisp::LispObject::is_string (self=...) at /home/jeandudey/rust-projects/remacs/rust_src/src/lisp.rs:430
#3  0x0822de9c in remacs::lisp::deprecated::STRINGP (x=...) at /home/jeandudey/rust-projects/remacs/rust_src/src/lisp.rs:798
#4  0x0822e2a9 in remacs::lisp::CHECK_STRING (x=...) at /home/jeandudey/rust-projects/remacs/rust_src/src/lisp.rs:874
```

Now becomest this in a `backtrace`:
```
#0  0x0822b9d8 in remacs::lisp::LispObject::get_type (self=...) at /home/jeandudey/rust-projects/remacs/rust_src/src/lisp.rs:168
#1  0x0822c35c in remacs::lisp::LispObject::is_string (self=...) at /home/jeandudey/rust-projects/remacs/rust_src/src/lisp.rs:430
#2  0x0822e2a9 in remacs::lisp::CHECK_STRING (x=...) at /home/jeandudey/rust-projects/remacs/rust_src/src/lisp.rs:874
```