### PR TITLE
Porting base64-decode-string to Rust.

### DIFF
--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -81,6 +81,7 @@ pub extern "C" fn rust_init_syms() {
         defsubr(&*strings::Sstringp);
         defsubr(&*strings::Seq);
         defsubr(&*strings::Sbase64_encode_string);
+        defsubr(&*strings::Sbase64_decode_string);
         defsubr(&*strings::Snull);
         defsubr(&*character::Smax_char);
 

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -81,7 +81,6 @@ pub extern "C" fn rust_init_syms() {
         defsubr(&*strings::Sstringp);
         defsubr(&*strings::Seq);
         defsubr(&*strings::Sbase64_encode_string);
-        defsubr(&*strings::Sbase64_decode_string);
         defsubr(&*strings::Snull);
         defsubr(&*character::Smax_char);
 

--- a/rust_src/src/strings.rs
+++ b/rust_src/src/strings.rs
@@ -118,6 +118,7 @@ fn Fbase64_decode_string(string: LispObject) -> LispObject {
 
     let length = SBYTES(string);
     let mut buffer: Vec<libc::c_char> = Vec::with_capacity(length as usize);
+    let mut decoded_string: LispObject = LispObject::constant_nil();
 
     unsafe {
         let decoded = buffer.as_mut_ptr();
@@ -127,7 +128,6 @@ fn Fbase64_decode_string(string: LispObject) -> LispObject {
                                              false, 
                                              ptr::null_mut());
 
-        let mut decoded_string: LispObject = Qnil;
         if decoded_length > length {
             panic!("Decoded length is above length");
         } else if decoded_length >= 0 {

--- a/rust_src/src/strings.rs
+++ b/rust_src/src/strings.rs
@@ -3,7 +3,7 @@ use std::ptr;
 
 extern crate libc;
 
-use lisp::{LispObject, LispSubr, Qnil, SBYTES, SSDATA, STRING_MULTIBYTE, STRINGP};
+use lisp::{LispObject, LispSubr, Qnil, SBYTES, SSDATA, STRING_MULTIBYTE, STRINGP, CHECK_STRING};
 use lists::NILP;
 
 extern "C" {
@@ -13,6 +13,12 @@ extern "C" {
                        length: libc::ptrdiff_t,
                        line_break: bool,
                        multibyte: bool)
+                       -> libc::ptrdiff_t;
+    fn base64_decode_1(from: *const libc::c_char,
+                       to: *mut libc::c_char,
+                       length: libc::ptrdiff_t,
+                       multibyte: bool,
+                       nchars_return: *mut libc::ptrdiff_t)
                        -> libc::ptrdiff_t;
     fn error(m: *const u8, ...);
 }
@@ -63,7 +69,7 @@ defun!("null",
 
 
 fn Fbase64_encode_string(string: LispObject, noLineBreak: LispObject) -> LispObject {
-    debug_assert!(STRINGP(string));
+    CHECK_STRING(string);
 
     // We need to allocate enough room for the encoded text
     // We will need 33 1/3% more space, plus a newline every 76 characters(MIME_LINE_LENGTH)
@@ -106,3 +112,42 @@ defun!("base64-encode-string",
        into shorter lines.
 
 (fn STRING &optional NO-LINE-BREAK)");
+
+fn Fbase64_decode_string(string: LispObject) -> LispObject {
+    CHECK_STRING(string);
+
+    let length = SBYTES(string);
+    let mut buffer: Vec<libc::c_char> = Vec::with_capacity(length as usize);
+
+    unsafe {
+        let decoded = buffer.as_mut_ptr();
+        let decoded_length = base64_decode_1(SSDATA(string), 
+                                             decoded, 
+                                             length, 
+                                             false, 
+                                             ptr::null_mut());
+
+        let mut decoded_string: LispObject = Qnil;
+        if decoded_length > length {
+            panic!("Decoded length is above length");
+        } else if decoded_length >= 0 {
+            decoded_string = make_unibyte_string(decoded, decoded_length);
+        }
+
+        if !STRINGP(decoded_string) {
+            error("Invalid base64 data\0".as_ptr());
+        }
+
+        decoded_string
+    }
+}
+
+defun!("base64-decode-string",
+       Fbase64_decode_string,
+       Sbase64_decode_string,
+       1,
+       1,
+       ptr::null(),
+       "Base64-decode STRING and return the result.
+
+(fn STRING)");

--- a/rust_src/src/strings.rs
+++ b/rust_src/src/strings.rs
@@ -3,7 +3,7 @@ use std::ptr;
 
 extern crate libc;
 
-use lisp::{LispObject, LispSubr, Qnil, SBYTES, SSDATA, STRING_MULTIBYTE, STRINGP, CHECK_STRING};
+use lisp::{LispObject, LispSubr, Qnil, SBYTES, SSDATA, STRING_MULTIBYTE, STRINGP};
 use lists::NILP;
 
 extern "C" {
@@ -13,12 +13,6 @@ extern "C" {
                        length: libc::ptrdiff_t,
                        line_break: bool,
                        multibyte: bool)
-                       -> libc::ptrdiff_t;
-    fn base64_decode_1(from: *const libc::c_char,
-                       to: *mut libc::c_char,
-                       length: libc::ptrdiff_t,
-                       multibyte: bool,
-                       nchars_return: *mut libc::ptrdiff_t)
                        -> libc::ptrdiff_t;
     fn error(m: *const u8, ...);
 }
@@ -69,7 +63,7 @@ defun!("null",
 
 
 fn Fbase64_encode_string(string: LispObject, noLineBreak: LispObject) -> LispObject {
-    CHECK_STRING(string);
+    debug_assert!(STRINGP(string));
 
     // We need to allocate enough room for the encoded text
     // We will need 33 1/3% more space, plus a newline every 76 characters(MIME_LINE_LENGTH)
@@ -112,42 +106,3 @@ defun!("base64-encode-string",
        into shorter lines.
 
 (fn STRING &optional NO-LINE-BREAK)");
-
-fn Fbase64_decode_string(string: LispObject) -> LispObject {
-    CHECK_STRING(string);
-
-    let length = SBYTES(string);
-    let mut buffer: Vec<libc::c_char> = Vec::with_capacity(length as usize);
-
-    unsafe {
-        let decoded = buffer.as_mut_ptr();
-        let decoded_length = base64_decode_1(SSDATA(string), 
-                                             decoded, 
-                                             length, 
-                                             false, 
-                                             ptr::null_mut());
-
-        let mut decoded_string: LispObject = Qnil;
-        if decoded_length > length {
-            panic!("Decoded length is above length");
-        } else if decoded_length >= 0 {
-            decoded_string = make_unibyte_string(decoded, decoded_length);
-        }
-
-        if !STRINGP(decoded_string) {
-            error("Invalid base64 data\0".as_ptr());
-        }
-
-        decoded_string
-    }
-}
-
-defun!("base64-decode-string",
-       Fbase64_decode_string,
-       Sbase64_decode_string,
-       1,
-       1,
-       ptr::null(),
-       "Base64-decode STRING and return the result.
-
-(fn STRING)");

--- a/src/fns.c
+++ b/src/fns.c
@@ -3144,7 +3144,7 @@ static const short base64_char_to_value[128] =
 
 
 ptrdiff_t base64_encode_1 (const char *, char *, ptrdiff_t, bool, bool);
-static ptrdiff_t base64_decode_1 (const char *, char *, ptrdiff_t, bool,
+ptrdiff_t base64_decode_1 (const char *, char *, ptrdiff_t, bool,
 				  ptrdiff_t *);
 
 DEFUN ("base64-encode-region", Fbase64_encode_region, Sbase64_encode_region,
@@ -3366,45 +3366,12 @@ If the region can't be decoded, signal an error and don't modify the buffer.  */
   return make_number (inserted_chars);
 }
 
-DEFUN ("base64-decode-string", Fbase64_decode_string, Sbase64_decode_string,
-       1, 1, 0,
-       doc: /* Base64-decode STRING and return the result.  */)
-  (Lisp_Object string)
-{
-  char *decoded;
-  ptrdiff_t length, decoded_length;
-  Lisp_Object decoded_string;
-  USE_SAFE_ALLOCA;
-
-  CHECK_STRING (string);
-
-  length = SBYTES (string);
-  /* We need to allocate enough room for decoding the text. */
-  decoded = SAFE_ALLOCA (length);
-
-  /* The decoded result should be unibyte. */
-  decoded_length = base64_decode_1 (SSDATA (string), decoded, length,
-				    0, NULL);
-  if (decoded_length > length)
-    emacs_abort ();
-  else if (decoded_length >= 0)
-    decoded_string = make_unibyte_string (decoded, decoded_length);
-  else
-    decoded_string = Qnil;
-
-  SAFE_FREE ();
-  if (!STRINGP (decoded_string))
-    error ("Invalid base64 data");
-
-  return decoded_string;
-}
-
 /* Base64-decode the data at FROM of LENGTH bytes into TO.  If
    MULTIBYTE, the decoded result should be in multibyte
    form.  If NCHARS_RETURN is not NULL, store the number of produced
    characters in *NCHARS_RETURN.  */
 
-static ptrdiff_t
+ptrdiff_t
 base64_decode_1 (const char *from, char *to, ptrdiff_t length,
 		 bool multibyte, ptrdiff_t *nchars_return)
 {
@@ -5184,7 +5151,6 @@ this variable.  */);
   defsubr (&Swidget_apply);
   defsubr (&Sbase64_encode_region);
   defsubr (&Sbase64_decode_region);
-  defsubr (&Sbase64_decode_string);
   defsubr (&Smd5);
   defsubr (&Ssecure_hash);
   defsubr (&Sbuffer_hash);


### PR DESCRIPTION
This commit follows the same strategy as base64-encode-string. We will farm out
the implementation of the base64 decoding to the c-layer function 'base64_decode_1'. It is good to note that 'base64_decode_1' is a strong candidate to be brought into the rust layer, maybe by an existing library. 
I believe it would make the most sense to bring 'base64_{encode/decode}_1' into rust when we port 'base64_encode_region/base64_decode_region'. 

I am also changing the debug_assert!(STRINGP(string)) in Fbase64_encode_string to be a CHECK_STRING call, as that is more inline with what the c code was doing beforehand. 