### PR TITLE
Deprecate functions in lisp.rs

### DIFF
--- a/rust_src/src/character.rs
+++ b/rust_src/src/character.rs
@@ -1,8 +1,6 @@
 use std::os::raw::c_char;
 use std::ptr;
 
-use lisp;
-
 extern crate libc;
 
 use lisp::{LispObject, LispSubr, EmacsInt, CharBits};
@@ -11,7 +9,7 @@ use lisp::{LispObject, LispSubr, EmacsInt, CharBits};
 pub const MaxChar: EmacsInt = (1 << CharBits::CHARACTERBITS as EmacsInt) - 1;
 
 fn Fmax_char() -> LispObject {
-    lisp::make_number(MaxChar)
+    unsafe { LispObject::from_fixnum_unchecked(MaxChar) }
 }
 
 defun!("max-char",

--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -13,7 +13,7 @@ use std::mem;
 use std::ops::Deref;
 use std::fmt::{Debug, Formatter, Error};
 
-use marker::{LispMarker, marker_position};
+use marker::marker_position;
 
 // TODO: tweak Makefile to rebuild C files if this changes.
 
@@ -619,6 +619,7 @@ pub mod deprecated {
     use super::*;
     use ::libc;
     use ::std;
+    use ::marker::LispMarker;
 
     /// Convert a LispObject to an EmacsInt.
     #[allow(non_snake_case)]
@@ -858,7 +859,7 @@ pub mod deprecated {
     #[allow(non_snake_case)]
     pub fn XMARKER(a: LispObject) -> *const LispMarker {
         debug_assert!(MARKERP(a));
-        unsafe { mem::transmute(a.to_misc_unchecked()) }
+        unsafe { std::mem::transmute(a.to_misc_unchecked()) }
     }
 }
 

--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -615,7 +615,7 @@ impl Debug for LispObject {
 /// and lacks unsafe marks. However we'll keep them during the porting process to make
 /// the porting easy, we should be able to remove once the relevant functionality is Rust-only.
 #[allow(dead_code)]
-mod deprecated {
+pub mod deprecated {
     use super::*;
     use ::libc;
     use ::std;
@@ -824,10 +824,10 @@ mod deprecated {
         unsafe { std::mem::transmute(a.get_untaggedptr()) }
     }
 
+    // TODO: Create a Rust version of this.
     pub fn SBYTES(string: LispObject) -> libc::ptrdiff_t {
         unsafe { STRING_BYTES(XSTRING(string)) }
     }
-
 
     /// Convert a tagged pointer to a normal C pointer.
     ///
@@ -847,8 +847,6 @@ mod deprecated {
         n
     }
 }
-
-pub use self::deprecated::*;
 
 /// Check that `x` is an integer or float, coercing markers to integers.
 ///

--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -846,6 +846,20 @@ pub mod deprecated {
         debug_assert!(0 <= n);
         n
     }
+
+    // TODO: Create a Rust version of this.
+    #[allow(non_snake_case)]
+    pub fn MARKERP(a: LispObject) -> bool {
+        debug_assert!(a.is_misc());
+        unsafe { a.to_misc_unchecked().ty == LispMiscType::Marker }
+    }
+
+    // TODO: Create a Rust version of this.
+    #[allow(non_snake_case)]
+    pub fn XMARKER(a: LispObject) -> *const LispMarker {
+        debug_assert!(MARKERP(a));
+        unsafe { mem::transmute(a.to_misc_unchecked()) }
+    }
 }
 
 /// Check that `x` is an integer or float, coercing markers to integers.
@@ -856,7 +870,7 @@ pub mod deprecated {
 /// `CHECK_NUMBER_OR_FLOAT_COERCE_MARKER` in Emacs C, but returns a
 /// value rather than assigning to a variable.
 pub fn check_number_coerce_marker(x: LispObject) -> LispObject {
-    if MARKERP(x) {
+    if deprecated::MARKERP(x) {
         unsafe { LispObject::from_fixnum_unchecked(marker_position(x) as EmacsInt) }
     } else {
         unsafe {
@@ -866,6 +880,7 @@ pub fn check_number_coerce_marker(x: LispObject) -> LispObject {
     }
 }
 
+// TODO: Create a macro version of this.
 /// Raise an error if `x` is the wrong type. `ok` should be a Rust/C
 /// expression that evaluates if the type is correct. `predicate` is
 /// the elisp-level equivalent predicate that failed.
@@ -883,18 +898,6 @@ pub fn CHECK_TYPE(ok: bool, predicate: LispObject, x: LispObject) {
 #[no_mangle]
 pub extern "C" fn CHECK_STRING(x: LispObject) {
     CHECK_TYPE(x.is_string(), unsafe { Qstringp }, x);
-}
-
-#[allow(non_snake_case)]
-pub fn MARKERP(a: LispObject) -> bool {
-    debug_assert!(a.is_misc());
-    unsafe { a.to_misc_unchecked().ty == LispMiscType::Marker }
-}
-
-#[allow(non_snake_case)]
-pub fn XMARKER(a: LispObject) -> *const LispMarker {
-    debug_assert!(MARKERP(a));
-    unsafe { mem::transmute(a.to_misc_unchecked()) }
 }
 
 #[test]

--- a/rust_src/src/lists.rs
+++ b/rust_src/src/lists.rs
@@ -4,7 +4,7 @@ use std::os::raw::c_char;
 use std::ptr;
 use std::mem;
 
-use lisp::{CHECK_TYPE, LispObject, LispSubr, LispType, Qnil, XTYPE, XUNTAG, wrong_type_argument};
+use lisp::{CHECK_TYPE, LispObject, LispSubr, LispType, Qnil, wrong_type_argument};
 
 extern "C" {
     static Qconsp: LispObject;
@@ -14,7 +14,7 @@ extern "C" {
 
 
 pub fn CONSP(x: LispObject) -> bool {
-    XTYPE(x) == LispType::Lisp_Cons
+    x.get_type() == LispType::Lisp_Cons
 }
 
 fn Fatom(object: LispObject) -> LispObject {
@@ -81,7 +81,7 @@ pub struct LispConsChain {
 /// Extract the LispCons data from an elisp value.
 fn XCONS(a: LispObject) -> *mut LispCons {
     debug_assert!(CONSP(a));
-    unsafe { mem::transmute(XUNTAG(a, LispType::Lisp_Cons)) }
+    unsafe { mem::transmute(a.get_untaggedptr()) }
 }
 
 /// Set the car of a cons cell.

--- a/rust_src/src/marker.rs
+++ b/rust_src/src/marker.rs
@@ -1,7 +1,8 @@
 extern crate libc;
 
 use std::ptr;
-use lisp::{LispObject, LispMiscType, XMARKER, CHECK_TYPE, MARKERP};
+use lisp::{LispObject, LispMiscType, CHECK_TYPE};
+use lisp::deprecated::{XMARKER, MARKERP};
 
 extern "C" {
     // defined in eval.c, where it can actually take an arbitrary

--- a/rust_src/src/marker.rs
+++ b/rust_src/src/marker.rs
@@ -36,7 +36,7 @@ pub struct LispMarker {
 /// Return the char position of marker MARKER, as a C integer.
 pub fn marker_position(marker: LispObject) -> libc::ptrdiff_t {
     let m_ptr = XMARKER(marker);
-    let m = unsafe { ptr::read(m_ptr) };
+    let m: LispMarker = unsafe { ptr::read(m_ptr) };
 
     let buf = m.buffer;
     if buf.is_null() {

--- a/rust_src/src/numbers.rs
+++ b/rust_src/src/numbers.rs
@@ -3,10 +3,14 @@ extern crate libc;
 use std::os::raw::c_char;
 use std::ptr;
 
-use lisp::{LispObject, LispSubr, Qnil, Qt, INTEGERP, FLOATP, MARKERP, NATNUMP, NUMBERP};
+use lisp::{LispObject, LispSubr, Qnil, Qt, MARKERP};
 
 fn Ffloatp(object: LispObject) -> LispObject {
-    if FLOATP(object) { unsafe { Qt } } else { Qnil }
+    if object.is_float() {
+        unsafe { Qt }
+    } else {
+        Qnil
+    }
 }
 
 defun!("floatp",
@@ -20,7 +24,7 @@ defun!("floatp",
 (fn OBJECT)");
 
 fn Fintegerp(object: LispObject) -> LispObject {
-    if INTEGERP(object) {
+    if object.is_integer() {
         unsafe { Qt }
     } else {
         Qnil
@@ -38,7 +42,7 @@ defun!("integerp",
 (fn OBJECT)");
 
 fn Finteger_or_marker_p(object: LispObject) -> LispObject {
-    if MARKERP(object) || INTEGERP(object) {
+    if MARKERP(object) || object.is_integer() {
         unsafe { Qt }
     } else {
         Qnil
@@ -56,7 +60,11 @@ defun!("integer-or-marker-p",
 (fn OBJECT)");
 
 fn Fnatnump(object: LispObject) -> LispObject {
-    if NATNUMP(object) { unsafe { Qt } } else { Qnil }
+    if object.is_integer() && 0 <= object.to_fixnum().unwrap() {
+        unsafe { Qt }
+    } else {
+        Qnil
+    }
 }
 
 defun!("natnump",
@@ -70,7 +78,11 @@ defun!("natnump",
 (fn OBJECT)");
 
 fn Fnumberp(object: LispObject) -> LispObject {
-    if NUMBERP(object) { unsafe { Qt } } else { Qnil }
+    if object.is_number() {
+        unsafe { Qt }
+    } else {
+        Qnil
+    }
 }
 
 defun!("numberp",
@@ -84,7 +96,7 @@ defun!("numberp",
 (fn OBJECT)");
 
 fn Fnumber_or_marker_p(object: LispObject) -> LispObject {
-    if NUMBERP(object) || MARKERP(object) {
+    if object.is_number() || MARKERP(object) {
         unsafe { Qt }
     } else {
         Qnil

--- a/rust_src/src/numbers.rs
+++ b/rust_src/src/numbers.rs
@@ -3,7 +3,8 @@ extern crate libc;
 use std::os::raw::c_char;
 use std::ptr;
 
-use lisp::{LispObject, LispSubr, Qnil, Qt, MARKERP};
+use lisp::{LispObject, LispSubr, Qnil, Qt};
+use lisp::deprecated::MARKERP;
 
 fn Ffloatp(object: LispObject) -> LispObject {
     if object.is_float() {

--- a/rust_src/src/strings.rs
+++ b/rust_src/src/strings.rs
@@ -3,7 +3,8 @@ use std::ptr;
 
 extern crate libc;
 
-use lisp::{LispObject, LispSubr, Qnil, SBYTES, SSDATA, STRING_MULTIBYTE};
+use lisp::{LispObject, LispSubr, Qnil, SSDATA, STRING_MULTIBYTE};
+use lisp::deprecated::SBYTES;
 use lists::NILP;
 
 extern "C" {

--- a/rust_src/src/strings.rs
+++ b/rust_src/src/strings.rs
@@ -3,7 +3,7 @@ use std::ptr;
 
 extern crate libc;
 
-use lisp::{LispObject, LispSubr, Qnil, SBYTES, SSDATA, STRING_MULTIBYTE, STRINGP};
+use lisp::{LispObject, LispSubr, Qnil, SBYTES, SSDATA, STRING_MULTIBYTE};
 use lists::NILP;
 
 extern "C" {
@@ -63,7 +63,7 @@ defun!("null",
 
 
 fn Fbase64_encode_string(string: LispObject, noLineBreak: LispObject) -> LispObject {
-    debug_assert!(STRINGP(string));
+    debug_assert!(string.is_string());
 
     // We need to allocate enough room for the encoded text
     // We will need 33 1/3% more space, plus a newline every 76 characters(MIME_LINE_LENGTH)


### PR DESCRIPTION
- Made `deprecated` module public.
- Added a `#[deprecated]` attribute on every function that has a Rust way of doing it.
- Also refactored other modules to use the Rust way.