### PR TITLE
Recompile with cargo and rebuild temacs when the Rust source changes

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -390,16 +390,11 @@ epaths-force-w32:
 	  -e "/^.*#/s|@SRC@|$${w32srcdir}|g") &&		\
 	${srcdir}/build-aux/move-if-change epaths.h.$$$$ src/epaths.h
 
-.PHONY: rust-src
-rust-src:
-	RUSTFLAGS=${RUSTFLAGS} \
-	$(CARGO_BUILD) $(CARGO_FLAGS) --manifest-path ${cargo_manifest}
-
 # If lib/Makefile would build files in '.', then build them before
 # building 'lib', to avoid races with parallel makes.
-lib: am--refresh rust-src
+lib: am--refresh
 
-lib-src src: $(NTDIR) lib rust-src
+lib-src src: $(NTDIR) lib
 
 src: lib-src
 

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -343,6 +343,10 @@ am__v_at_ = $(am__v_at_@AM_DEFAULT_V@)
 am__v_at_0 = @
 am__v_at_1 =
 
+CARGO_BUILD=@CARGO_BUILD@
+CARGO_CLEAN=@CARGO_CLEAN@
+CARGO_TEST=@CARGO_TEST@
+CARGO_FLAGS=@CARGO_FLAGS@
 
 ifeq ($(findstring --release,$(CARGO_FLAGS)),--release)
 CARGO_BUILD_DIR=release
@@ -596,13 +600,20 @@ gl-stamp: $(libsrc)/make-docfile$(EXEEXT) $(GLOBAL_SOURCES)
 
 globals.h: gl-stamp; @true
 
-RUSTFLAGS_FILE=$(top_srcdir)/rust_src/target/.rustflags
+rust_srcdir=$(top_srcdir)/rust_src
+RUSTFLAGS_FILE=$(rust_srcdir)/target/.rustflags
 $(RUSTFLAGS_FILE) : FORCE
+	mkdir -p $(dir $@)
 	echo "$(CARGO_FLAGS) $(RUSTFLAGS)" > $@.tmp
 	diff -q $@ $@.tmp || cp $@.tmp $@
 	rm -f $@.tmp
 
-LIBREMACS_ARCHIVE=$(top_srcdir)/rust_src/target/$(CARGO_BUILD_DIR)/libremacs.a
+cargo_manifest=$(rust_srcdir)/Cargo.toml
+LIBREMACS_ARCHIVE=$(rust_srcdir)/target/$(CARGO_BUILD_DIR)/libremacs.a
+$(LIBREMACS_ARCHIVE): $(rust_srcdir)/src/** $(rust_srcdir)/*.rs $(rust_srcdir)/Cargo.*
+	RUSTFLAGS=$(RUSTFLAGS) \
+	$(CARGO_BUILD) $(CARGO_FLAGS) --manifest-path $(cargo_manifest)
+
 $(ALLOBJS): globals.h
 
 LIBEGNU_ARCHIVE = $(lib)/lib$(if $(HYBRID_MALLOC),e)gnu.a


### PR DESCRIPTION
* Moved rust compilation inside the src-Makefile
* Added a target to build the build the remacs archive. This target
  depends on all rust src files

## Examples

All examples assume a previously completed run of `make` or `make src` and abbreviates some output with `[...]`

### Updated rust source file: runs cargo and builds temacs

```shell
$ touch rust_src/src/lisp.rs
$ make src
make -C lib all
[...]
make[2]: 'libXMenu11.a' is up to date.
make[2]: Leaving directory '/home/jonas/workspace/remacs/oldXMenu'
RUSTFLAGS= \
cargo build --release --manifest-path ../rust_src/Cargo.toml
   Compiling remacs v0.1.0 (file:///home/jonas/workspace/remacs/src/../rust_src)
note: link against the following native artifacts when linking against this static library

note: the order and any duplication can be significant on some platforms, and so may need to be preserved

note: library: util

note: library: dl

note: library: pthread

note: library: gcc_s

note: library: c

note: library: m

note: library: rt

note: library: util

    Finished release [optimized] target(s) in 1.44 secs
mkdir -p ../rust_src/target/
echo "--release " > ../rust_src/target/.rustflags.tmp
diff -q ../rust_src/target/.rustflags ../rust_src/target/.rustflags.tmp || cp ../rust_src/target/.rustflags.tmp ../rust_src/target/.rustflags
rm -f ../rust_src/target/.rustflags.tmp
[...]
  CCLD     temacs
/bin/mkdir -p ../etc
make -C ../lisp update-subdirs
make[2]: Entering directory '/home/jonas/workspace/remacs/lisp'
make[2]: Leaving directory '/home/jonas/workspace/remacs/lisp'
./temacs --batch  --load loadup bootstrap
[...]
Adding name remacs-26.0.50.2
ln -f remacs bootstrap-emacs
make[1]: Leaving directory '/home/jonas/workspace/remacs/src'
```

### Updated C source file: does NOT run cargo and builds temacs

```shell
$ touch src/lisp.h
$ make src
make -C lib all
[...]
make[2]: 'libXMenu11.a' is up to date.
make[2]: Leaving directory '/home/jonas/workspace/remacs/oldXMenu'
  CC       dispnew.o
[...]
mkdir -p ../rust_src/target/
echo "--release " > ../rust_src/target/.rustflags.tmp
diff -q ../rust_src/target/.rustflags ../rust_src/target/.rustflags.tmp || cp ../rust_src/target/.rustflags.tmp ../rust_src/target/.rustflags
rm -f ../rust_src/target/.rustflags.tmp
[...]
  CCLD     temacs
/bin/mkdir -p ../etc
make -C ../lisp update-subdirs
make[2]: Entering directory '/home/jonas/workspace/remacs/lisp'
make[2]: Leaving directory '/home/jonas/workspace/remacs/lisp'
./temacs --batch  --load loadup bootstrap
[...]
Adding name remacs-26.0.50.7
ln -f remacs bootstrap-emacs
make[1]: Leaving directory '/home/jonas/workspace/remacs/src'
```
