### PR TITLE
Use custom allocator on Mac OS X

### DIFF
--- a/rust_src/Cargo.lock
+++ b/rust_src/Cargo.lock
@@ -2,9 +2,14 @@
 name = "remacs"
 version = "0.1.0"
 dependencies = [
+ "alloc_unexecmacosx 0.1.0",
  "lazy_static 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "alloc_unexecmacosx"
+version = "0.1.0"
 
 [[package]]
 name = "lazy_static"

--- a/rust_src/Cargo.toml
+++ b/rust_src/Cargo.toml
@@ -11,6 +11,9 @@ build = "build.rs"
 [dependencies]
 lazy_static = "0.2.2"
 libc = "0.2.17"
+
+# Only want this local crate as dependency on Mac OS X
+[target.'cfg(target_os = "macos")'.dependencies]
 alloc_unexecmacosx = { version = "0.1.0", path = "alloc_unexecmacosx" }
 
 [build-dependencies]

--- a/rust_src/Cargo.toml
+++ b/rust_src/Cargo.toml
@@ -11,6 +11,7 @@ build = "build.rs"
 [dependencies]
 lazy_static = "0.2.2"
 libc = "0.2.17"
+alloc_unexecmacosx = { version = "0.1.0", path = "alloc_unexecmacosx" }
 
 [build-dependencies]
 libc = "0.2.17"

--- a/rust_src/alloc_unexecmacosx/Cargo.toml
+++ b/rust_src/alloc_unexecmacosx/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "alloc_unexecmacosx"
+version = "0.1.0"
+authors = ["Felix S. Klock II <pnkfelix@pnkfx.org>"]
+
+# Would be nice to do this, but saying "default-features = false"
+# locally gets cancelled out by the other imports of libc globally.
+# Instead we will just cut-and-paste type definitions (boo!).
+#
+# [dependencies]
+# libc = { version = "0.2.17", default-features = false }

--- a/rust_src/alloc_unexecmacosx/src/lib.rs
+++ b/rust_src/alloc_unexecmacosx/src/lib.rs
@@ -45,24 +45,33 @@ extern "C" {
 // what is found below.
 //
 // Note that the standard `malloc` and `realloc` functions do not provide a way
-// to communicate alignment so this implementation would need to be improved
-// with respect to alignment in that aspect.
+// to communicate alignment. While a more ambitious implementor might have
+// attempted to support custom alignments, this simple code simply asserts that
+// we never request an alignment that is not already satisfied by the underlying
+// malloc call.
 
 #[no_mangle]
-pub extern fn __rust_allocate(size: usize, _align: usize) -> *mut u8 {
-    unsafe { unexec_malloc(size as libc::size_t) as *mut u8 }
+pub extern fn __rust_allocate(size: usize, align: usize) -> *mut u8 {
+    unsafe {
+        let addr = unexec_malloc(size as libc::size_t) as usize;
+        assert_eq!(addr & (align - 1), 0);
+        addr as *mut u8
+    }
 }
 
 #[no_mangle]
-pub extern fn __rust_deallocate(ptr: *mut u8, _old_size: usize, _align: usize) {
+pub extern fn __rust_deallocate(ptr: *mut u8, _old_size: usize, align: usize) {
+    assert_eq!(ptr as usize & (align - 1), 0);
     unsafe { unexec_free(ptr as *mut libc::c_void) }
 }
 
 #[no_mangle]
 pub extern fn __rust_reallocate(ptr: *mut u8, _old_size: usize, size: usize,
-                                _align: usize) -> *mut u8 {
+                                align: usize) -> *mut u8 {
     unsafe {
-        unexec_realloc(ptr as *mut libc::c_void, size as libc::size_t) as *mut u8
+        let addr = unexec_realloc(ptr as *mut libc::c_void, size as libc::size_t) as usize;
+        assert_eq!(addr & (align - 1), 0);
+        addr as *mut u8
     }
 }
 

--- a/rust_src/alloc_unexecmacosx/src/lib.rs
+++ b/rust_src/alloc_unexecmacosx/src/lib.rs
@@ -1,0 +1,78 @@
+#![feature(allocator)]
+#![allocator]
+
+#![no_std]
+
+// // Would be nice to do this, but saying "default-features = false"
+// // locally gets cancelled out by the other imports of libc globally.
+// // Instead we will just cut-and-paste type definitions (boo!).
+// //
+// // See also https://github.com/rust-lang/rust/issues/39262
+//
+// extern crate libc;
+
+mod libc {
+    #![allow(non_camel_case_types)]
+
+    pub type size_t = usize;
+
+    // Use repr(u8) as LLVM expects `void*` to be the same as `i8*` to help enable
+    // more optimization opportunities around it recognizing things like
+    // malloc/free.
+    #[repr(u8)]
+    pub enum c_void {
+        // Two dummy variants so the #[repr] attribute can be used.
+        #[doc(hidden)]
+        __variant1,
+        #[doc(hidden)]
+        __variant2,
+    }
+}
+
+/// To adhere to the rule that all calls to malloc, realloc, and free
+/// be redirected to their "unexec_"-prefixed variants, this crate
+/// provides a custom system allocator that performs such a mapping.
+
+extern "C" {
+    fn unexec_malloc(size: libc::size_t) -> *mut libc::c_void;
+    fn unexec_realloc(old_ptr: *mut libc::c_void, new_size: libc::size_t) -> *mut libc::c_void;
+    fn unexec_free(ptr: *mut libc::c_void);
+}
+
+// Listed below are the five allocation functions currently required by custom
+// allocators. Their signatures and symbol names are not currently typechecked
+// by the compiler, but this is a future extension and are required to match
+// what is found below.
+//
+// Note that the standard `malloc` and `realloc` functions do not provide a way
+// to communicate alignment so this implementation would need to be improved
+// with respect to alignment in that aspect.
+
+#[no_mangle]
+pub extern fn __rust_allocate(size: usize, _align: usize) -> *mut u8 {
+    unsafe { unexec_malloc(size as libc::size_t) as *mut u8 }
+}
+
+#[no_mangle]
+pub extern fn __rust_deallocate(ptr: *mut u8, _old_size: usize, _align: usize) {
+    unsafe { unexec_free(ptr as *mut libc::c_void) }
+}
+
+#[no_mangle]
+pub extern fn __rust_reallocate(ptr: *mut u8, _old_size: usize, size: usize,
+                                _align: usize) -> *mut u8 {
+    unsafe {
+        unexec_realloc(ptr as *mut libc::c_void, size as libc::size_t) as *mut u8
+    }
+}
+
+#[no_mangle]
+pub extern fn __rust_reallocate_inplace(_ptr: *mut u8, old_size: usize,
+                                        _size: usize, _align: usize) -> usize {
+    old_size // this api is not supported by libc
+}
+
+#[no_mangle]
+pub extern fn __rust_usable_size(size: usize, _align: usize) -> usize {
+    size
+}

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -3,6 +3,8 @@
 
 #![cfg_attr(feature = "strict", deny(warnings))]
 
+// Wilfred/remacs#38 : Need to override the allocator for legacy unexec support on Mac.
+#[cfg(target_os = "macos")]
 extern crate alloc_unexecmacosx;
 
 #[macro_use]

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -3,6 +3,8 @@
 
 #![cfg_attr(feature = "strict", deny(warnings))]
 
+extern crate alloc_unexecmacosx;
+
 #[macro_use]
 extern crate lazy_static;
 


### PR DESCRIPTION
Use custom allocator on Mac OS X to uphold the rule that all calls to malloc/realloc/free go through their `unexec_`-prefixed variants on OS X.

The changes are hopefully properly conditionalized so that they do not affect non Mac OS X targets. It would be good for someone with a Linux box to verify this claim.

----

We will probably need to go through a similar process for targets that do not have native support for `unexec`; you can get a feel for the set of targets this means by doing `% ls src/unex*.c`:

```
src/unexaix.c		src/unexcw.c		src/unexhp9k800.c	src/unexsol.c
src/unexcoff.c		src/unexelf.c		src/unexmacosx.c	        src/unexw32.c
```

(Of course we do not actually *care* about all of those targets...)

----

Also, one more thing: I am not sure whether this is a bug in my PR, or a pre-existing problem with the remacs build system, but making changes to `rust_src/alloc_unexecmacosx/src/lib.rs` does not on its own suffice to cause `make` to properly rebuild the project. I had to manually go in and do `cargo clean` in `rust_src` before each of my builds before I observed changes I had made.  So, that is something to keep an eye out for. (Or maybe there's some trivial fix to the Makefile; I didn't really investigate.)

----

Fix #38 
