### PR TITLE
Revert "Remove --enable-check-lisp-object-type configure flag."

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -510,6 +510,16 @@ if test x$ac_glyphs_debug != x ; then
 [Define this to enable glyphs debugging code.])
 fi
 
+AC_ARG_ENABLE(check-lisp-object-type,
+[AS_HELP_STRING([--enable-check-lisp-object-type],
+                [enable compile time checks for the Lisp_Object data type.
+		This is useful for development for catching certain types of bugs.])],
+if test "${enableval}" != "no"; then
+   AC_DEFINE(CHECK_LISP_OBJECT_TYPE, 1,
+   [Define this to enable compile time checks for the Lisp_Object data type.])
+fi)
+
+
 dnl The name of this option is unfortunate.  It predates, and has no
 dnl relation to, the "sampling-based elisp profiler" added in 24.3.
 dnl Actually, it stops it working.

--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -54,6 +54,8 @@ pub const GCTYPEBITS: EmacsInt = 3;
 #[cfg(dummy = "impossible")]
 pub const USE_LSB_TAG: bool = true;
 
+// This is dependent on CHECK_LISP_OBJECT_TYPE, a compile time flag,
+// but it's usually false.
 #[repr(C)]
 #[derive(PartialEq, Eq, Clone, Copy)]
 pub struct LispObject(EmacsInt);

--- a/src/.gdbinit
+++ b/src/.gdbinit
@@ -44,17 +44,29 @@ handle SIGALRM ignore
 # Use $bugfix so that the value isn't a constant.
 # Using a constant runs into GDB bugs sometimes.
 define xgetptr
-  set $bugfix = $arg0
+  if (CHECK_LISP_OBJECT_TYPE)
+    set $bugfix = $arg0.i
+  else
+    set $bugfix = $arg0
+  end
   set $ptr = $bugfix & VALMASK
 end
 
 define xgetint
-  set $bugfix = $arg0
+  if (CHECK_LISP_OBJECT_TYPE)
+    set $bugfix = $arg0.i
+  else
+    set $bugfix = $arg0
+  end
   set $int = $bugfix << (USE_LSB_TAG ? 0 : INTTYPEBITS) >> INTTYPEBITS
 end
 
 define xgettype
-  set $bugfix = $arg0
+  if (CHECK_LISP_OBJECT_TYPE)
+    set $bugfix = $arg0.i
+  else
+    set $bugfix = $arg0
+  end
   set $type = (enum Lisp_Type) (USE_LSB_TAG ? $bugfix & (1 << GCTYPEBITS) - 1 : (EMACS_UINT) $bugfix >> VALBITS)
 end
 

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -7499,6 +7499,7 @@ union
   enum CHARTAB_SIZE_BITS CHARTAB_SIZE_BITS;
   enum char_table_specials char_table_specials;
   enum char_bits char_bits;
+  enum CHECK_LISP_OBJECT_TYPE CHECK_LISP_OBJECT_TYPE;
   enum DEFAULT_HASH_SIZE DEFAULT_HASH_SIZE;
   enum Lisp_Bits Lisp_Bits;
   enum Lisp_Compiled Lisp_Compiled;

--- a/src/lisp.h
+++ b/src/lisp.h
@@ -204,6 +204,11 @@ extern bool suppress_checking EXTERNALLY_VISIBLE;
     : die (# cond, __FILE__, __LINE__))
 #endif /* ENABLE_CHECKING */
 
+
+/* Use the configure flag --enable-check-lisp-object-type to make
+   Lisp_Object use a struct type instead of the default int.  The flag
+   causes CHECK_LISP_OBJECT_TYPE to be defined.  */
+
 /***** Select the tagging scheme.  *****/
 /* The following option controls the tagging scheme:
    - USE_LSB_TAG means that we can assume the least 3 bits of pointers are
@@ -298,8 +303,13 @@ error !;
    Commentary for these macros can be found near their corresponding
    functions, below.  */
 
-#define lisp_h_XLI(o) (o)
-#define lisp_h_XIL(i) (i)
+#if CHECK_LISP_OBJECT_TYPE
+# define lisp_h_XLI(o) ((o).i)
+# define lisp_h_XIL(i) ((Lisp_Object) { i })
+#else
+# define lisp_h_XLI(o) (o)
+# define lisp_h_XIL(i) (i)
+#endif
 #define lisp_h_CHECK_LIST_CONS(x, y) CHECK_TYPE (CONSP (x), Qlistp, y)
 #define lisp_h_CHECK_NUMBER(x) CHECK_TYPE (INTEGERP (x), Qintegerp, x)
 #define lisp_h_CHECK_SYMBOL(x) CHECK_TYPE (SYMBOLP (x), Qsymbolp, x)
@@ -531,9 +541,23 @@ enum Lisp_Fwd_Type
    your object -- this way, the same object could be used to represent
    several disparate C structures.  */
 
+#ifdef CHECK_LISP_OBJECT_TYPE
+
+typedef struct { EMACS_INT i; } Lisp_Object;
+
+#define LISP_INITIALLY(i) {i}
+
+#undef CHECK_LISP_OBJECT_TYPE
+enum CHECK_LISP_OBJECT_TYPE { CHECK_LISP_OBJECT_TYPE = true };
+#else /* CHECK_LISP_OBJECT_TYPE */
+
+/* If a struct type is not wanted, define Lisp_Object as just a number.  */
+
 typedef EMACS_INT Lisp_Object;
 #define LISP_INITIALLY(i) (i)
-
+enum CHECK_LISP_OBJECT_TYPE { CHECK_LISP_OBJECT_TYPE = false };
+#endif /* CHECK_LISP_OBJECT_TYPE */
+
 /* Forward declarations.  */
 
 /* Defined in this file.  */


### PR DESCRIPTION
Reverts Wilfred/remacs#111

32-bit linux requires that `Lisp_Object` is a struct. We need to pass this flag on 32-bit linux to avoid #95.

I will not merge this until we have CI confirming this is correct.