### PR TITLE
Refactor lisp::deprecated module

### DIFF
--- a/rust_src/src/character.rs
+++ b/rust_src/src/character.rs
@@ -1,17 +1,16 @@
 use std::os::raw::c_char;
 use std::ptr;
 
-use lisp;
-
 extern crate libc;
 
 use lisp::{LispObject, LispSubr, EmacsInt, CharBits};
 
+// TODO: Uppercase?
 /// Maximum character code
 pub const MaxChar: EmacsInt = (1 << CharBits::CHARACTERBITS as EmacsInt) - 1;
 
 fn Fmax_char() -> LispObject {
-    lisp::make_number(MaxChar)
+    unsafe { LispObject::from_fixnum_unchecked(MaxChar) }
 }
 
 defun!("max-char",

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -12,17 +12,17 @@ extern crate lazy_static;
 
 extern crate libc;
 
-mod lisp;
-mod lists;
-mod marker;
-mod eval;
-mod floatfns;
-mod math;
-mod numbers;
-mod strings;
-mod symbols;
-mod globals;
-mod character;
+pub mod lisp;
+pub mod lists;
+pub mod marker;
+pub mod eval;
+pub mod floatfns;
+pub mod math;
+pub mod numbers;
+pub mod strings;
+pub mod symbols;
+pub mod globals;
+pub mod character;
 
 use lisp::LispSubr;
 

--- a/rust_src/src/lists.rs
+++ b/rust_src/src/lists.rs
@@ -4,7 +4,7 @@ use std::os::raw::c_char;
 use std::ptr;
 use std::mem;
 
-use lisp::{CHECK_TYPE, LispObject, LispSubr, LispType, Qnil, XTYPE, XUNTAG, wrong_type_argument};
+use lisp::{CHECK_TYPE, LispObject, LispSubr, LispType, Qnil, wrong_type_argument};
 
 extern "C" {
     static Qconsp: LispObject;
@@ -14,7 +14,7 @@ extern "C" {
 
 
 pub fn CONSP(x: LispObject) -> bool {
-    XTYPE(x) == LispType::Lisp_Cons
+    x.get_type() == LispType::Lisp_Cons
 }
 
 fn Fatom(object: LispObject) -> LispObject {
@@ -81,7 +81,7 @@ pub struct LispConsChain {
 /// Extract the LispCons data from an elisp value.
 fn XCONS(a: LispObject) -> *mut LispCons {
     debug_assert!(CONSP(a));
-    unsafe { mem::transmute(XUNTAG(a, LispType::Lisp_Cons)) }
+    unsafe { mem::transmute(a.get_untaggedptr()) }
 }
 
 /// Set the car of a cons cell.

--- a/rust_src/src/marker.rs
+++ b/rust_src/src/marker.rs
@@ -1,7 +1,7 @@
 extern crate libc;
 
 use std::ptr;
-use lisp::{LispObject, LispMiscType, XMARKER, CHECK_TYPE, MARKERP};
+use lisp::{LispObject, LispMiscType, CHECK_TYPE};
 
 extern "C" {
     // defined in eval.c, where it can actually take an arbitrary
@@ -12,10 +12,10 @@ extern "C" {
 }
 
 /// Raise an error if `x` is not marker.
-#[allow(non_snake_case)]
+#[allow(non_snake_case, deprecated)]
 #[no_mangle]
 pub extern "C" fn CHECK_MARKER(x: LispObject) {
-    CHECK_TYPE(MARKERP(x), unsafe { Qmarkerp }, x)
+    CHECK_TYPE(::lisp::deprecated::MARKERP(x), unsafe { Qmarkerp }, x)
 }
 
 // TODO: write a docstring based on the docs in lisp.h.
@@ -33,8 +33,9 @@ pub struct LispMarker {
 }
 
 /// Return the char position of marker MARKER, as a C integer.
+#[allow(deprecated)]
 pub fn marker_position(marker: LispObject) -> libc::ptrdiff_t {
-    let m_ptr = XMARKER(marker);
+    let m_ptr = unsafe { ::lisp::deprecated::XMARKER(marker) };
     let m = unsafe { ptr::read(m_ptr) };
 
     let buf = m.buffer;

--- a/rust_src/src/math.rs
+++ b/rust_src/src/math.rs
@@ -8,20 +8,19 @@ use std::ptr;
 use std::slice;
 use libc::ptrdiff_t;
 
-use lisp::{LispSubr, MANY, LispObject, Qarith_error, XINT, make_number, EmacsInt, CHECK_TYPE,
-           Qnumberp, LispType};
+use lisp::{LispSubr, MANY, LispObject, Qarith_error, EmacsInt, CHECK_TYPE, Qnumberp, LispType};
 use eval::xsignal0;
 
 fn Fmod(x: LispObject, y: LispObject) -> LispObject {
     let x = lisp::check_number_coerce_marker(x);
     let y = lisp::check_number_coerce_marker(y);
 
-    if lisp::FLOATP(x) || lisp::FLOATP(y) {
+    if x.is_float() || y.is_float() {
         return floatfns::fmod_float(x, y);
     }
 
-    let mut i1 = XINT(x);
-    let i2 = XINT(y);
+    let mut i1 = x.to_fixnum().unwrap();
+    let i2 = y.to_fixnum().unwrap();
 
     if i2 == 0 {
         unsafe {
@@ -36,7 +35,7 @@ fn Fmod(x: LispObject, y: LispObject) -> LispObject {
         i1 += i2
     }
 
-    make_number(i1)
+    unsafe { LispObject::from_fixnum_unchecked(i1) }
 }
 
 // TODO: There's some magic somewhere in core Emacs that means
@@ -105,14 +104,14 @@ fn arith_driver(code: ArithOp, nargs: ptrdiff_t, args: *mut LispObject) -> LispO
 
         let coerced_val = lisp::check_number_coerce_marker(*val);
 
-        if lisp::FLOATP(coerced_val) {
+        if coerced_val.is_float() {
             unsafe {
                 return float_arith_driver(ok_accum as f64, ok_args, code, nargs, args);
             }
         }
 
         *val = coerced_val;
-        let next = lisp::XINT(*val);
+        let next = val.to_fixnum().unwrap();
 
         match code {
             ArithOp::Add => {
@@ -182,7 +181,7 @@ fn arith_driver(code: ArithOp, nargs: ptrdiff_t, args: *mut LispObject) -> LispO
         }
     }
 
-    make_number(accum)
+    unsafe { LispObject::from_fixnum_unchecked(accum) }
 }
 
 #[no_mangle]
@@ -237,7 +236,7 @@ defun!("*",
 pub extern "C" fn Fquo(nargs: ptrdiff_t, args: *mut LispObject) -> LispObject {
     for argnum in 2..nargs {
         let arg = unsafe { *args.offset(argnum) };
-        if lisp::FLOATP(arg) {
+        if arg.is_float() {
             unsafe {
                 return float_arith_driver(0.0, 0, ArithOp::Div, nargs, args);
             }
@@ -342,7 +341,9 @@ fn Fabs(obj: LispObject) -> LispObject {
 
     match obj.get_type() {
         LispType::Lisp_Float => LispObject::from_float(obj.to_float().unwrap().abs()),
-        _ => make_number(obj.to_fixnum().unwrap().abs() as EmacsInt),
+        _ => unsafe {
+            LispObject::from_fixnum_unchecked(obj.to_fixnum().unwrap().abs() as EmacsInt)
+        },
     }
 
 }

--- a/rust_src/src/numbers.rs
+++ b/rust_src/src/numbers.rs
@@ -3,10 +3,15 @@ extern crate libc;
 use std::os::raw::c_char;
 use std::ptr;
 
-use lisp::{LispObject, LispSubr, Qnil, Qt, INTEGERP, FLOATP, MARKERP, NATNUMP, NUMBERP};
+use lisp::{LispObject, LispSubr, Qnil, Qt};
 
 fn Ffloatp(object: LispObject) -> LispObject {
-    if FLOATP(object) { unsafe { Qt } } else { Qnil }
+    // TODO: use LispObject::constant_t and constant_nil.
+    if object.is_float() {
+        unsafe { Qt }
+    } else {
+        Qnil
+    }
 }
 
 defun!("floatp",
@@ -20,7 +25,7 @@ defun!("floatp",
 (fn OBJECT)");
 
 fn Fintegerp(object: LispObject) -> LispObject {
-    if INTEGERP(object) {
+    if object.is_integer() {
         unsafe { Qt }
     } else {
         Qnil
@@ -37,8 +42,9 @@ defun!("integerp",
 
 (fn OBJECT)");
 
+#[allow(deprecated)]
 fn Finteger_or_marker_p(object: LispObject) -> LispObject {
-    if MARKERP(object) || INTEGERP(object) {
+    if ::lisp::deprecated::MARKERP(object) || object.is_integer() {
         unsafe { Qt }
     } else {
         Qnil
@@ -56,7 +62,11 @@ defun!("integer-or-marker-p",
 (fn OBJECT)");
 
 fn Fnatnump(object: LispObject) -> LispObject {
-    if NATNUMP(object) { unsafe { Qt } } else { Qnil }
+    if object.is_number() {
+        unsafe { Qt }
+    } else {
+        Qnil
+    }
 }
 
 defun!("natnump",
@@ -70,7 +80,11 @@ defun!("natnump",
 (fn OBJECT)");
 
 fn Fnumberp(object: LispObject) -> LispObject {
-    if NUMBERP(object) { unsafe { Qt } } else { Qnil }
+    if object.is_number() {
+        unsafe { Qt }
+    } else {
+        Qnil
+    }
 }
 
 defun!("numberp",
@@ -83,8 +97,9 @@ defun!("numberp",
 
 (fn OBJECT)");
 
+#[allow(deprecated)]
 fn Fnumber_or_marker_p(object: LispObject) -> LispObject {
-    if NUMBERP(object) || MARKERP(object) {
+    if object.is_number() || ::lisp::deprecated::MARKERP(object) {
         unsafe { Qt }
     } else {
         Qnil


### PR DESCRIPTION
I will be doing a series of PRs to cleanup the Rust codebase, in order to fix #95 more easily without breaking to much things.

### Summary
- [x] Make `lisp::deprecated` public
- [x] Add `#[deprecated]` attribute to functions inside `lisp::deprecated`.
- [x] Refactor functions to be use safe code.
- [x] Make the modules in lib.rs public so the documentation actually gets generated.
    - [x] Add documentation for deprecated functions showing the Rusty way.
- [x] Mark some deprecated functions as `unsafe`.
- [x] Move `MARKERP` and it's friends to `lisp::deprecated`
- [x] Squash commits.