### PR TITLE
Move LispSubr to remacs-sys

### DIFF
--- a/rust_src/remacs-sys/lib.rs
+++ b/rust_src/remacs-sys/lib.rs
@@ -54,17 +54,38 @@ pub struct vectorlike_header {
     pub size: libc::ptrdiff_t,
 }
 
+/// Representation of an Emacs Lisp function symbol.
 #[derive(Debug)]
 #[repr(C)]
 pub struct Lisp_Subr {
     pub header: vectorlike_header,
-    // This field is actually an union
+
+    /// This is the function pointer that will be called when the user invokes
+    /// the Emacs Lisp function. Also, this field is actually an union in C.
     pub function: *const libc::c_void,
+
+    /// The minimum number of arguments that can be passed to the Emacs Lisp
+    /// function.
     pub min_args: libc::c_short,
+
+    /// The maximum number of arguments that can be passed to te Emacs Lisp
+    /// function.
     pub max_args: libc::c_short,
+
+    /// The name of the function in Emacs Lisp.
     pub symbol_name: *const libc::c_char,
+
+    /// The interactive specification. This may be a normal prompt
+    /// string, such as `"bBuffer: "` or an elisp form as a string.
+    /// If the function is not interactive, this should be a null
+    /// pointer.
     pub intspec: *const libc::c_char,
-    // In, Emacs C, this is an EMACS_INT. Should this be changed?
+
+    // TODO: Change this to EMACS_INT
+    //
+    // If you wan't to give it a try and solve this you should see this commit:
+    // https://github.com/Wilfred/remacs/commit/c5461d03a411ff5c6f43885a0a9030e8a94bbc2e
+    /// The docstring of the Emacs Lisp function.
     pub doc: *const libc::c_char,
 }
 

--- a/rust_src/remacs-sys/lib.rs
+++ b/rust_src/remacs-sys/lib.rs
@@ -20,6 +20,62 @@ include!(concat!(env!("OUT_DIR"), "/definitions.rs"));
 
 pub type Lisp_Object = EmacsInt;
 
+pub const PSEUDOVECTOR_SIZE_BITS: libc::c_int = 12;
+pub const PSEUDOVECTOR_SIZE_MASK: libc::c_int = (1 << PSEUDOVECTOR_SIZE_BITS) - 1;
+pub const PSEUDOVECTOR_REST_BITS: libc::c_int = 12;
+pub const PSEUDOVECTOR_REST_MASK: libc::c_int = (((1 << PSEUDOVECTOR_REST_BITS) - 1) <<
+                                                 PSEUDOVECTOR_SIZE_BITS);
+pub const PSEUDOVECTOR_AREA_BITS: libc::c_int = PSEUDOVECTOR_SIZE_BITS + PSEUDOVECTOR_REST_BITS;
+pub const PVEC_TYPE_MASK: libc::c_int = 0x3f << PSEUDOVECTOR_AREA_BITS;
+
+pub type pvec_type = libc::c_int;
+pub const PVEC_NORMAL_VECTOR: pvec_type = 0;
+pub const PVEC_FREE: pvec_type = 1;
+pub const PVEC_PROCESS: pvec_type = 2;
+pub const PVEC_FRAME: pvec_type = 3;
+pub const PVEC_WINDOW: pvec_type = 4;
+pub const PVEC_BOOL_VECTOR: pvec_type = 5;
+pub const PVEC_BUFFER: pvec_type = 6;
+pub const PVEC_HASH_TABLE: pvec_type = 7;
+pub const PVEC_TERMINAL: pvec_type = 8;
+pub const PVEC_WINDOW_CONFIGURATION: pvec_type = 9;
+pub const PVEC_SUBR: pvec_type = 10;
+pub const PVEC_OTHER: pvec_type = 11;
+pub const PVEC_XWIDGET: pvec_type = 12;
+pub const PVEC_XWIDGET_VIEW: pvec_type = 13;
+pub const PVEC_COMPILED: pvec_type = 14;
+pub const PVEC_CHAR_TABLE: pvec_type = 15;
+pub const PVEC_SUB_CHAR_TABLE: pvec_type = 16;
+pub const PVEC_FONT: pvec_type = 17;
+
+#[derive(Debug)]
+#[repr(C)]
+pub struct vectorlike_header {
+    pub size: libc::ptrdiff_t,
+}
+
+#[derive(Debug)]
+#[repr(C)]
+pub struct Lisp_Subr {
+    pub header: vectorlike_header,
+    // This field is actually an union
+    pub function: *const libc::c_void,
+    pub min_args: libc::c_short,
+    pub max_args: libc::c_short,
+    pub symbol_name: *const libc::c_char,
+    pub intspec: *const libc::c_char,
+    // In, Emacs C, this is an EMACS_INT. Should this be changed?
+    pub doc: *const libc::c_char,
+}
+
+// In order to use `lazy_static!` with LispSubr, it must be Sync. Raw
+// pointers are not Sync, but it isn't a problem to define Sync if we
+// never mutate LispSubr values. If we do, we will need to create
+// these objects at runtime, perhaps using forget().
+//
+// Based on http://stackoverflow.com/a/28116557/509706
+unsafe impl Sync for Lisp_Subr {}
+
 extern "C" {
     pub fn make_unibyte_string(s: *const libc::c_char, length: libc::ptrdiff_t) -> Lisp_Object;
 }

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -27,7 +27,7 @@ mod globals;
 mod character;
 mod base64;
 
-use lisp::LispSubr;
+use remacs_sys::Lisp_Subr;
 
 pub use base64::base64_encode_1;
 pub use base64::base64_decode_1;
@@ -57,7 +57,7 @@ pub use marker::CHECK_MARKER;
 pub use lisp::CHECK_STRING;
 
 extern "C" {
-    fn defsubr(sname: *const LispSubr);
+    fn defsubr(sname: *const Lisp_Subr);
 }
 
 #[no_mangle]

--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -6,7 +6,6 @@
 
 extern crate libc;
 
-use std::os::raw::c_char;
 #[cfg(test)]
 use std::cmp::max;
 use std::mem;
@@ -422,80 +421,6 @@ impl LispObject {
     }
 }
 
-
-
-
-const PSEUDOVECTOR_SIZE_BITS: libc::c_int = 12;
-#[allow(dead_code)]
-const PSEUDOVECTOR_SIZE_MASK: libc::c_int = (1 << PSEUDOVECTOR_SIZE_BITS) - 1;
-const PSEUDOVECTOR_REST_BITS: libc::c_int = 12;
-#[allow(dead_code)]
-const PSEUDOVECTOR_REST_MASK: libc::c_int = (((1 << PSEUDOVECTOR_REST_BITS) - 1) <<
-                                             PSEUDOVECTOR_SIZE_BITS);
-pub const PSEUDOVECTOR_AREA_BITS: libc::c_int = PSEUDOVECTOR_SIZE_BITS + PSEUDOVECTOR_REST_BITS;
-#[allow(dead_code)]
-const PVEC_TYPE_MASK: libc::c_int = 0x3f << PSEUDOVECTOR_AREA_BITS;
-
-#[allow(non_camel_case_types)]
-#[allow(dead_code)]
-pub enum PvecType {
-    // TODO: confirm these are the right numbers.
-    PVEC_NORMAL_VECTOR = 0,
-    PVEC_FREE = 1,
-    PVEC_PROCESS = 2,
-    PVEC_FRAME = 3,
-    PVEC_WINDOW = 4,
-    PVEC_BOOL_VECTOR = 5,
-    PVEC_BUFFER = 6,
-    PVEC_HASH_TABLE = 7,
-    PVEC_TERMINAL = 8,
-    PVEC_WINDOW_CONFIGURATION = 9,
-    PVEC_SUBR = 10,
-    PVEC_OTHER = 11,
-    PVEC_XWIDGET = 12,
-    PVEC_XWIDGET_VIEW = 13,
-
-    PVEC_COMPILED = 14,
-    PVEC_CHAR_TABLE = 15,
-    PVEC_SUB_CHAR_TABLE = 16,
-    PVEC_FONT = 17,
-}
-
-#[repr(C)]
-pub struct VectorLikeHeader {
-    pub size: libc::ptrdiff_t,
-}
-
-/// Represents an elisp function.
-#[repr(C)]
-pub struct LispSubr {
-    pub header: VectorLikeHeader,
-    /// The C or Rust function that we will call when the user invokes
-    /// the elisp function.
-    pub function: *const libc::c_void,
-    /// The minimum number of arguments to the elisp function.
-    pub min_args: libc::c_short,
-    /// The maximum number of arguments to the elisp function.
-    pub max_args: libc::c_short,
-    /// The name of the function in elisp.
-    pub symbol_name: *const c_char,
-    /// The interactive specification. This may be a normal prompt
-    /// string, such as `"bBuffer: "` or an elisp form as a string.
-    /// If the function is not interactive, this should be a null
-    /// pointer.
-    pub intspec: *const c_char,
-    /// The docstring of our function.
-    pub doc: *const c_char,
-}
-
-// In order to use `lazy_static!` with LispSubr, it must be Sync. Raw
-// pointers are not Sync, but it isn't a problem to define Sync if we
-// never mutate LispSubr values. If we do, we will need to create
-// these objects at runtime, perhaps using forget().
-//
-// Based on http://stackoverflow.com/a/28116557/509706
-unsafe impl Sync for LispSubr {}
-
 /// Define an elisp function struct.
 ///
 /// # Example
@@ -536,10 +461,10 @@ macro_rules! defun {
         lazy_static! {
 // TODO: this is blindly hoping we have the correct alignment.
 // We should ensure we have GCALIGNMENT (8 bytes).
-            pub static ref $sname: $crate::lisp::LispSubr = $crate::lisp::LispSubr {
-                header: $crate::lisp::VectorLikeHeader {
-                    size: (($crate::lisp::PvecType::PVEC_SUBR as $crate::libc::c_int) <<
-                           $crate::lisp::PSEUDOVECTOR_AREA_BITS) as $crate::libc::ptrdiff_t,
+            pub static ref $sname: $crate::remacs_sys::Lisp_Subr = $crate::remacs_sys::Lisp_Subr {
+                header: $crate::remacs_sys::vectorlike_header {
+                    size: ($crate::remacs_sys::PVEC_SUBR <<
+                           $crate::remacs_sys::PSEUDOVECTOR_AREA_BITS) as $crate::libc::ptrdiff_t,
                 },
                 function: ($fname as *const $crate::libc::c_void),
                 min_args: $min_args,
@@ -594,10 +519,10 @@ macro_rules! defun_many {
         lazy_static! {
 // TODO: this is blindly hoping we have the correct alignment.
 // We should ensure we have GCALIGNMENT (8 bytes).
-            pub static ref $sname: $crate::lisp::LispSubr = $crate::lisp::LispSubr {
-                header: $crate::lisp::VectorLikeHeader {
-                    size: (($crate::lisp::PvecType::PVEC_SUBR as $crate::libc::c_int) <<
-                           $crate::lisp::PSEUDOVECTOR_AREA_BITS) as $crate::libc::ptrdiff_t,
+            pub static ref $sname: $crate::remacs_sys::Lisp_Subr = $crate::remacs_sys::Lisp_Subr {
+                header: $crate::remacs_sys::vectorlike_header {
+                    size: ($crate::remacs_sys::PVEC_SUBR <<
+                           $crate::remacs_sys::PSEUDOVECTOR_AREA_BITS) as $crate::libc::ptrdiff_t,
                 },
                 function: ($fname as *const $crate::libc::c_void),
                 min_args: $min_args,


### PR DESCRIPTION
`LispSubr` is now `Lisp_Subr` in `remacs-sys`.