### PR TITLE
Fix rust build

### DIFF
--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -612,6 +612,7 @@ mod deprecated {
     use super::*;
     use libc;
     use std;
+    use remacs_sys::EmacsInt;
 
     /// Convert a LispObject to an EmacsInt.
     #[allow(non_snake_case)]


### PR DESCRIPTION
I have a build error

> Compiling libc v0.2.17
>    Compiling rustc-serialize v0.3.22
>    Compiling lazy_static v0.2.2
>    Compiling remacs-sys v0.1.0 (file:///******/remacs/rust_src/remacs-sys)
>    Compiling remacs v0.1.0 (file:///******/remacs/src/../rust_src)
> error[E0412]: type name `EmacsInt` is undefined or not in scope
>    --> ../rust_src/src/lisp.rs:620:34
>     |
> 620 |     pub fn XLI(o: LispObject) -> EmacsInt {
>     |                                  ^^^^^^^^ undefined or not in scope
>     |
>     = help: you can import it into scope: `use remacs_sys::EmacsInt;`.
> 
> error[E0412]: type name `EmacsInt` is undefined or not in scope
>    --> ../rust_src/src/lisp.rs:627:19
>     |
> 627 |     pub fn XIL(i: EmacsInt) -> LispObject {
>     |                   ^^^^^^^^ undefined or not in scope
>     |
>     = help: you can import it into scope: `use remacs_sys::EmacsInt;`.
> 
> error[E0412]: type name `EmacsInt` is undefined or not in scope
>    --> ../rust_src/src/lisp.rs:647:27
>     |
> 647 |     pub fn make_number(n: EmacsInt) -> LispObject {
>     |                           ^^^^^^^^ undefined or not in scope
>     |
>     = help: you can import it into scope: `use remacs_sys::EmacsInt;`.
> 
> error[E0412]: type name `EmacsInt` is undefined or not in scope
>    --> ../rust_src/src/lisp.rs:654:35
>     |
> 654 |     pub fn XINT(a: LispObject) -> EmacsInt {
>     |                                   ^^^^^^^^ undefined or not in scope
>     |
>     = help: you can import it into scope: `use remacs_sys::EmacsInt;`.
> 
> error[E0412]: type name `EmacsInt` is undefined or not in scope
>    --> ../rust_src/src/lisp.rs:701:27
>     |
> 701 |     pub fn make_natnum(n: EmacsInt) -> LispObject {
>     |                           ^^^^^^^^ undefined or not in scope
>     |
>     = help: you can import it into scope: `use remacs_sys::EmacsInt;`.
> 
> error[E0412]: type name `EmacsInt` is undefined or not in scope
>    --> ../rust_src/src/lisp.rs:826:39
>     |
> 826 |     pub fn XFASTINT(a: LispObject) -> EmacsInt {
>     |                                       ^^^^^^^^ undefined or not in scope
>     |
>     = help: you can import it into scope: `use remacs_sys::EmacsInt;`.
> 
> error[E0412]: type name `EmacsInt` is undefined or not in scope
>    --> ../rust_src/src/lisp.rs:827:16
>     |
> 827 |         let n: EmacsInt = XINT(a);
>     |                ^^^^^^^^ undefined or not in scope
>     |
>     = help: you can import it into scope: `use remacs_sys::EmacsInt;`.
> 
> error: aborting due to 7 previous errors
> 
> error: Could not compile `remacs`.

Fixed