### PR TITLE
Skip EIEIO test that fails non-deterministically on Travis

### DIFF
--- a/test/lisp/emacs-lisp/eieio-tests/eieio-tests.el
+++ b/test/lisp/emacs-lisp/eieio-tests/eieio-tests.el
@@ -893,6 +893,9 @@ Subclasses to override slot attributes.")
   (list newname 2))
 
 (ert-deftest eieio-test-37-obsolete-name-in-constructor ()
+  ;; Skipping on Remacs as this fails non-deterministically on Travis
+  ;; https://github.com/Wilfred/remacs/issues/159
+  (skip-unless (equal invocation-name "emacs"))
   (should (equal (eieio--testing "toto") '("toto" 2))))
 
 (ert-deftest eieio-autoload ()


### PR DESCRIPTION
See #159.

This caused legitimate PRs #153 and #158 to fail.