### PR TITLE
Porting characterp

### DIFF
--- a/rust_src/src/character.rs
+++ b/rust_src/src/character.rs
@@ -19,12 +19,12 @@ defun!("max-char",
        ptr::null(),
        "Return the character of the maximum code.");
 
-/* Nonzero iff X is a character.  */
+// Nonzero iff X is a character.
 pub fn CHARACTERP(x: LispObject) -> bool {
     lisp::NATNUMP(x) && lisp::XFASTINT(x) <= MAX_CHAR
 }
 
-fn characterp(object: LispObject, ignore: LispObject) -> LispObject {
+fn characterp(object: LispObject, _ignore: LispObject) -> LispObject {
     if CHARACTERP(object) {
         LispObject::constant_t()
     } else {

--- a/rust_src/src/character.rs
+++ b/rust_src/src/character.rs
@@ -18,3 +18,29 @@ defun!("max-char",
        0,
        ptr::null(),
        "Return the character of the maximum code.");
+
+/* Nonzero iff X is a character.  */
+pub fn CHARACTERP(x: LispObject) -> bool {
+    lisp::NATNUMP(x) && lisp::XFASTINT(x) <= MAX_CHAR
+}
+
+fn characterp(object: LispObject, ignore: LispObject) -> LispObject {
+    if CHARACTERP(object) {
+        LispObject::constant_t()
+    } else {
+        LispObject::constant_nil()
+    }
+}
+
+defun!("characterp",
+       Fcharacterp(x, y),
+       Scharacterp,
+       characterp,
+       1,
+       2,
+       ptr::null(),
+       "Return non-nil if OBJECT is a character.
+In Emacs Lisp, characters are represented by character codes, which
+are non-negative integers.  The function `max-char' returns the
+maximum character code.
+usage: (characterp OBJECT)");

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -112,6 +112,7 @@ pub extern "C" fn rust_init_syms() {
         defsubr(&*strings::Sstring_bytes);
         defsubr(&*strings::Snull);
         defsubr(&*character::Smax_char);
+        defsubr(&*character::Scharacterp);
 
         floatfns::init_float_syms();
     }

--- a/src/character.c
+++ b/src/character.c
@@ -216,17 +216,6 @@ translate_char (Lisp_Object table, int c)
   return c;
 }
 
-DEFUN ("characterp", Fcharacterp, Scharacterp, 1, 2, 0,
-       doc: /* Return non-nil if OBJECT is a character.
-In Emacs Lisp, characters are represented by character codes, which
-are non-negative integers.  The function `max-char' returns the
-maximum character code.
-usage: (characterp OBJECT)  */
-       attributes: const)
-  (Lisp_Object object, Lisp_Object ignore)
-{
-  return (CHARACTERP (object) ? Qt : Qnil);
-}
 
 DEFUN ("unibyte-char-to-multibyte", Funibyte_char_to_multibyte,
        Sunibyte_char_to_multibyte, 1, 1, 0,
@@ -1051,7 +1040,6 @@ syms_of_character (void)
   staticpro (&Vchar_unify_table);
   Vchar_unify_table = Qnil;
 
-  defsubr (&Scharacterp);
   defsubr (&Sunibyte_char_to_multibyte);
   defsubr (&Smultibyte_char_to_unibyte);
   defsubr (&Schar_width);


### PR DESCRIPTION
This is my first experience on rust. I started porting a single function from character.c which also needed to port a macro from character.h which I did not delete after porting.

This compiles and the function works
But I noticed documentation is not working, neither in this function nor in other ported functions. like `max-char` or the one of the readme page `numberp`

Looking forward to listen from your reviews
