### PR TITLE
Move `extern "C"` block to remacs-sys

### DIFF
--- a/rust_src/remacs-sys/lib.rs
+++ b/rust_src/remacs-sys/lib.rs
@@ -637,9 +637,32 @@ pub struct emacs_globals {
     pub f_x_use_underline_position_properties: bool,
 }
 
+/// Represents a string value in elisp
+#[repr(C)]
+pub struct Lisp_String {
+    pub size: libc::ptrdiff_t,
+    pub size_byte: libc::ptrdiff_t,
+    // TODO: Use correct definition for this.
+    //
+    // Maybe use rust nightly unions?
+    pub intervals: *mut libc::c_void, // @TODO implement
+    pub data: *mut libc::c_char,
+}
+
 extern "C" {
     pub static mut globals: emacs_globals;
+    pub static Qt: Lisp_Object;
+    pub static Qarith_error: Lisp_Object;
+    pub static Qnumber_or_marker_p: Lisp_Object;
+    pub static Qnumberp: Lisp_Object;
+    pub static Qfloatp: Lisp_Object;
+    pub static Qstringp: Lisp_Object;
 
     pub fn make_unibyte_string(s: *const libc::c_char, length: libc::ptrdiff_t) -> Lisp_Object;
+    pub fn wrong_type_argument(predicate: Lisp_Object, value: Lisp_Object) -> Lisp_Object;
+    pub fn STRING_BYTES(s: *mut Lisp_String) -> libc::ptrdiff_t;
+    pub fn STRING_MULTIBYTE(a: Lisp_Object) -> bool;
+    pub fn SSDATA(string: Lisp_Object) -> *mut libc::c_char;
+    pub fn make_float(float_value: libc::c_double) -> Lisp_Object;
 
 }

--- a/rust_src/src/floatfns.rs
+++ b/rust_src/src/floatfns.rs
@@ -1,7 +1,7 @@
 use std::ptr;
 
-use lisp::{LispObject, Qnumberp, Qfloatp, CHECK_TYPE};
-use remacs_sys::{EmacsDouble, Lisp_Object};
+use lisp::{LispObject, CHECK_TYPE};
+use remacs_sys::{EmacsDouble, Lisp_Object, Qnumberp, Qfloatp};
 
 pub fn init_float_syms() {
     unsafe {

--- a/rust_src/src/lists.rs
+++ b/rust_src/src/lists.rs
@@ -3,8 +3,8 @@ use std::mem;
 
 use libc;
 
-use lisp::{CHECK_TYPE, LispObject, LispType, Qnil, XTYPE, XUNTAG, wrong_type_argument};
-use remacs_sys::Lisp_Object;
+use lisp::{CHECK_TYPE, LispObject, LispType, Qnil, XTYPE, XUNTAG};
+use remacs_sys::{Lisp_Object, wrong_type_argument};
 
 extern "C" {
     static Qconsp: Lisp_Object;

--- a/rust_src/src/math.rs
+++ b/rust_src/src/math.rs
@@ -3,9 +3,9 @@ use libc::ptrdiff_t;
 
 use floatfns;
 use lisp;
-use lisp::{LispObject, Qarith_error, XINT, make_number, CHECK_TYPE, Qnumberp, LispType};
+use lisp::{LispObject, XINT, make_number, CHECK_TYPE, LispType};
 use eval::xsignal0;
-use remacs_sys::{EmacsInt, Lisp_Object};
+use remacs_sys::{EmacsInt, Lisp_Object, Qarith_error, Qnumberp};
 
 fn lisp_mod(x: LispObject, y: LispObject) -> LispObject {
     let x = lisp::check_number_coerce_marker(x);

--- a/rust_src/src/numbers.rs
+++ b/rust_src/src/numbers.rs
@@ -1,6 +1,7 @@
 use std::ptr;
 
-use lisp::{LispObject, Qnil, Qt, INTEGERP, FLOATP, MARKERP, NATNUMP, NUMBERP};
+use lisp::{LispObject, Qnil, INTEGERP, FLOATP, MARKERP, NATNUMP, NUMBERP};
+use remacs_sys::Qt;
 
 fn floatp(object: LispObject) -> LispObject {
     if FLOATP(object) {

--- a/rust_src/src/strings.rs
+++ b/rust_src/src/strings.rs
@@ -2,9 +2,9 @@ use std::ptr;
 
 use libc;
 
-use lisp::{LispObject, Qnil, SBYTES, SSDATA, STRING_MULTIBYTE, STRINGP, CHECK_STRING};
+use lisp::{LispObject, Qnil, SBYTES, STRINGP, CHECK_STRING};
 use lists::NILP;
-use remacs_sys::Lisp_Object;
+use remacs_sys::{Lisp_Object, SSDATA, STRING_MULTIBYTE};
 
 extern "C" {
     fn make_string(s: *const libc::c_char, length: libc::ptrdiff_t) -> Lisp_Object;

--- a/rust_src/src/strings.rs
+++ b/rust_src/src/strings.rs
@@ -159,7 +159,7 @@ defun!("base64-decode-string",
 
 fn string_bytes(string: LispObject) -> LispObject {
     CHECK_STRING(string.to_raw());
-    unsafe { LispObject::from_fixnum_unchecked(SBYTES(string) as EmacsInt) }
+    unsafe { LispObject::from_fixnum_unchecked(SBYTES(string) as ::remacs_sys::EmacsInt) }
 }
 
 defun!("string-bytes",


### PR DESCRIPTION
In a effort to refactor lisp.rs i moved some extern functions and
statics to remacs-sys.

Signed-off-by: Jean Pierre Dudey <jeandudey@hotmail.com>