### PR TITLE
Remove rust_print_lisp_object function

### DIFF
--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -117,8 +117,3 @@ pub extern "C" fn rust_init_syms() {
         floatfns::init_float_syms();
     }
 }
-
-#[no_mangle]
-pub extern "C" fn rust_print_lisp_object(v: lisp::LispObject) {
-    println!("{:?}", v)
-}


### PR DESCRIPTION
This function was used for debugging but now it isn't needed anymore.

Signed-off-by: Jean Pierre Dudey <jeandudey@hotmail.com>