### PR TITLE
Add define_functions macro.

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,14 +293,16 @@ defun!("numberp", // the name of our primitive function inside elisp
 (fn OBJECT)");
 ```
 
-Finally, we need to delete the old C definition and call `defsubr`
-inside `rust_init_syms`:
+Finally, we need to delete the old C definition and put the
+symbol name in the `define_functions` macro inside `rust_init_syms`:
 
 ``` rust
 pub extern "C" fn rust_init_syms() {
-    unsafe {
+    define_functions! {
         // ...
-        defsubr(&*yourmodule::Snumberp);
+        yourmodule = {
+            Snumberp
+        }
     }
 }
 ```

--- a/rust_src/src/floatfns.rs
+++ b/rust_src/src/floatfns.rs
@@ -3,26 +3,6 @@ use std::ptr;
 use lisp::{LispObject, Qnumberp, Qfloatp, CHECK_TYPE};
 use remacs_sys::{EmacsDouble, Lisp_Object};
 
-pub fn init_float_syms() {
-    unsafe {
-        ::defsubr(&*Sisnan);
-        ::defsubr(&*Sacos);
-        ::defsubr(&*Sasin);
-        ::defsubr(&*Satan);
-        ::defsubr(&*Scos);
-        ::defsubr(&*Ssin);
-        ::defsubr(&*Stan);
-        ::defsubr(&*Slog);
-
-        ::defsubr(&*Ssqrt);
-        ::defsubr(&*Sexp);
-        ::defsubr(&*Sffloor);
-        ::defsubr(&*Sfceiling);
-        ::defsubr(&*Sftruncate);
-        ::defsubr(&*Sfloat);
-    }
-}
-
 /// Either extracts a floating point number from a lisp number (of any kind) or throws an error
 /// TODO eventually, this can hopefully go away when we have a better approach for error handling
 #[no_mangle]

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -77,44 +77,85 @@ extern "C" {
     fn defsubr(sname: *const Lisp_Subr);
 }
 
+/// Define Emacs Lisp native functions.
+///
+/// TODO: Remove `S` prefix of symbols (requires *nightly*).
+/// TODO: Declare modules instead of importing it manually
+macro_rules! define_functions {
+    ($($module_name:ident = { $($native_symbol:ident),+ }),+) => {
+        unsafe {
+        $($(
+            $crate::defsubr(&*$module_name::$native_symbol);
+        )+)+
+        }
+    }
+}
+
+
 #[no_mangle]
 pub extern "C" fn rust_init_syms() {
-    unsafe {
-        defsubr(&*lists::Satom);
-        defsubr(&*lists::Slistp);
-        defsubr(&*lists::Snlistp);
-        defsubr(&*math::Smod);
-        defsubr(&*math::Splus);
-        defsubr(&*math::Sminus);
-        defsubr(&*math::Stimes);
-        defsubr(&*math::Squo);
-        defsubr(&*math::Slogand);
-        defsubr(&*math::Slogior);
-        defsubr(&*math::Slogxor);
-        defsubr(&*math::Smax);
-        defsubr(&*math::Smin);
-        defsubr(&*math::Sabs);
-        defsubr(&*numbers::Sintegerp);
-        defsubr(&*numbers::Sinteger_or_marker_p);
-        defsubr(&*numbers::Sfloatp);
-        defsubr(&*numbers::Snatnump);
-        defsubr(&*numbers::Snumber_or_marker_p);
-        defsubr(&*numbers::Snumberp);
-        defsubr(&*symbols::Ssymbolp);
-        defsubr(&*lists::Sconsp);
-        defsubr(&*lists::Ssetcar);
-        defsubr(&*lists::Ssetcdr);
-        defsubr(&*lists::Scar);
-        defsubr(&*lists::Scdr);
-        defsubr(&*strings::Sstringp);
-        defsubr(&*strings::Seq);
-        defsubr(&*strings::Sbase64_encode_string);
-        defsubr(&*strings::Sbase64_decode_string);
-        defsubr(&*strings::Sstring_bytes);
-        defsubr(&*strings::Snull);
-        defsubr(&*character::Smax_char);
-
-        floatfns::init_float_syms();
+    define_functions! {
+        lists = {
+            Satom,
+            Slistp,
+            Snlistp,
+            Sconsp,
+            Ssetcar,
+            Ssetcdr,
+            Scar,
+            Scdr
+        },
+        math = {
+            Smod,
+            Splus,
+            Sminus,
+            Stimes,
+            Squo,
+            Slogand,
+            Slogior,
+            Slogxor,
+            Smax,
+            Smin,
+            Sabs
+        },
+        numbers = {
+            Sintegerp,
+            Sinteger_or_marker_p,
+            Sfloatp,
+            Snatnump,
+            Snumber_or_marker_p,
+            Snumberp
+        },
+        symbols = {
+            Ssymbolp
+        },
+        strings = {
+            Sstringp,
+            Sstring_bytes,
+            Seq,
+            Sbase64_encode_string,
+            Sbase64_decode_string,
+            Snull
+        },
+        character = {
+            Smax_char
+        },
+        floatfns = {
+            Sisnan,
+            Sacos,
+            Sasin,
+            Satan,
+            Scos,
+            Ssin,
+            Stan,
+            Slog,
+            Ssqrt,
+            Sexp,
+            Sffloor,
+            Sfceiling,
+            Sftruncate,
+            Sfloat
+        }
     }
 }
 


### PR DESCRIPTION
I refactored the `rust_init_syms` function, i added the define_functions
macro. It handles the definition of the `rust_init_syms` function, also
it eventually could be used to export C functions and handle modules
definitions.

Also the `floatfns_init_syms` function was removed, the define_functions
allows us to initialize the symbols more cleanly without the need of another
function.

Signed-off-by: Jean Pierre Dudey <jeandudey@hotmail.com>