### PR TITLE
Import Lisp_String into scope

### DIFF
--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -567,6 +567,7 @@ mod deprecated {
     use libc;
     use std;
     use remacs_sys::EmacsInt;
+    use remacs_sys::Lisp_String;
 
     /// Convert a LispObject to an EmacsInt.
     #[allow(non_snake_case)]


### PR DESCRIPTION
Build fails with error

```
error[E0412]: type name `Lisp_String` is undefined or not in scope
   --> ../rust_src/src/lisp.rs:756:43
    |
756 |     pub fn XSTRING(a: LispObject) -> *mut Lisp_String {
    |                                           ^^^^^^^^^^^ undefined or not in scope
    |
    = help: you can import it into scope: `use remacs_sys::Lisp_String;`.
```