### PR TITLE
Fix for issue #187. 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5118,7 +5118,7 @@ fi
 AC_SUBST(CARGO_FLAGS)
 
 case "${opsys}" in
-  darwin) RUST_DEPS="-ldl"
+  darwin) RUST_DEPS="-ldl -lresolv"
   	  REMACSLIB_CFLAGS="-pthread" ;;
   gnu*) RUST_DEPS="-ldl -lrt"
         REMACSLIB_CFLAGS="-pthread" ;;

--- a/lib-src/Makefile.in
+++ b/lib-src/Makefile.in
@@ -348,7 +348,7 @@ uninstall:
 mostlyclean:
 	rm -f core *.o *.res
 
-clean: mostlyclean
+clean: mostlyclean remacs-libclean
 	rm -f ${EXE_FILES}
 
 distclean: clean
@@ -377,6 +377,9 @@ cargo_manifest=../rust_src/remacs-lib/Cargo.toml
 $(RUST_LIB):
 	RUSTFLAGS=$(RUSTFLAGS) \
 	$(CARGO_BUILD) $(CARGO_FLAGS) --manifest-path=$(cargo_manifest)
+
+remacs-libclean:
+	$(CARGO_CLEAN) --manifest-path=$(cargo_manifest)
 
 regex.o: $(srcdir)/../src/regex.c $(srcdir)/../src/regex.h $(config_h)
 	$(AM_V_CC)$(CC) -c $(CPP_CFLAGS) $<


### PR DESCRIPTION
Fix for https://github.com/Wilfred/remacs/issues/187, which will cause users on certain OSX versions to be unable to build remacs. 

I've also included a separate commit to fix another issue I noticed while fixing this one; running `make clean` in lib-src will not run cargo clean for remacs-lib. 