### PR TITLE
Converting 'count-trailing-zeros' and 'count_one_bits' to Rust

### DIFF
--- a/rust_src/remacs-lib/lib.rs
+++ b/rust_src/remacs-lib/lib.rs
@@ -7,6 +7,14 @@
 extern crate libc;
 
 mod files;
+mod math;
 
 // Used for creating temporary files in emacs
 pub use files::rust_make_temp;
+
+pub use math::rust_count_trailing_zeros;
+pub use math::rust_count_trailing_zeros_l;
+pub use math::rust_count_trailing_zeros_ll;
+pub use math::rust_count_one_bits;
+pub use math::rust_count_one_bits_l;
+pub use math::rust_count_one_bits_ll;

--- a/rust_src/remacs-lib/math.rs
+++ b/rust_src/remacs-lib/math.rs
@@ -1,4 +1,4 @@
-extern crate libc;
+use libc;
 
 // Macro used to generate a c function that wraps functionality provided by the Rust stdlib
 // for u32 and other unsigned types.

--- a/rust_src/remacs-lib/math.rs
+++ b/rust_src/remacs-lib/math.rs
@@ -1,0 +1,22 @@
+extern crate libc;
+
+// Macro used to generate a c function that wraps functionality provided by the Rust stdlib
+// for u32 and other unsigned types.
+macro_rules! gen_unsigned_wrapper_fn {
+    ($fn_name: ident, $invoke: ident, $type: ty) => {
+        #[no_mangle]
+        pub extern "C" fn $fn_name(bar: $type) -> libc::c_int {
+            bar.$invoke() as libc::c_int
+        }
+    }
+}
+
+gen_unsigned_wrapper_fn!(rust_count_trailing_zeros, trailing_zeros, libc::c_uint);
+gen_unsigned_wrapper_fn!(rust_count_trailing_zeros_l, trailing_zeros, libc::c_ulong);
+gen_unsigned_wrapper_fn!(rust_count_trailing_zeros_ll,
+                         trailing_zeros,
+                         libc::c_ulonglong);
+
+gen_unsigned_wrapper_fn!(rust_count_one_bits, count_ones, libc::c_uint);
+gen_unsigned_wrapper_fn!(rust_count_one_bits_l, count_ones, libc::c_ulong);
+gen_unsigned_wrapper_fn!(rust_count_one_bits_ll, count_ones, libc::c_ulonglong);

--- a/src/data.c
+++ b/src/data.c
@@ -23,7 +23,6 @@ along with GNU Emacs.  If not, see <http://www.gnu.org/licenses/>.  */
 
 #include <byteswap.h>
 #include <count-one-bits.h>
-#include <count-trailing-zeros.h>
 #include <intprops.h>
 
 #include "lisp.h"
@@ -34,6 +33,7 @@ along with GNU Emacs.  If not, see <http://www.gnu.org/licenses/>.  */
 #include "process.h"
 #include "frame.h"
 #include "keymap.h"
+#include "remacs-lib.h"
 
 static void swap_in_symval_forwarding (struct Lisp_Symbol *,
 				       struct Lisp_Buffer_Local_Value *);
@@ -2712,8 +2712,8 @@ enum { ULL_WIDTH = ULLONG_WIDTH };
 #else
 enum { ULL_WIDTH = ULONG_WIDTH };
 # define ULL_MAX ULONG_MAX
-# define count_one_bits_ll count_one_bits_l
-# define count_trailing_zeros_ll count_trailing_zeros_l
+# define rust_count_one_bits_ll rust_count_one_bits_l
+# define rust_count_trailing_zeros_ll rust_count_trailing_zeros_l
 #endif
 
 /* Shift VAL right by the width of an unsigned long long.
@@ -2733,13 +2733,13 @@ static int
 count_one_bits_word (bits_word w)
 {
   if (BITS_WORD_MAX <= UINT_MAX)
-    return count_one_bits (w);
+    return rust_count_one_bits (w);
   else if (BITS_WORD_MAX <= ULONG_MAX)
-    return count_one_bits_l (w);
+    return rust_count_one_bits_l (w);
   else
     {
       int i = 0, count = 0;
-      while (count += count_one_bits_ll (w),
+      while (count += rust_count_one_bits_ll (w),
 	     (i += ULL_WIDTH) < BITS_PER_BITS_WORD)
 	w = shift_right_ull (w);
       return count;
@@ -2868,19 +2868,19 @@ static int
 count_trailing_zero_bits (bits_word val)
 {
   if (BITS_WORD_MAX == UINT_MAX)
-    return count_trailing_zeros (val);
+    return rust_count_trailing_zeros (val);
   if (BITS_WORD_MAX == ULONG_MAX)
-    return count_trailing_zeros_l (val);
+    return rust_count_trailing_zeros_l (val);
   if (BITS_WORD_MAX == ULL_MAX)
-    return count_trailing_zeros_ll (val);
+    return rust_count_trailing_zeros_ll (val);
 
   /* The rest of this code is for the unlikely platform where bits_word differs
      in width from unsigned int, unsigned long, and unsigned long long.  */
   val |= ~ BITS_WORD_MAX;
   if (BITS_WORD_MAX <= UINT_MAX)
-    return count_trailing_zeros (val);
+    return rust_count_trailing_zeros (val);
   if (BITS_WORD_MAX <= ULONG_MAX)
-    return count_trailing_zeros_l (val);
+    return rust_count_trailing_zeros_l (val);
   else
     {
       int count;
@@ -2889,7 +2889,7 @@ count_trailing_zero_bits (bits_word val)
 	   count += ULL_WIDTH)
 	{
 	  if (val & ULL_MAX)
-	    return count + count_trailing_zeros_ll (val);
+	    return count + rust_count_trailing_zeros_ll (val);
 	  val = shift_right_ull (val);
 	}
 
@@ -2897,7 +2897,7 @@ count_trailing_zero_bits (bits_word val)
 	  && BITS_WORD_MAX == (bits_word) -1)
 	val |= (bits_word) 1 << pre_value (ULONG_MAX < BITS_WORD_MAX,
 					   BITS_PER_BITS_WORD % ULL_WIDTH);
-      return count + count_trailing_zeros_ll (val);
+      return count + rust_count_trailing_zeros_ll (val);
     }
 }
 

--- a/src/remacs-lib.h
+++ b/src/remacs-lib.h
@@ -9,4 +9,12 @@
 // the same guarantees
 int rust_make_temp(char *template, int flags);
 
+int rust_count_trailing_zeros(unsigned int x);
+int rust_count_trailing_zeros_l(unsigned long x);
+int rust_count_trailing_zeros_ll(unsigned long long x);
+
+int rust_count_one_bits(unsigned int x);
+int rust_count_one_bits_l(unsigned long x);
+int rust_count_one_bits_ll(unsigned long long x);
+
 #endif


### PR DESCRIPTION
This PR will allow us to delete:
 ```
lib/count-one-bits.c
lib/count-one-bits.h
lib/count-trailing-zeros.c
lib/count-trailing-zeros.h
```
By replacing the functionality provided in these files by function provided by the Rust standard library. 

I will submit the deletion of those files as a separate PR, as it looks like people (including myself!) have been removing files from lib/ without running gnulib-tool to re-generate the make files. Running gnulib-tool now with the proper generation command leads to some slightly incorrect makefiles, and that will need to be corrected.  