### PR TITLE
Updating 'bits_word' to always be a typedef for size_t. 

### DIFF
--- a/rust_src/remacs-lib/lib.rs
+++ b/rust_src/remacs-lib/lib.rs
@@ -12,9 +12,5 @@ mod math;
 // Used for creating temporary files in emacs
 pub use files::rust_make_temp;
 
-pub use math::rust_count_trailing_zeros;
-pub use math::rust_count_trailing_zeros_l;
-pub use math::rust_count_trailing_zeros_ll;
+pub use math::rust_count_trailing_zero_bits;
 pub use math::rust_count_one_bits;
-pub use math::rust_count_one_bits_l;
-pub use math::rust_count_one_bits_ll;

--- a/rust_src/remacs-lib/math.rs
+++ b/rust_src/remacs-lib/math.rs
@@ -1,22 +1,11 @@
 use libc;
 
-// Macro used to generate a c function that wraps functionality provided by the Rust stdlib
-// for u32 and other unsigned types.
-macro_rules! gen_unsigned_wrapper_fn {
-    ($fn_name: ident, $invoke: ident, $type: ty) => {
-        #[no_mangle]
-        pub extern "C" fn $fn_name(bar: $type) -> libc::c_int {
-            bar.$invoke() as libc::c_int
-        }
-    }
+#[no_mangle]
+pub extern "C" fn rust_count_trailing_zero_bits(val: libc::size_t) -> libc::c_int {
+    val.trailing_zeros() as libc::c_int
 }
 
-gen_unsigned_wrapper_fn!(rust_count_trailing_zeros, trailing_zeros, libc::c_uint);
-gen_unsigned_wrapper_fn!(rust_count_trailing_zeros_l, trailing_zeros, libc::c_ulong);
-gen_unsigned_wrapper_fn!(rust_count_trailing_zeros_ll,
-                         trailing_zeros,
-                         libc::c_ulonglong);
-
-gen_unsigned_wrapper_fn!(rust_count_one_bits, count_ones, libc::c_uint);
-gen_unsigned_wrapper_fn!(rust_count_one_bits_l, count_ones, libc::c_ulong);
-gen_unsigned_wrapper_fn!(rust_count_one_bits_ll, count_ones, libc::c_ulonglong);
+#[no_mangle]
+pub extern "C" fn rust_count_one_bits(val: libc::size_t) -> libc::c_int {
+    val.count_ones() as libc::c_int
+}

--- a/src/lisp.h
+++ b/src/lisp.h
@@ -112,19 +112,11 @@ enum {  BOOL_VECTOR_BITS_PER_CHAR =
 };
 
 /* An unsigned integer type representing a fixed-length bit sequence,
-   suitable for bool vector words, GC mark bits, etc.  Normally it is size_t
-   for speed, but on weird platforms it is unsigned char and not all
-   its bits are used.  */
-#if BOOL_VECTOR_BITS_PER_CHAR == CHAR_BIT
+   suitable for bool vector words, GC mark bits, etc. */
+
 typedef size_t bits_word;
 # define BITS_WORD_MAX SIZE_MAX
 enum { BITS_PER_BITS_WORD = SIZE_WIDTH };
-#else
-typedef unsigned char bits_word;
-# define BITS_WORD_MAX ((1u << BOOL_VECTOR_BITS_PER_CHAR) - 1)
-enum { BITS_PER_BITS_WORD = BOOL_VECTOR_BITS_PER_CHAR };
-#endif
-verify (BITS_WORD_MAX >> (BITS_PER_BITS_WORD - 1) == 1);
 
 /* printmax_t and uprintmax_t are types for printing large integers.
    These are the widest integers that are supported for printing.

--- a/src/remacs-lib.h
+++ b/src/remacs-lib.h
@@ -9,12 +9,7 @@
 // the same guarantees
 int rust_make_temp(char *template, int flags);
 
-int rust_count_trailing_zeros(unsigned int x);
-int rust_count_trailing_zeros_l(unsigned long x);
-int rust_count_trailing_zeros_ll(unsigned long long x);
-
-int rust_count_one_bits(unsigned int x);
-int rust_count_one_bits_l(unsigned long x);
-int rust_count_one_bits_ll(unsigned long long x);
+int rust_count_trailing_zero_bits(size_t val);
+int rust_count_one_bits(size_t val);
 
 #endif


### PR DESCRIPTION
This PR allows us to delete several legacy codepaths in data.c for determining the number of trailing 0 bits in a bits_word, and the number of total one bits in a bits_word. These functions can now be easily farmed out to the standard rust implementation.