### PR TITLE
Explicitly pin a rustfmt version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,10 @@ env:
   # Ensure that we build without warnings.
   - CARGO_FLAGS="--features 'strict'"
 
-before_script: (cargo install --force rustfmt || true)
+before_script:
+  # Install rustfmt 0.9.0 if it isn't already installed on
+  # Travis. This can be slow to install, so raise the Travis timeout.
+  - (which rustfmt && rustfmt --version && [ "$(rustfmt --version)" = 0.9.0-* ]) || travis_wait cargo install --force rustfmt --vers 0.9.0
 
 script:
   - ./.travis.sh


### PR DESCRIPTION
Currently, the build fails every time a new version of rustfmt comes out. This is surprising for PR authors, who expect the build to be green other than any changes they might make.

Pin to the latest version of rustfmt as this time of writing.

This will fail because our source code is currently formatted for 0.8.x and rustfmt 0.9.0 is out. I will fix this in this branch, unless #203 is merged first.