### PR TITLE
Cleanup: use "extern crate" only in crate root

### DIFF
--- a/rust_src/remacs-lib/files.rs
+++ b/rust_src/remacs-lib/files.rs
@@ -1,23 +1,18 @@
-extern crate libc;
-extern crate rand;
-extern crate errno;
+use rand;
+use errno;
 
 use std::ffi::{CStr, CString};
 use std::io;
+
+use libc::{self, c_int, c_char, EEXIST, EINVAL};
 
 #[cfg(unix)]
 use libc::{O_CLOEXEC, O_EXCL, O_RDWR, O_CREAT, open};
 
 #[cfg(windows)]
 extern "C" {
-    fn sys_open(
-        filename: *const libc::c_char,
-        flags: libc::c_int,
-        mode: libc::c_int,
-    ) -> libc::c_int;
+    fn sys_open(filename: *const c_char, flags: c_int, mode: c_int) -> c_int;
 }
-
-use libc::{EEXIST, EINVAL};
 
 #[cfg(test)]
 use std::env;
@@ -27,7 +22,7 @@ use self::rand::Rng;
 const NUM_RETRIES: usize = 50;
 
 #[no_mangle]
-pub extern "C" fn rust_make_temp(template: *mut libc::c_char, flags: libc::c_int) -> libc::c_int {
+pub extern "C" fn rust_make_temp(template: *mut c_char, flags: c_int) -> c_int {
     let save_errno = errno::errno();
     let template_string = unsafe { CStr::from_ptr(template).to_string_lossy().into_owned() };
 
@@ -89,7 +84,7 @@ fn generate_temporary_filename(name: &mut String) {
 }
 
 #[cfg(unix)]
-fn open_temporary_file(name: &CString, flags: libc::c_int) -> io::Result<libc::c_int> {
+fn open_temporary_file(name: &CString, flags: c_int) -> io::Result<c_int> {
     unsafe {
         match open(
             name.as_ptr(),
@@ -103,7 +98,7 @@ fn open_temporary_file(name: &CString, flags: libc::c_int) -> io::Result<libc::c
 }
 
 #[cfg(windows)]
-fn open_temporary_file(name: &CString, flags: libc::c_int) -> io::Result<libc::c_int> {
+fn open_temporary_file(name: &CString, flags: c_int) -> io::Result<c_int> {
     let _O_CREAT = 0x0100;
     let _O_EXCL = 0x0400;
     let _O_RDWR = 0x0002;

--- a/rust_src/remacs-lib/lib.rs
+++ b/rust_src/remacs-lib/lib.rs
@@ -5,6 +5,8 @@
 #![cfg_attr(feature = "strict", deny(warnings))]
 
 extern crate libc;
+extern crate rand;
+extern crate errno;
 
 mod files;
 mod math;

--- a/rust_src/remacs-lib/math.rs
+++ b/rust_src/remacs-lib/math.rs
@@ -1,11 +1,11 @@
-use libc;
+use libc::{c_int, size_t};
 
 #[no_mangle]
-pub extern "C" fn rust_count_trailing_zero_bits(val: libc::size_t) -> libc::c_int {
-    val.trailing_zeros() as libc::c_int
+pub extern "C" fn rust_count_trailing_zero_bits(val: size_t) -> c_int {
+    val.trailing_zeros() as c_int
 }
 
 #[no_mangle]
-pub extern "C" fn rust_count_one_bits(val: libc::size_t) -> libc::c_int {
-    val.count_ones() as libc::c_int
+pub extern "C" fn rust_count_one_bits(val: size_t) -> c_int {
+    val.count_ones() as c_int
 }

--- a/rust_src/src/crypto/mod.rs
+++ b/rust_src/src/crypto/mod.rs
@@ -1,5 +1,3 @@
-extern crate libc;
-
 use sha1;
 use sha2::{Sha224, Digest, Sha256, Sha384, Sha512};
 use std::{ptr, slice};

--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -1,10 +1,8 @@
 #![allow(non_upper_case_globals)]
 #![macro_use]
 
-/// This module contains Rust definitions whose C equivalents live in
-/// lisp.h.
-
-extern crate libc;
+//! This module contains Rust definitions whose C equivalents live in
+//! lisp.h.
 
 #[cfg(test)]
 use std::cmp::max;
@@ -12,6 +10,7 @@ use std::mem;
 use std::slice;
 use std::ops::Deref;
 use std::fmt::{Debug, Formatter, Error};
+use libc::{c_void, intptr_t};
 
 use marker::{LispMarker, marker_position};
 use multibyte::{LispStringRef, MAX_CHAR};
@@ -144,8 +143,8 @@ impl LispObject {
     }
 
     #[inline]
-    pub fn get_untaggedptr(self) -> *mut libc::c_void {
-        (self.to_raw() & VALMASK) as libc::intptr_t as *mut libc::c_void
+    pub fn get_untaggedptr(self) -> *mut c_void {
+        (self.to_raw() & VALMASK) as intptr_t as *mut c_void
     }
 }
 
@@ -581,7 +580,7 @@ impl LispCons {
     /// Check that "self" is an impure (i.e. not readonly) cons cell.
     pub fn check_impure(self) {
         unsafe {
-            CHECK_IMPURE(self.0.to_raw(), self._extract() as *const libc::c_void);
+            CHECK_IMPURE(self.0.to_raw(), self._extract() as *const c_void);
         }
     }
 }

--- a/rust_src/src/marker.rs
+++ b/rust_src/src/marker.rs
@@ -1,7 +1,8 @@
-extern crate libc;
-
 use std::ptr;
+use libc::ptrdiff_t;
+
 use lisp::{LispObject, LispMiscType};
+use buffers::Lisp_Buffer;
 use remacs_sys::error;
 use remacs_macros::lisp_fn;
 
@@ -13,14 +14,14 @@ pub struct LispMarker {
     // insertion_type flag.
     padding: u16,
     // TODO: define a proper buffer struct.
-    buffer: *const libc::c_void,
+    buffer: *const Lisp_Buffer,
     next: *const LispMarker,
-    charpos: libc::ptrdiff_t,
-    bytepos: libc::ptrdiff_t,
+    charpos: ptrdiff_t,
+    bytepos: ptrdiff_t,
 }
 
 /// Return the char position of marker MARKER, as a C integer.
-pub fn marker_position(m_ptr: *const LispMarker) -> libc::ptrdiff_t {
+pub fn marker_position(m_ptr: *const LispMarker) -> ptrdiff_t {
     let m = unsafe { ptr::read(m_ptr) };
 
     let buf = m.buffer;


### PR DESCRIPTION
Also switch to always using libc types without prefix.