### PR TITLE
Converting 'string-to-unibyte' from C to Rust.

### DIFF
--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -79,6 +79,7 @@ pub use symbols::Fsymbolp;
 pub use strings::Fstring_equal;
 pub use strings::Fstring_as_multibyte;
 pub use strings::Fstring_to_multibyte;
+pub use strings::Fstring_to_unibyte;
 pub use vectors::Flength;
 pub use vectors::Fsort;
 pub use lists::merge;
@@ -171,6 +172,7 @@ pub extern "C" fn rust_init_syms() {
         defsubr(&*strings::Sstring_equal);
         defsubr(&*strings::Sstring_as_multibyte);
         defsubr(&*strings::Sstring_to_multibyte);
+        defsubr(&*strings::Sstring_to_unibyte);
         defsubr(&*character::Smax_char);
         defsubr(&*character::Scharacterp);
         defsubr(&*vectors::Slength);

--- a/rust_src/src/multibyte.rs
+++ b/rust_src/src/multibyte.rs
@@ -87,6 +87,14 @@ impl LispStringRef {
         self.data as *mut c_char
     }
 
+    pub fn const_data_ptr(&self) -> *const c_uchar {
+        self.data as *const c_uchar
+    }
+
+    pub fn const_sdata_ptr(&self) -> *const c_char {
+        self.data as *const c_char
+    }
+
     #[inline]
     pub fn as_slice(&self) -> &[u8] {
         unsafe { slice::from_raw_parts(self.data as *const u8, self.len_bytes() as usize) }

--- a/rust_src/src/strings.rs
+++ b/rust_src/src/strings.rs
@@ -172,14 +172,13 @@ fn string_to_multibyte(string: LispObject) -> LispObject {
 }
 
 /// Return a unibyte string with the same individual chars as STRING.
-/// -If STRING is unibyte, the result is STRING itself.
-/// -Otherwise it is a newly created string, with no text properties,
-/// -where each `eight-bit' character is converted to the corresponding byte.
-/// -If STRING contains a non-ASCII, non-`eight-bit' character,
-/// -an error is signaled.
+/// If STRING is unibyte, the result is STRING itself.
+/// Otherwise it is a newly created string, with no text properties,
+/// where each `eight-bit' character is converted to the corresponding byte.
+/// If STRING contains a non-ASCII, non-`eight-bit' character,
+/// an error is signaled.
 #[lisp_fn]
 fn string_to_unibyte(string: LispObject) -> LispObject {
-    let mut string_mut = string;
     let lispstr = string.as_string_or_error();
     if lispstr.is_multibyte() {
         let size = lispstr.len_bytes();
@@ -190,15 +189,15 @@ fn string_to_unibyte(string: LispObject) -> LispObject {
         unsafe {
             if converted_size < size {
                 error(
-                    "Can't convert %dth character to unibyte\0".as_ptr(),
+                    "Can't convert %ldth character to unibyte\0".as_ptr(),
                     converted_size,
                 );
             }
 
             let raw_ptr = make_unibyte_string(buffer.as_ptr() as *const libc::c_char, size);
-            string_mut = LispObject::from_raw(raw_ptr);
-        };
+            LispObject::from_raw(raw_ptr)
+        }
+    } else {
+        string
     }
-
-    string_mut
 }

--- a/src/fns.c
+++ b/src/fns.c
@@ -979,33 +979,6 @@ If STRING is multibyte and contains a character of charset
   return string;
 }
 
-DEFUN ("string-to-unibyte", Fstring_to_unibyte, Sstring_to_unibyte,
-       1, 1, 0,
-       doc: /* Return a unibyte string with the same individual chars as STRING.
-If STRING is unibyte, the result is STRING itself.
-Otherwise it is a newly created string, with no text properties,
-where each `eight-bit' character is converted to the corresponding byte.
-If STRING contains a non-ASCII, non-`eight-bit' character,
-an error is signaled.  */)
-  (Lisp_Object string)
-{
-  CHECK_STRING (string);
-
-  if (STRING_MULTIBYTE (string))
-    {
-      ptrdiff_t chars = SCHARS (string);
-      unsigned char *str = xmalloc (chars);
-      ptrdiff_t converted = str_to_unibyte (SDATA (string), str, chars);
-
-      if (converted < chars)
-	error ("Can't convert the %"pD"dth character to unibyte", converted);
-      string = make_unibyte_string ((char *) str, chars);
-      xfree (str);
-    }
-  return string;
-}
-
-
 DEFUN ("copy-alist", Fcopy_alist, Scopy_alist, 1, 1, 0,
        doc: /* Return a copy of ALIST.
 This is an alist which represents the same mapping from objects to objects,
@@ -4047,7 +4020,6 @@ this variable.  */);
   defsubr (&Sstring_make_multibyte);
   defsubr (&Sstring_make_unibyte);
   defsubr (&Sstring_as_unibyte);
-  defsubr (&Sstring_to_unibyte);
   defsubr (&Scopy_alist);
   defsubr (&Ssubstring);
   defsubr (&Ssubstring_no_properties);


### PR DESCRIPTION
 This PR converts 'string-to-unibyte' from C to Rust. I've also added const ptr getter methods to LispStringRef, since it seemed like we don't always want to take ownership of the string if we only want it as a const pointer.