### PR TITLE
travis formatting for remacs-macros

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -24,8 +24,7 @@ cd "$DIR/rust_src/remacs-lib"
 cargo fmt -- --write-mode=diff
 
 cd "$DIR/rust_src/remacs-macros"
-# TODO: not yet - cargo fmt seems to enter an infinite loop here.
-# cargo fmt -- --write-mode=diff
+cargo fmt -- --write-mode=diff lib.rs
 
 cd "$DIR/rust_src/alloc_unexecmacosx"
 cargo fmt -- --write-mode=diff

--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ Medium tasks:
 - [ ] Teach `describe-function` to find functions defined in Rust.
 - [ ] Expand our Travis configuration to run 'make check', so we know
   remacs passes Emacs' internal test suite.
-- [ ] Expand our Travis configuration to ensure that Rust code has been
+- [x] Expand our Travis configuration to ensure that Rust code has been
   formatted with rustfmt
 - [ ] Set up bors/homu.
 - [ ] Set up a badge tracking pub struct/function coverage using

--- a/rust_src/remacs-macros/lib.rs
+++ b/rust_src/remacs-macros/lib.rs
@@ -33,15 +33,17 @@ pub fn lisp_fn(attr_ts: TokenStream, fn_ts: TokenStream) -> TokenStream {
                 let arg = quote! { ::lisp::LispObject::from_raw(#ident), };
                 rargs.append(arg);
             }
-        },
+        }
         function::LispFnType::Many => {
-            let args = quote! {
+            let args =
+                quote! {
                 nargs: ::libc::ptrdiff_t,
                 args: *mut ::remacs_sys::Lisp_Object,
             };
             cargs.append(args);
 
-            let b = quote! {
+            let b =
+                quote! {
                 let args = unsafe {
                     ::std::slice::from_raw_parts_mut::<::remacs_sys::Lisp_Object>(
                         args, nargs as usize)
@@ -65,7 +67,8 @@ pub fn lisp_fn(attr_ts: TokenStream, fn_ts: TokenStream) -> TokenStream {
     };
     let symbol_name = CByteLiteral(&lisp_fn_args.name);
 
-    let tokens = quote! {
+    let tokens =
+        quote! {
         #[no_mangle]
         pub extern "C" fn #fname(#cargs) -> ::remacs_sys::Lisp_Object {
             #body

--- a/rust_src/remacs-macros/lisp_attr.rs
+++ b/rust_src/remacs-macros/lisp_attr.rs
@@ -74,8 +74,8 @@ named!(key_value -> (syn::Ident, syn::StrLit),
 
 #[test]
 fn parse_args_str() {
-    let args = parse_arguments(r#"(name = "foo", min = "0")"#)
-        .expect("cannot parse lisp_fn attributes");
+    let args =
+        parse_arguments(r#"(name = "foo", min = "0")"#).expect("cannot parse lisp_fn attributes");
 
     // name = "foo"
     assert_eq!(format!("{}", args[0].0), "name");


### PR DESCRIPTION
I updated the travis script to format remacs-macros.

Cargo fmt would hang when run as
```bash
cargo fmt -- --write-mode=diff
```
but by specifying the base file to format seems to prevent it from hanging.
```bash
cargo fmt -- --write-mode=diff lib.rs
```

example:
```bash
remacs/rust_src/remacs-macros
▶ cargo fmt -- -v --write-mode=diff lib.rs
Formatting /Users/mark/prog/remacs/rust_src/remacs-macros/function.rs
Formatting /Users/mark/prog/remacs/rust_src/remacs-macros/lib.rs
Formatting /Users/mark/prog/remacs/rust_src/remacs-macros/lisp_attr.rs
```

So the question is, is this an acceptable fix?

I also ran cargo fmt over the remacs-macros source and updated the readme to reflect the additions of the format checker.