### PR TITLE
Port 'string-lessp' to Rust

### DIFF
--- a/rust_src/remacs-sys/lib.rs
+++ b/rust_src/remacs-sys/lib.rs
@@ -665,9 +665,28 @@ pub struct Lisp_String {
     pub data: *mut libc::c_char,
 }
 
-// @TODO
+#[repr(C)]
+pub union SymbolUnion {
+    pub value: Lisp_Object,
+    pub alias: *mut Lisp_Symbol,
+    pub blv: *mut libc::c_void, // @TODO implement Lisp_Buffer_Local_Value
+    pub fwd: *mut libc::c_void, // @TODO implement Lisp_Fwd
+}
+
+/// This struct has 4 bytes of padding, representing the bitfield that 
+/// lives at the top of a Lisp_Symbol. The first 10 bits of this field are
+/// used
+
+// @TODO check the value of name post and pre transmutation, it seems that name is surviving but
+// may not be the correct value
 #[repr(C)]
 pub struct Lisp_Symbol {
+    pub symbol_bitfield: u32,
+    pub name: Lisp_Object,
+    pub val: SymbolUnion,
+    pub function: Lisp_Object,
+    pub plist: Lisp_Object,
+    pub next: *mut Lisp_Symbol,
 }
 
 extern "C" {

--- a/rust_src/remacs-sys/lib.rs
+++ b/rust_src/remacs-sys/lib.rs
@@ -676,9 +676,6 @@ pub union SymbolUnion {
 /// This struct has 4 bytes of padding, representing the bitfield that 
 /// lives at the top of a Lisp_Symbol. The first 10 bits of this field are
 /// used
-
-// @TODO check the value of name post and pre transmutation, it seems that name is surviving but
-// may not be the correct value
 #[repr(C)]
 pub struct Lisp_Symbol {
     pub symbol_bitfield: u32,
@@ -732,7 +729,8 @@ extern "C" {
     pub static Qfont_spec: Lisp_Object;
     pub static Qfont_entity: Lisp_Object;
     pub static Qfont_object: Lisp_Object;
-
+    pub static lispsym: Lisp_Symbol;
+    
     pub fn Fcons(car: Lisp_Object, cdr: Lisp_Object) -> Lisp_Object;
     pub fn Fcurrent_buffer() -> Lisp_Object;
     pub fn Fget_buffer(buffer_or_name: Lisp_Object) -> Lisp_Object;

--- a/rust_src/remacs-sys/lib.rs
+++ b/rust_src/remacs-sys/lib.rs
@@ -665,6 +665,11 @@ pub struct Lisp_String {
     pub data: *mut libc::c_char,
 }
 
+// @TODO
+#[repr(C)]
+pub struct Lisp_Symbol {
+}
+
 extern "C" {
     pub static mut globals: emacs_globals;
     pub static Qt: Lisp_Object;
@@ -675,6 +680,7 @@ extern "C" {
     pub static Qintegerp: Lisp_Object;
     pub static Qfloatp: Lisp_Object;
     pub static Qstringp: Lisp_Object;
+    pub static Qsymbolp: Lisp_Object;
     pub static Qlistp: Lisp_Object;
     pub static Qmarkerp: Lisp_Object;
     pub static Qwholenump: Lisp_Object;

--- a/rust_src/remacs-sys/lib.rs
+++ b/rust_src/remacs-sys/lib.rs
@@ -669,11 +669,11 @@ pub struct Lisp_String {
 pub union SymbolUnion {
     pub value: Lisp_Object,
     pub alias: *mut Lisp_Symbol,
-    pub blv: *mut libc::c_void, // @TODO implement Lisp_Buffer_Local_Value
-    pub fwd: *mut libc::c_void, // @TODO implement Lisp_Fwd
+pub blv: *mut libc::c_void, // @TODO implement Lisp_Buffer_Local_Value
+pub fwd: *mut libc::c_void, // @TODO implement Lisp_Fwd
 }
 
-/// This struct has 4 bytes of padding, representing the bitfield that 
+/// This struct has 4 bytes of padding, representing the bitfield that
 /// lives at the top of a Lisp_Symbol. The first 10 bits of this field are
 /// used
 #[repr(C)]
@@ -730,7 +730,7 @@ extern "C" {
     pub static Qfont_entity: Lisp_Object;
     pub static Qfont_object: Lisp_Object;
     pub static lispsym: Lisp_Symbol;
-    
+
     pub fn Fcons(car: Lisp_Object, cdr: Lisp_Object) -> Lisp_Object;
     pub fn Fcurrent_buffer() -> Lisp_Object;
     pub fn Fget_buffer(buffer_or_name: Lisp_Object) -> Lisp_Object;

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -84,6 +84,7 @@ pub use strings::Fstring_as_multibyte;
 pub use strings::Fstring_to_multibyte;
 pub use strings::Fstring_to_unibyte;
 pub use strings::Fmultibyte_string_p;
+pub use strings::Fstring_lessp;
 pub use vectors::Flength;
 pub use vectors::Fsort;
 pub use lists::merge;
@@ -180,6 +181,7 @@ pub extern "C" fn rust_init_syms() {
         defsubr(&*strings::Sstring_as_multibyte);
         defsubr(&*strings::Sstring_to_multibyte);
         defsubr(&*strings::Sstring_to_unibyte);
+        defsubr(&*strings::Sstring_lessp);
         defsubr(&*character::Smax_char);
         defsubr(&*character::Scharacterp);
         defsubr(&*character::Schar_or_string_p);

--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -174,6 +174,14 @@ impl LispObject {
             unsafe { wrong_type_argument(Qsymbolp, self.to_raw()) }
         }
     }
+
+    #[inline]
+    pub fn as_string_or_symbol(string: LispObject) -> LispStringRef {
+        match string.as_symbol() {
+            Some(sym) => sym.symbol_name().as_string().expect("Expected a symbol name?"),
+            None => string.as_string_or_error()
+        }
+    }
 }
 
 // Misc support (LispType == Lisp_Misc == 1)

--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -19,10 +19,10 @@ use vectors::LispVectorlikeRef;
 use buffers::LispBufferRef;
 
 use remacs_sys::{EmacsInt, EmacsUint, EmacsDouble, EMACS_INT_MAX, EMACS_INT_SIZE,
-                 EMACS_FLOAT_SIZE, USE_LSB_TAG, GCTYPEBITS, wrong_type_argument, Qstringp, Qsymbolp,
-                 Qnumber_or_marker_p, Qt, make_float, Qlistp, Qintegerp, Qconsp, circular_list,
-                 internal_equal, Fcons, CHECK_IMPURE, Qnumberp, Qfloatp, Qwholenump, Qvectorp,
-                 SYMBOL_NAME, PseudovecType, lispsym};
+                 EMACS_FLOAT_SIZE, USE_LSB_TAG, GCTYPEBITS, wrong_type_argument, Qstringp,
+                 Qsymbolp, Qnumber_or_marker_p, Qt, make_float, Qlistp, Qintegerp, Qconsp,
+                 circular_list, internal_equal, Fcons, CHECK_IMPURE, Qnumberp, Qfloatp,
+                 Qwholenump, Qvectorp, SYMBOL_NAME, PseudovecType, lispsym};
 use remacs_sys::Lisp_Object as CLisp_Object;
 
 // TODO: tweak Makefile to rebuild C files if this changes.
@@ -160,7 +160,9 @@ impl LispObject {
     #[inline]
     pub fn as_symbol(&self) -> Option<LispSymbolRef> {
         if self.is_symbol() {
-            Some(LispSymbolRef::new(unsafe { mem::transmute(self.symbol_ptr_value()) })) 
+            Some(LispSymbolRef::new(
+                unsafe { mem::transmute(self.symbol_ptr_value()) },
+            ))
         } else {
             None
         }
@@ -169,7 +171,7 @@ impl LispObject {
     #[inline]
     pub fn as_symbol_or_error(&self) -> LispSymbolRef {
         if self.is_symbol() {
-            LispSymbolRef::new(unsafe { mem::transmute(self.symbol_ptr_value()) } )
+            LispSymbolRef::new(unsafe { mem::transmute(self.symbol_ptr_value()) })
         } else {
             unsafe { wrong_type_argument(Qsymbolp, self.to_raw()) }
         }
@@ -178,8 +180,12 @@ impl LispObject {
     #[inline]
     pub fn as_string_or_symbol(string: LispObject) -> LispStringRef {
         match string.as_symbol() {
-            Some(sym) => sym.symbol_name().as_string().expect("Expected a symbol name?"),
-            None => string.as_string_or_error()
+            Some(sym) => {
+                sym.symbol_name().as_string().expect(
+                    "Expected a symbol name?",
+                )
+            }
+            None => string.as_string_or_error(),
         }
     }
 
@@ -187,7 +193,7 @@ impl LispObject {
     fn symbol_ptr_value(&self) -> EmacsInt {
         let ptr_value = if USE_LSB_TAG {
             self.to_raw() as EmacsInt
-        } else { 
+        } else {
             self.get_untaggedptr() as EmacsInt
         };
 

--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -154,6 +154,10 @@ impl LispObject {
     pub fn is_symbol(self) -> bool {
         self.get_type() == LispType::Lisp_Symbol
     }
+
+    pub fn symbol_name(&self) -> LispObject {
+        unsafe { LispObject::from_raw(SYMBOL_NAME(self.to_raw())) }
+    }
 }
 
 // Misc support (LispType == Lisp_Misc == 1)

--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -178,7 +178,7 @@ impl LispObject {
     }
 
     #[inline]
-    pub fn as_string_or_symbol(string: LispObject) -> LispStringRef {
+    pub fn symbol_or_string_as_string(string: LispObject) -> LispStringRef {
         match string.as_symbol() {
             Some(sym) => {
                 sym.symbol_name().as_string().expect(

--- a/rust_src/src/multibyte.rs
+++ b/rust_src/src/multibyte.rs
@@ -113,7 +113,7 @@ pub struct LispStringRefIterator<'a> {
 
 pub struct LispStringRefCharIterator<'a>(LispStringRefIterator<'a>);
 
-// Substitue for FETCH_STRING_CHAR_ADVANCE
+// Substitute for FETCH_STRING_CHAR_ADVANCE
 impl<'a> Iterator for LispStringRefIterator<'a> {
     type Item = (usize, Codepoint);
 

--- a/rust_src/src/multibyte.rs
+++ b/rust_src/src/multibyte.rs
@@ -118,17 +118,18 @@ impl<'a> Iterator for LispStringRefIterator<'a> {
     fn next(&mut self) -> Option<(Codepoint, usize)> {
         if self.cur < self.string_ref.len_bytes() as usize {
             let codepoint: Codepoint;
+            let point = self.cur;
             let ref_slice = self.string_ref.as_slice();
             if self.string_ref.is_multibyte() {
                 let (cp, advance) = multibyte_char_at(&ref_slice[self.cur..]);
                 codepoint = cp;
                 self.cur += advance;
             } else {
-                codepoint = ref_slice[self.cur] as u32;
+                codepoint = ref_slice[self.cur] as Codepoint;
                 self.cur += 1;
             }
             
-            Some((codepoint, self.cur))
+            Some((codepoint, point))
         } else {
             None
         }

--- a/rust_src/src/multibyte.rs
+++ b/rust_src/src/multibyte.rs
@@ -110,17 +110,17 @@ pub struct LispStringRefIterator<'a> {
     string_ref: &'a LispStringRef,
     cur: usize,
 }
+
 pub struct LispStringRefCharIterator<'a>(LispStringRefIterator<'a>);
-pub struct LispStringRefIndexIterator<'a>(LispStringRefIterator<'a>);
 
 // Substitue for FETCH_STRING_CHAR_ADVANCE
 impl<'a> Iterator for LispStringRefIterator<'a> {
-    type Item = (Codepoint, usize);
+    type Item = (usize, Codepoint);
 
-    fn next(&mut self) -> Option<(Codepoint, usize)> {
+    fn next(&mut self) -> Option<(usize, Codepoint)> {
         if self.cur < self.string_ref.len_bytes() as usize {
             let codepoint: Codepoint;
-            let point = self.cur;
+            let old_index = self.cur;
             let ref_slice = self.string_ref.as_slice();
             if self.string_ref.is_multibyte() {
                 let (cp, advance) = multibyte_char_at(&ref_slice[self.cur..]);
@@ -131,7 +131,7 @@ impl<'a> Iterator for LispStringRefIterator<'a> {
                 self.cur += 1;
             }
 
-            Some((codepoint, point))
+            Some((old_index, codepoint))
         } else {
             None
         }
@@ -142,20 +142,12 @@ impl<'a> Iterator for LispStringRefCharIterator<'a> {
     type Item = Codepoint;
 
     fn next(&mut self) -> Option<Codepoint> {
-        self.0.next().map(|result| result.0)
-    }
-}
-
-impl<'a> Iterator for LispStringRefIndexIterator<'a> {
-    type Item = usize;
-
-    fn next(&mut self) -> Option<usize> {
         self.0.next().map(|result| result.1)
     }
 }
 
 impl LispStringRef {
-    pub fn iter(&self) -> LispStringRefIterator {
+    pub fn char_indices(&self) -> LispStringRefIterator {
         LispStringRefIterator {
             string_ref: self,
             cur: 0,
@@ -163,11 +155,7 @@ impl LispStringRef {
     }
 
     pub fn chars(&self) -> LispStringRefCharIterator {
-        LispStringRefCharIterator(self.iter())
-    }
-
-    pub fn char_indices(&self) -> LispStringRefIndexIterator {
-        LispStringRefIndexIterator(self.iter())
+        LispStringRefCharIterator(self.char_indices())
     }
 }
 

--- a/rust_src/src/multibyte.rs
+++ b/rust_src/src/multibyte.rs
@@ -43,7 +43,7 @@ use remacs_sys::{CHAR_MODIFIER_MASK, CHAR_SHIFT, CHAR_CTL, emacs_abort, CHARACTE
 pub type LispStringRef = ExternalPtr<Lisp_String>;
 
 // cannot use `char`, it takes values out of its range
-type Codepoint = u32;
+pub type Codepoint = u32;
 
 /// Maximum character code
 pub const MAX_CHAR: Codepoint = (1 << CHARACTERBITS) - 1;
@@ -103,6 +103,22 @@ impl LispStringRef {
     #[inline]
     pub fn as_mut_slice(&self) -> &mut [u8] {
         unsafe { slice::from_raw_parts_mut(self.data as *mut u8, self.len_bytes() as usize) }
+    }
+}
+
+// Substitue for FETCH_STRING_CHAR_ADVANCE
+impl Iterator for LispStringRef {
+    type Item = (Codepoint, u32);
+
+    // @TODO need to implement proper next function
+    fn next(&mut self) -> Option<(Codepoint, u32)> {
+        if self.is_multibyte() {
+
+        } else {
+
+        }
+        
+        Some((0x00 as Codepoint, 0))
     }
 }
 

--- a/rust_src/src/multibyte.rs
+++ b/rust_src/src/multibyte.rs
@@ -117,7 +117,7 @@ impl<'a> Iterator for LispStringRefIterator<'a> {
 
     fn next(&mut self) -> Option<(Codepoint, usize)> {
         if self.cur < self.string_ref.len_bytes() as usize {
-            let mut codepoint: Codepoint = 0x00;
+            let codepoint: Codepoint;
             let ref_slice = self.string_ref.as_slice();
             if self.string_ref.is_multibyte() {
                 let (cp, advance) = multibyte_char_at(&ref_slice[self.cur..]);

--- a/rust_src/src/multibyte.rs
+++ b/rust_src/src/multibyte.rs
@@ -110,6 +110,8 @@ pub struct LispStringRefIterator<'a> {
     string_ref: &'a LispStringRef,
     cur: usize,
 }
+pub struct LispStringRefCharIterator<'a>(LispStringRefIterator<'a>);
+pub struct LispStringRefIndexIterator<'a>(LispStringRefIterator<'a>);
 
 // Substitue for FETCH_STRING_CHAR_ADVANCE
 impl<'a> Iterator for LispStringRefIterator<'a> {
@@ -136,12 +138,36 @@ impl<'a> Iterator for LispStringRefIterator<'a> {
     }
 }
 
+impl<'a> Iterator for LispStringRefCharIterator<'a> {
+    type Item = Codepoint;
+
+    fn next(&mut self) -> Option<Codepoint> {
+        self.0.next().map(|result| result.0)
+    }
+}
+
+impl<'a> Iterator for LispStringRefIndexIterator<'a> {
+    type Item = usize;
+
+    fn next(&mut self) -> Option<usize> {
+        self.0.next().map(|result| result.1)
+    }
+}
+
 impl LispStringRef {
     pub fn iter(&self) -> LispStringRefIterator {
         LispStringRefIterator {
             string_ref: self,
             cur: 0,
         }
+    }
+
+    pub fn chars(&self) -> LispStringRefCharIterator {
+        LispStringRefCharIterator(self.iter())
+    }
+
+    pub fn char_indices(&self) -> LispStringRefIndexIterator {
+        LispStringRefIndexIterator(self.iter())
     }
 }
 

--- a/rust_src/src/multibyte.rs
+++ b/rust_src/src/multibyte.rs
@@ -108,7 +108,7 @@ impl LispStringRef {
 
 pub struct LispStringRefIterator<'a> {
     string_ref: &'a LispStringRef,
-    cur: usize
+    cur: usize,
 }
 
 // Substitue for FETCH_STRING_CHAR_ADVANCE
@@ -128,7 +128,7 @@ impl<'a> Iterator for LispStringRefIterator<'a> {
                 codepoint = ref_slice[self.cur] as Codepoint;
                 self.cur += 1;
             }
-            
+
             Some((codepoint, point))
         } else {
             None
@@ -140,7 +140,7 @@ impl LispStringRef {
     pub fn iter(&self) -> LispStringRefIterator {
         LispStringRefIterator {
             string_ref: self,
-            cur: 0
+            cur: 0,
         }
     }
 }

--- a/rust_src/src/strings.rs
+++ b/rust_src/src/strings.rs
@@ -216,25 +216,18 @@ fn string_lessp(string1: LispObject, string2: LispObject) -> LispObject {
     let lispstr1 = get_string_or_symbol(string1);
     let lispstr2 = get_string_or_symbol(string2);
 
-    let end = cmp::min(lispstr1.len_bytes(), lispstr2.len_bytes());
-    let mut i1 = 0;
-    let mut str1iter = lispstr1.iter();
-    let mut str2iter = lispstr2.iter();
-    while i1 < end {
-        // Unwraps should be fine here, due to our manual tracking of
-        // valid length
-        let (codept1, _) = str1iter.next().unwrap();
-        let (codept2, _) = str2iter.next().unwrap();
-        i1 += 1;
-        
+    let mut count = 0;
+    let zip = lispstr1.iter().zip(lispstr2.iter());
+    for ((codept1, _), (codept2, _)) in zip {
+        count += 1;
         if codept1 != codept2 {
             return LispObject::from_bool(codept1 < codept2);
         }
     }
 
-    LispObject::from_bool(i1 < lispstr2.len_bytes())
+    LispObject::from_bool(count < lispstr2.len_chars())
 }
-    
+
 /// Return t if OBJECT is a multibyte string.
 /// Return nil if OBJECT is either a unibyte string, or not a string.
 #[lisp_fn]

--- a/rust_src/src/strings.rs
+++ b/rust_src/src/strings.rs
@@ -202,18 +202,10 @@ fn string_to_unibyte(string: LispObject) -> LispObject {
     }
 }
 
-fn get_string_or_symbol(mut string: LispObject) -> multibyte::LispStringRef {
-    if string.is_symbol() {
-        string = string.as_symbol_or_error().symbol_name()
-    }
-
-    string.as_string_or_error()
-}
-
 #[lisp_fn]
 fn string_lessp(string1: LispObject, string2: LispObject) -> LispObject {
-    let lispstr1 = get_string_or_symbol(string1);
-    let lispstr2 = get_string_or_symbol(string2);
+    let lispstr1 = LispObject::as_string_or_symbol(string1);
+    let lispstr2 = LispObject::as_string_or_symbol(string2);
 
     let zip = lispstr1.iter().zip(lispstr2.iter());
     for ((codept1, _), (codept2, _)) in zip {

--- a/rust_src/src/strings.rs
+++ b/rust_src/src/strings.rs
@@ -1,6 +1,6 @@
 //! Functions operating on strings.
 
-use std::ptr;
+use std::{ptr, cmp};
 
 use libc::{self, c_char, c_void, ptrdiff_t};
 
@@ -199,5 +199,43 @@ fn string_to_unibyte(string: LispObject) -> LispObject {
         }
     } else {
         string
+    }
+}
+
+fn get_string_or_symbol(mut string: LispObject) -> multibyte::LispStringRef {
+    if string.is_symbol() {
+        string = string.symbol_name()
+    }
+
+    string.as_string_or_error()
+}
+
+fn string_lessp(string1: LispObject, string2: LispObject) -> LispObject {
+    let mut lispstr1 = get_string_or_symbol(string1);
+    let mut lispstr2 = get_string_or_symbol(string2);
+
+    let end = cmp::min(lispstr1.len_bytes(), lispstr2.len_bytes());
+    let mut i1 = 0;
+    while i1 < end {
+        // Unwraps should be fine here, due to our manual tracking of
+        // valid length
+        let (codept1, i1_bytes) = lispstr1.next().unwrap();
+        let (codept2, _) = lispstr2.next().unwrap();
+
+        i1 += i1_bytes as isize;
+        
+        if codept1 != codept2 {
+            if codept1 < codept2 {
+                return LispObject::constant_t();
+            } else {
+                return LispObject::constant_nil();
+            }
+        }
+    }
+
+    if i1 < lispstr2.len_bytes() {
+        return LispObject::constant_t();
+    } else {
+        return LispObject::constant_nil();
     }
 }

--- a/rust_src/src/strings.rs
+++ b/rust_src/src/strings.rs
@@ -1,6 +1,6 @@
 //! Functions operating on strings.
 
-use std::{ptr, cmp};
+use std::ptr;
 
 use libc::{self, c_char, c_void, ptrdiff_t};
 
@@ -216,16 +216,14 @@ fn string_lessp(string1: LispObject, string2: LispObject) -> LispObject {
     let lispstr1 = get_string_or_symbol(string1);
     let lispstr2 = get_string_or_symbol(string2);
 
-    let mut count = 0;
     let zip = lispstr1.iter().zip(lispstr2.iter());
     for ((codept1, _), (codept2, _)) in zip {
-        count += 1;
         if codept1 != codept2 {
             return LispObject::from_bool(codept1 < codept2);
         }
     }
 
-    LispObject::from_bool(count < lispstr2.len_chars())
+    LispObject::from_bool(lispstr1.len_chars() < lispstr2.len_chars())
 }
 
 /// Return t if OBJECT is a multibyte string.

--- a/rust_src/src/strings.rs
+++ b/rust_src/src/strings.rs
@@ -202,6 +202,8 @@ fn string_to_unibyte(string: LispObject) -> LispObject {
     }
 }
 
+/// Return non-nil if STRING1 is less than STRING2 in lexicographic order.
+/// Case is significant.
 #[lisp_fn]
 fn string_lessp(string1: LispObject, string2: LispObject) -> LispObject {
     let lispstr1 = LispObject::symbol_or_string_as_string(string1);

--- a/rust_src/src/strings.rs
+++ b/rust_src/src/strings.rs
@@ -204,8 +204,8 @@ fn string_to_unibyte(string: LispObject) -> LispObject {
 
 #[lisp_fn]
 fn string_lessp(string1: LispObject, string2: LispObject) -> LispObject {
-    let lispstr1 = LispObject::as_string_or_symbol(string1);
-    let lispstr2 = LispObject::as_string_or_symbol(string2);
+    let lispstr1 = LispObject::symbol_or_string_as_string(string1);
+    let lispstr2 = LispObject::symbol_or_string_as_string(string2);
 
     let zip = lispstr1.chars().zip(lispstr2.chars());
     for (codept1, codept2) in zip {

--- a/rust_src/src/strings.rs
+++ b/rust_src/src/strings.rs
@@ -219,10 +219,9 @@ fn string_lessp(string1: LispObject, string2: LispObject) -> LispObject {
     while i1 < end {
         // Unwraps should be fine here, due to our manual tracking of
         // valid length
-        let (codept1, i1_bytes) = lispstr1.next().unwrap();
+        let (codept1, _) = lispstr1.next().unwrap();
         let (codept2, _) = lispstr2.next().unwrap();
-
-        i1 += i1_bytes as isize;
+        i1 += 1;
         
         if codept1 != codept2 {
             if codept1 < codept2 {

--- a/rust_src/src/strings.rs
+++ b/rust_src/src/strings.rs
@@ -207,8 +207,8 @@ fn string_lessp(string1: LispObject, string2: LispObject) -> LispObject {
     let lispstr1 = LispObject::as_string_or_symbol(string1);
     let lispstr2 = LispObject::as_string_or_symbol(string2);
 
-    let zip = lispstr1.iter().zip(lispstr2.iter());
-    for ((codept1, _), (codept2, _)) in zip {
+    let zip = lispstr1.chars().zip(lispstr2.chars());
+    for (codept1, codept2) in zip {
         if codept1 != codept2 {
             return LispObject::from_bool(codept1 < codept2);
         }

--- a/rust_src/src/strings.rs
+++ b/rust_src/src/strings.rs
@@ -202,10 +202,9 @@ fn string_to_unibyte(string: LispObject) -> LispObject {
     }
 }
 
-// @TODO need to rework this function to use new as_symbol_or_error API
 fn get_string_or_symbol(mut string: LispObject) -> multibyte::LispStringRef {
     if string.is_symbol() {
-        string = string.symbol_name()
+        string = string.as_symbol_or_error().symbol_name()
     }
 
     string.as_string_or_error()

--- a/rust_src/src/symbols.rs
+++ b/rust_src/src/symbols.rs
@@ -1,5 +1,14 @@
 use remacs_macros::lisp_fn;
-use lisp::LispObject;
+use lisp::{LispObject, ExternalPtr};
+use remacs_sys::Lisp_Symbol;
+
+pub type LispSymbolRef = ExternalPtr<Lisp_Symbol>;
+
+impl LispSymbolRef {
+    pub fn symbol_name(&self) -> LispObject {
+        LispObject::from_bool(false) // @TODO
+    }
+}
 
 /// Return t if OBJECT is a symbol.
 #[lisp_fn]

--- a/rust_src/src/symbols.rs
+++ b/rust_src/src/symbols.rs
@@ -6,7 +6,7 @@ pub type LispSymbolRef = ExternalPtr<Lisp_Symbol>;
 
 impl LispSymbolRef {
     pub fn symbol_name(&self) -> LispObject {
-        LispObject::from_bool(false) // @TODO
+        LispObject::from_raw(self.name)
     }
 }
 

--- a/src/fns.c
+++ b/src/fns.c
@@ -167,43 +167,6 @@ If string STR1 is greater, the value is a positive number N;
   return Qt;
 }
 
-DEFUN ("string-lessp", Fstring_lessp, Sstring_lessp, 2, 2, 0,
-       doc: /* Return non-nil if STRING1 is less than STRING2 in lexicographic order.
-Case is significant.
-Symbols are also allowed; their print names are used instead.  */)
-  (register Lisp_Object string1, Lisp_Object string2)
-{
-  register ptrdiff_t end;
-  register ptrdiff_t i1, i1_byte, i2, i2_byte;
-
-  if (SYMBOLP (string1))
-    string1 = SYMBOL_NAME (string1);
-  if (SYMBOLP (string2))
-    string2 = SYMBOL_NAME (string2);
-  CHECK_STRING (string1);
-  CHECK_STRING (string2);
-
-  i1 = i1_byte = i2 = i2_byte = 0;
-
-  end = SCHARS (string1);
-  if (end > SCHARS (string2))
-    end = SCHARS (string2);
-
-  while (i1 < end)
-    {
-      /* When we find a mismatch, we must compare the
-	 characters, not just the bytes.  */
-      int c1, c2;
-
-      FETCH_STRING_CHAR_ADVANCE (c1, string1, i1, i1_byte);
-      FETCH_STRING_CHAR_ADVANCE (c2, string2, i2, i2_byte);
-
-      if (c1 != c2)
-	return c1 < c2 ? Qt : Qnil;
-    }
-  return i1 < SCHARS (string2) ? Qt : Qnil;
-}
-
 DEFUN ("string-version-lessp", Fstring_version_lessp,
        Sstring_version_lessp, 2, 2, 0,
        doc: /* Return non-nil if S1 is less than S2, as version strings.
@@ -4009,7 +3972,6 @@ this variable.  */);
   defsubr (&Sidentity);
   defsubr (&Srandom);
   defsubr (&Scompare_strings);
-  defsubr (&Sstring_lessp);
   defsubr (&Sstring_version_lessp);
   defsubr (&Sstring_collate_lessp);
   defsubr (&Sstring_collate_equalp);


### PR DESCRIPTION
This is a WIP PR for porting string-lessp to Rust. As part of this work, it seemed useful to add an iterator for a LispStringRef, in order to replace the macro FETCH_STRING_CHAR_ADVANCE

Work left to do:

- [x] Port basic string-lessp functionality to Rust
- [x] Remove string-lessp implmentation in C.
- [x] Add code point iterator for LispStringRef
- [x] Add safe API for working with LispSymbol's, similar to LispStringRef/as_string/as_string_or_error
   - [x] Fix issue where the value coming out of the LispSymbolRef's mem::transmute seem to be nonsense
- [x] Verify that the alignment/size/padding of Rust's Lisp_Symbol matches the alignment/size/padding of C's Lisp_Symbol
- [x] Basic profiling to make sure that these new concepts do not add significant cost over their C equivalents. (Based on my findings, performance for this function is equivalent to it's C counterpart)  