### PR TITLE
Fix OSX build on 1.20 nightly. 

### DIFF
--- a/rust_src/Cargo.lock
+++ b/rust_src/Cargo.lock
@@ -16,6 +16,9 @@ dependencies = [
 [[package]]
 name = "alloc_unexecmacosx"
 version = "0.1.0"
+dependencies = [
+ "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "byte-tools"

--- a/rust_src/alloc_unexecmacosx/Cargo.toml
+++ b/rust_src/alloc_unexecmacosx/Cargo.toml
@@ -3,9 +3,5 @@ name = "alloc_unexecmacosx"
 version = "0.1.0"
 authors = ["Felix S. Klock II <pnkfelix@pnkfx.org>"]
 
-# Would be nice to do this, but saying "default-features = false"
-# locally gets cancelled out by the other imports of libc globally.
-# Instead we will just cut-and-paste type definitions (boo!).
-#
-# [dependencies]
-# libc = { version = "0.2.17", default-features = false }
+[dependencies]
+libc = { version = "0.2.17", default-features = false }

--- a/rust_src/alloc_unexecmacosx/src/lib.rs
+++ b/rust_src/alloc_unexecmacosx/src/lib.rs
@@ -1,33 +1,9 @@
-#![feature(allocator)]
-#![allocator]
+#![feature(allocator_api)]
+extern crate libc;
 
-#![no_std]
-
-// // Would be nice to do this, but saying "default-features = false"
-// // locally gets cancelled out by the other imports of libc globally.
-// // Instead we will just cut-and-paste type definitions (boo!).
-// //
-// // See also https://github.com/rust-lang/rust/issues/39262
-//
-// extern crate libc;
-
-mod libc {
-    #![allow(non_camel_case_types)]
-
-    pub type size_t = usize;
-
-    // Use repr(u8) as LLVM expects `void*` to be the same as `i8*` to help enable
-    // more optimization opportunities around it recognizing things like
-    // malloc/free.
-    #[repr(u8)]
-    pub enum c_void {
-        // Two dummy variants so the #[repr] attribute can be used.
-        #[doc(hidden)]
-        __variant1,
-        #[doc(hidden)]
-        __variant2,
-    }
-}
+use std::heap::Alloc;
+use std::heap::Layout;
+use std::heap::AllocErr;
 
 /// To adhere to the rule that all calls to malloc, realloc, and free
 /// be redirected to their "unexec_"-prefixed variants, this crate
@@ -39,66 +15,33 @@ extern "C" {
     fn unexec_free(ptr: *mut libc::c_void);
 }
 
-// Listed below are the five allocation functions currently required by custom
-// allocators. Their signatures and symbol names are not currently typechecked
-// by the compiler, but this is a future extension and are required to match
-// what is found below.
-//
-// Note that the standard `malloc` and `realloc` functions do not provide a way
-// to communicate alignment. While a more ambitious implementor might have
-// attempted to support custom alignments, this simple code simply asserts that
-// we never request an alignment that is not already satisfied by the underlying
-// malloc call.
+pub struct OsxUnexecAlloc;
 
-#[no_mangle]
-pub extern "C" fn __rust_allocate(size: usize, align: usize) -> *mut u8 {
-    unsafe {
-        let addr = unexec_malloc(size as libc::size_t) as usize;
-        assert_eq!(addr & (align - 1), 0);
-        addr as *mut u8
+unsafe impl<'a> Alloc for &'a OsxUnexecAlloc {
+    unsafe fn alloc(&mut self, layout: Layout) -> Result<*mut u8, AllocErr> {
+        let addr = unexec_malloc(layout.size() as libc::size_t) as usize;
+        assert_eq!(addr & (layout.align() - 1), 0);
+        Ok(addr as *mut u8)
     }
-}
 
-#[no_mangle]
-pub extern "C" fn __rust_allocate_zeroed(size: usize, align: usize) -> *mut u8 {
-    unsafe {
-        let addr = unexec_malloc(size as libc::size_t) as usize;
-        assert_eq!(addr & (align - 1), 0);
-        addr as *mut u8
+    unsafe fn dealloc(&mut self, ptr: *mut u8, layout: Layout) {
+        assert_eq!(ptr as usize & (layout.align() - 1), 0);
+        unexec_free(ptr as *mut libc::c_void)
     }
-}
 
-#[no_mangle]
-pub extern "C" fn __rust_deallocate(ptr: *mut u8, _old_size: usize, align: usize) {
-    assert_eq!(ptr as usize & (align - 1), 0);
-    unsafe { unexec_free(ptr as *mut libc::c_void) }
-}
-
-#[no_mangle]
-pub extern "C" fn __rust_reallocate(
-    ptr: *mut u8,
-    _old_size: usize,
-    size: usize,
-    align: usize,
-) -> *mut u8 {
-    unsafe {
-        let addr = unexec_realloc(ptr as *mut libc::c_void, size as libc::size_t) as usize;
-        assert_eq!(addr & (align - 1), 0);
-        addr as *mut u8
+    unsafe fn realloc(&mut self,
+                      ptr: *mut u8,
+                      layout: Layout,
+                      new_layout: Layout) -> Result<*mut u8, AllocErr> {
+        let addr = unexec_realloc(ptr as *mut libc::c_void, layout.size() as libc::size_t) as usize;
+        assert_eq!(addr & (new_layout.align() - 1), 0);
+        Ok(addr as *mut u8)
     }
-}
 
-#[no_mangle]
-pub extern "C" fn __rust_reallocate_inplace(
-    _ptr: *mut u8,
-    old_size: usize,
-    _size: usize,
-    _align: usize,
-) -> usize {
-    old_size // this api is not supported by libc
-}
-
-#[no_mangle]
-pub extern "C" fn __rust_usable_size(size: usize, _align: usize) -> usize {
-    size
+    unsafe fn alloc_zeroed(&mut self, layout: Layout) -> Result<*mut u8, AllocErr> {
+        let size = layout.size();
+        let addr = self.alloc(layout)?;
+        libc::memset(addr as *mut libc::c_void, 0, size);
+        Ok(addr as *mut u8)
+    }
 }

--- a/rust_src/alloc_unexecmacosx/src/lib.rs
+++ b/rust_src/alloc_unexecmacosx/src/lib.rs
@@ -31,17 +31,10 @@ unsafe impl<'a> Alloc for &'a OsxUnexecAlloc {
 
     unsafe fn realloc(&mut self,
                       ptr: *mut u8,
-                      layout: Layout,
+                      _old_layout: Layout,
                       new_layout: Layout) -> Result<*mut u8, AllocErr> {
-        let addr = unexec_realloc(ptr as *mut libc::c_void, layout.size() as libc::size_t) as usize;
+        let addr = unexec_realloc(ptr as *mut libc::c_void, new_layout.size() as libc::size_t) as usize;
         assert_eq!(addr & (new_layout.align() - 1), 0);
-        Ok(addr as *mut u8)
-    }
-
-    unsafe fn alloc_zeroed(&mut self, layout: Layout) -> Result<*mut u8, AllocErr> {
-        let size = layout.size();
-        let addr = self.alloc(layout)?;
-        libc::memset(addr as *mut libc::c_void, 0, size);
         Ok(addr as *mut u8)
     }
 }

--- a/rust_src/alloc_unexecmacosx/src/lib.rs
+++ b/rust_src/alloc_unexecmacosx/src/lib.rs
@@ -19,8 +19,12 @@ pub struct OsxUnexecAlloc;
 
 unsafe impl<'a> Alloc for &'a OsxUnexecAlloc {
     unsafe fn alloc(&mut self, layout: Layout) -> Result<*mut u8, AllocErr> {
-        let addr = unexec_malloc(layout.size() as libc::size_t) as usize;
-        assert_eq!(addr & (layout.align() - 1), 0);
+        let addr = unexec_malloc(layout.size() as libc::size_t);
+        if addr.is_null() {
+            return Err(AllocErr::Exhausted { request: layout });
+        }
+
+        assert_eq!(addr as usize & (layout.align() - 1), 0);
         Ok(addr as *mut u8)
     }
 
@@ -35,8 +39,12 @@ unsafe impl<'a> Alloc for &'a OsxUnexecAlloc {
         _layout: Layout,
         new_layout: Layout,
     ) -> Result<*mut u8, AllocErr> {
-        let addr = unexec_realloc(ptr as *mut libc::c_void, new_layout.size() as libc::size_t) as usize;
-        assert_eq!(addr & (new_layout.align() - 1), 0);
+        let addr = unexec_realloc(ptr as *mut libc::c_void, new_layout.size() as libc::size_t);
+        if addr.is_null() {
+            return Err(AllocErr::Exhausted { request: new_layout });
+        }
+
+        assert_eq!(addr as usize & (new_layout.align() - 1), 0);
         Ok(addr as *mut u8)
     }
 }

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -39,6 +39,8 @@ mod buffers;
 
 #[cfg(all(not(test), target_os = "macos"))]
 use alloc_unexecmacosx::OsxUnexecAlloc;
+
+#[cfg(all(not(test), target_os = "macos"))]
 #[global_allocator]
 static ALLOCATOR: OsxUnexecAlloc = OsxUnexecAlloc;
 

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -3,6 +3,7 @@
 #![allow(private_no_mangle_fns)]
 #![feature(proc_macro)]
 #![cfg_attr(feature = "strict", deny(warnings))]
+#![feature(global_allocator)]
 
 // Wilfred/remacs#38 : Need to override the allocator for legacy unexec support on Mac.
 #[cfg(all(not(test), target_os = "macos"))]
@@ -35,6 +36,11 @@ mod crypto;
 mod str2sig;
 mod multibyte;
 mod buffers;
+
+#[cfg(all(not(test), target_os = "macos"))]
+use alloc_unexecmacosx::OsxUnexecAlloc;
+#[global_allocator]
+static ALLOCATOR: OsxUnexecAlloc = OsxUnexecAlloc;
 
 use remacs_sys::Lisp_Subr;
 


### PR DESCRIPTION
 Updating the custom MacOSX allocator to use the new Global Allocator API, that was recently merged as part of 1.20 nightly. This API is considered unstable, but we will attempt to keep up with a moving target.

Information on this API was gathered from https://github.com/rust-lang/rfcs/pull/1974#issuecomment-306249616 and https://github.com/rust-lang/rust/issues/32838

Work to still be done:

- [x] Fix compilation issues with OSX build on 1.20 nightly
- [x] Verify that all needed functions of trait Allocator are being implemented.
- [x] Verify that linux/windows builds are unaffected by this
- [x] Add usage of AllocErr in cases of allocation error, do not always blindly assume allocation succeeded. 