### PR TITLE
Fixing (man "ls") panic, due to str_as_multibyte logic 

### DIFF
--- a/rust_src/src/multibyte.rs
+++ b/rust_src/src/multibyte.rs
@@ -508,7 +508,7 @@ pub fn str_as_multibyte(
             );
         }
         let mut to = 0;
-        let mut from = 0;
+        let mut from = offset;
         while from < slice.len() {
             chars += 1;
             match multibyte_length(&slice[from..], false) {
@@ -522,6 +522,7 @@ pub fn str_as_multibyte(
                 None => {
                     let byte = slice[from];
                     to += write_codepoint(&mut slice[to..], raw_byte_codepoint(byte));
+                    from += 1;
                 }
             }
         }


### PR DESCRIPTION
Fixing issue where running '(string-as-multibyte "\255")' would cause remacs to panic. This was caused by some faulty iteration logic in multibyte::str_as_multibyte. This should fix https://github.com/Wilfred/remacs/issues/222

Looking over the C code, I believe the two additions in this diff are needed to fix this problem. In an older version of character.c, before we ported some of the multibyte functions, we had 
```
ptrdiff_t
str_as_multibyte (unsigned char *str, ptrdiff_t len, ptrdiff_t nbytes,
                  ptrdiff_t *nchars)
{
  unsigned char *p = str, *endp = str + nbytes;
  unsigned char *to;
  ptrdiff_t chars = 0;
  int n;

  while (p < endp
         && ! CHAR_BYTE8_HEAD_P (*p)
         && (n = MULTIBYTE_LENGTH (p, endp)) > 0)
    p += n, chars++;
  if (nchars)
    *nchars = chars;
  if (p == endp)
    return nbytes;

  to = p;
  nbytes = endp - p;
  endp = str + len;
  memmove (endp - nbytes, p, nbytes);
  p = endp - nbytes;

  while (p < endp)
    {
//  ...
```

The logic for the second while loop is (p < endp). In rust, we express that as (from < slice.len()). At first glance, I don't think initializing from to 0 is equivalent to what was happening before. My understanding of the translation is that after the first while loop, p will be equivalent to our "start" variable in the if let block. Since we are making a new slice from start on, `to` can be set to 0. p (which looks to be equivalent to 'from' from this point on) in C is `(str + len) - nbytes`, and since str is a pointer offset, we can consider it 0 from working with a slice, so that just reduces down to len - nbytes, which we have already stored in 
the variable offset. 

As for the second change, also in character.c, we had 

```
  while (p < endp)
    {
      if (! CHAR_BYTE8_HEAD_P (*p)
          && (n = MULTIBYTE_LENGTH (p, endp)) > 0)
        {
          while (n--)
            *to++ = *p++;
        }
      else
        {
          int c = *p++;
          c = BYTE8_TO_CHAR (c);
          to += CHAR_STRING (c, to);
        }
      chars++;
    }
```
The else case here seems equivalent to the "None" case in Rust. In C, we iterated p with "*p++", however in Rust, we were never mutating from, causing a potential panic on the next iteration. 

@birkenfeld I'd appreciate if you could look this over when you have a chance and see if it makes sense. 