### PR TITLE
Port some basic symbol related functions to Rust

### DIFF
--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -79,6 +79,7 @@ pub use floatfns::fmod_float;
 pub use objects::Fequal;
 pub use objects::Fequal_including_properties;
 pub use symbols::Fsymbolp;
+pub use symbols::Fsymbol_name;
 pub use strings::Fstring_equal;
 pub use strings::Fstring_as_multibyte;
 pub use strings::Fstring_to_multibyte;
@@ -146,6 +147,7 @@ pub extern "C" fn rust_init_syms() {
         defsubr(&*objects::Sequal);
         defsubr(&*objects::Sequal_including_properties);
         defsubr(&*symbols::Ssymbolp);
+        defsubr(&*symbols::Ssymbol_name);
         defsubr(&*lists::Sconsp);
         defsubr(&*lists::Ssetcar);
         defsubr(&*lists::Ssetcdr);

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -81,6 +81,7 @@ pub use objects::Fequal_including_properties;
 pub use symbols::Fsymbolp;
 pub use symbols::Fsymbol_name;
 pub use symbols::Ffboundp;
+pub use symbols::Fsymbol_function;
 pub use strings::Fstring_equal;
 pub use strings::Fstring_as_multibyte;
 pub use strings::Fstring_to_multibyte;
@@ -150,6 +151,7 @@ pub extern "C" fn rust_init_syms() {
         defsubr(&*symbols::Ssymbolp);
         defsubr(&*symbols::Ssymbol_name);
         defsubr(&*symbols::Sfboundp);
+        defsubr(&*symbols::Ssymbol_function);
         defsubr(&*lists::Sconsp);
         defsubr(&*lists::Ssetcar);
         defsubr(&*lists::Ssetcdr);

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -80,6 +80,7 @@ pub use objects::Fequal;
 pub use objects::Fequal_including_properties;
 pub use symbols::Fsymbolp;
 pub use symbols::Fsymbol_name;
+pub use symbols::Ffboundp;
 pub use strings::Fstring_equal;
 pub use strings::Fstring_as_multibyte;
 pub use strings::Fstring_to_multibyte;
@@ -148,6 +149,7 @@ pub extern "C" fn rust_init_syms() {
         defsubr(&*objects::Sequal_including_properties);
         defsubr(&*symbols::Ssymbolp);
         defsubr(&*symbols::Ssymbol_name);
+        defsubr(&*symbols::Sfboundp);
         defsubr(&*lists::Sconsp);
         defsubr(&*lists::Ssetcar);
         defsubr(&*lists::Ssetcdr);

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -82,6 +82,7 @@ pub use symbols::Fsymbolp;
 pub use symbols::Fsymbol_name;
 pub use symbols::Ffboundp;
 pub use symbols::Fsymbol_function;
+pub use symbols::Fsymbol_plist;
 pub use strings::Fstring_equal;
 pub use strings::Fstring_as_multibyte;
 pub use strings::Fstring_to_multibyte;
@@ -152,6 +153,7 @@ pub extern "C" fn rust_init_syms() {
         defsubr(&*symbols::Ssymbol_name);
         defsubr(&*symbols::Sfboundp);
         defsubr(&*symbols::Ssymbol_function);
+        defsubr(&*symbols::Ssymbol_plist);
         defsubr(&*lists::Sconsp);
         defsubr(&*lists::Ssetcar);
         defsubr(&*lists::Ssetcdr);

--- a/rust_src/src/symbols.rs
+++ b/rust_src/src/symbols.rs
@@ -12,6 +12,10 @@ impl LispSymbolRef {
     pub fn get_function(&self) -> LispObject {
         LispObject::from_raw(self.function)
     }
+
+    pub fn get_plist(&self) -> LispObject {
+        LispObject::from_raw(self.plist)
+    }
 }
 
 /// Return t if OBJECT is a symbol.
@@ -44,4 +48,10 @@ fn fboundp(object: LispObject) -> LispObject {
 #[lisp_fn]
 fn symbol_function(object: LispObject) -> LispObject {
     object.as_symbol_or_error().get_function()
+}
+
+/// Return SYMBOL's property list.
+#[lisp_fn]
+fn symbol_plist(object: LispObject) -> LispObject {
+    object.as_symbol_or_error().get_plist()
 }

--- a/rust_src/src/symbols.rs
+++ b/rust_src/src/symbols.rs
@@ -15,3 +15,8 @@ impl LispSymbolRef {
 fn symbolp(object: LispObject) -> LispObject {
     LispObject::from_bool(object.is_symbol())
 }
+
+#[lisp_fn]
+fn symbol_name(symbol: LispObject) -> LispObject {
+    symbol.as_symbol_or_error().symbol_name()
+}

--- a/rust_src/src/symbols.rs
+++ b/rust_src/src/symbols.rs
@@ -39,3 +39,9 @@ fn fboundp(object: LispObject) -> LispObject {
     let symbol = object.as_symbol_or_error();
     LispObject::from_bool(!symbol.get_function().is_nil())
 }
+
+/// Return SYMBOL's function definition, or nil if that is void.
+#[lisp_fn]
+fn symbol_function(object: LispObject) -> LispObject {
+    object.as_symbol_or_error().get_function()
+}

--- a/rust_src/src/symbols.rs
+++ b/rust_src/src/symbols.rs
@@ -24,6 +24,7 @@ fn symbolp(object: LispObject) -> LispObject {
     LispObject::from_bool(object.is_symbol())
 }
 
+/// Return SYMBOL's name, a string.
 #[lisp_fn]
 fn symbol_name(symbol: LispObject) -> LispObject {
     symbol.as_symbol_or_error().symbol_name()

--- a/rust_src/src/symbols.rs
+++ b/rust_src/src/symbols.rs
@@ -8,6 +8,10 @@ impl LispSymbolRef {
     pub fn symbol_name(&self) -> LispObject {
         LispObject::from_raw(self.name)
     }
+
+    pub fn get_function(&self) -> LispObject {
+        LispObject::from_raw(self.function)
+    }
 }
 
 /// Return t if OBJECT is a symbol.
@@ -19,4 +23,19 @@ fn symbolp(object: LispObject) -> LispObject {
 #[lisp_fn]
 fn symbol_name(symbol: LispObject) -> LispObject {
     symbol.as_symbol_or_error().symbol_name()
+}
+
+
+/* FIXME: It has been previously suggested to make this function an
+   alias for symbol-function, but upon discussion at Bug#23957,
+   there is a risk breaking backward compatibility, as some users of
+   fboundp may expect `t' in particular, rather than any true
+   value.  An alias is still welcome so long as the compatibility
+   issues are addressed.  */
+
+/// Return t if SYMBOL's function definition is not void.
+#[lisp_fn]
+fn fboundp(object: LispObject) -> LispObject {
+    let symbol = object.as_symbol_or_error();
+    LispObject::from_bool(!symbol.get_function().is_nil())
 }

--- a/src/data.c
+++ b/src/data.c
@@ -355,14 +355,6 @@ Return SYMBOL.  */)
   return symbol;
 }
 
-DEFUN ("symbol-function", Fsymbol_function, Ssymbol_function, 1, 1, 0,
-       doc: /* Return SYMBOL's function definition, or nil if that is void.  */)
-  (register Lisp_Object symbol)
-{
-  CHECK_SYMBOL (symbol);
-  return XSYMBOL (symbol)->function;
-}
-
 DEFUN ("symbol-plist", Fsymbol_plist, Ssymbol_plist, 1, 1, 0,
        doc: /* Return SYMBOL's property list.  */)
   (register Lisp_Object symbol)
@@ -3030,7 +3022,6 @@ syms_of_data (void)
   defsubr (&Sinteractive_form);
   defsubr (&Stype_of);
   defsubr (&Skeywordp);
-  defsubr (&Ssymbol_function);
   defsubr (&Sindirect_function);
   defsubr (&Ssymbol_plist);
   defsubr (&Smakunbound);

--- a/src/data.c
+++ b/src/data.c
@@ -355,14 +355,6 @@ Return SYMBOL.  */)
   return symbol;
 }
 
-DEFUN ("symbol-plist", Fsymbol_plist, Ssymbol_plist, 1, 1, 0,
-       doc: /* Return SYMBOL's property list.  */)
-  (register Lisp_Object symbol)
-{
-  CHECK_SYMBOL (symbol);
-  return XSYMBOL (symbol)->plist;
-}
-
 DEFUN ("fset", Ffset, Sfset, 2, 2, 0,
        doc: /* Set SYMBOL's function definition to DEFINITION, and return DEFINITION.  */)
   (register Lisp_Object symbol, Lisp_Object definition)
@@ -3023,7 +3015,6 @@ syms_of_data (void)
   defsubr (&Stype_of);
   defsubr (&Skeywordp);
   defsubr (&Sindirect_function);
-  defsubr (&Ssymbol_plist);
   defsubr (&Smakunbound);
   defsubr (&Sfmakunbound);
   defsubr (&Sboundp);

--- a/src/data.c
+++ b/src/data.c
@@ -331,20 +331,6 @@ global value outside of any lexical scope.  */)
   return (EQ (valcontents, Qunbound) ? Qnil : Qt);
 }
 
-/* FIXME: It has been previously suggested to make this function an
-   alias for symbol-function, but upon discussion at Bug#23957,
-   there is a risk breaking backward compatibility, as some users of
-   fboundp may expect `t' in particular, rather than any true
-   value.  An alias is still welcome so long as the compatibility
-   issues are addressed.  */
-DEFUN ("fboundp", Ffboundp, Sfboundp, 1, 1, 0,
-       doc: /* Return t if SYMBOL's function definition is not void.  */)
-  (register Lisp_Object symbol)
-{
-  CHECK_SYMBOL (symbol);
-  return NILP (XSYMBOL (symbol)->function) ? Qnil : Qt;
-}
-
 DEFUN ("makunbound", Fmakunbound, Smakunbound, 1, 1, 0,
        doc: /* Make SYMBOL's value be void.
 Return SYMBOL.  */)
@@ -3050,7 +3036,6 @@ syms_of_data (void)
   defsubr (&Smakunbound);
   defsubr (&Sfmakunbound);
   defsubr (&Sboundp);
-  defsubr (&Sfboundp);
   defsubr (&Sfset);
   defsubr (&Sdefalias);
   defsubr (&Ssetplist);

--- a/src/data.c
+++ b/src/data.c
@@ -385,17 +385,6 @@ DEFUN ("symbol-plist", Fsymbol_plist, Ssymbol_plist, 1, 1, 0,
   return XSYMBOL (symbol)->plist;
 }
 
-DEFUN ("symbol-name", Fsymbol_name, Ssymbol_name, 1, 1, 0,
-       doc: /* Return SYMBOL's name, a string.  */)
-  (register Lisp_Object symbol)
-{
-  register Lisp_Object name;
-
-  CHECK_SYMBOL (symbol);
-  name = SYMBOL_NAME (symbol);
-  return name;
-}
-
 DEFUN ("fset", Ffset, Sfset, 2, 2, 0,
        doc: /* Set SYMBOL's function definition to DEFINITION, and return DEFINITION.  */)
   (register Lisp_Object symbol, Lisp_Object definition)
@@ -3058,7 +3047,6 @@ syms_of_data (void)
   defsubr (&Ssymbol_function);
   defsubr (&Sindirect_function);
   defsubr (&Ssymbol_plist);
-  defsubr (&Ssymbol_name);
   defsubr (&Smakunbound);
   defsubr (&Sfmakunbound);
   defsubr (&Sboundp);


### PR DESCRIPTION
Porting 'symbol-name', 'fboundp', 'symbol-function', and 'symbol-plist' to Rust. 