### PR TITLE
Port windowp to Rust

### DIFF
--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -36,6 +36,7 @@ mod crypto;
 mod str2sig;
 mod multibyte;
 mod buffers;
+mod windows;
 
 #[cfg(all(not(test), target_os = "macos"))]
 use alloc_unexecmacosx::OsxUnexecAlloc;
@@ -132,6 +133,7 @@ pub extern "C" fn rust_init_syms() {
     unsafe {
         defsubr(&*buffers::Soverlayp);
         defsubr(&*buffers::Sbuffer_live_p);
+        defsubr(&*windows::Swindowp);
         defsubr(&*lists::Satom);
         defsubr(&*lists::Slistp);
         defsubr(&*lists::Snlistp);

--- a/rust_src/src/windows.rs
+++ b/rust_src/src/windows.rs
@@ -4,7 +4,7 @@ use lisp::LispObject;
 use remacs_macros::lisp_fn;
 
 
-/// Return t if OBJECT is a window.
+/// Return t if OBJECT is a window and nil otherwise.
 #[lisp_fn]
 fn windowp(object: LispObject) -> LispObject {
     LispObject::from_bool(object.is_window())

--- a/rust_src/src/windows.rs
+++ b/rust_src/src/windows.rs
@@ -1,0 +1,11 @@
+//! Functions operating on windows.
+
+use lisp::LispObject;
+use remacs_macros::lisp_fn;
+
+
+/// Return t if OBJECT is a window.
+#[lisp_fn]
+fn windowp(object: LispObject) -> LispObject {
+    LispObject::from_bool(object.is_window())
+}

--- a/src/window.c
+++ b/src/window.c
@@ -301,13 +301,6 @@ wset_buffer (struct window *w, Lisp_Object val)
   adjust_window_count (w, 1);
 }
 
-DEFUN ("windowp", Fwindowp, Swindowp, 1, 1, 0,
-       doc: /* Return t if OBJECT is a window and nil otherwise.  */)
-  (Lisp_Object object)
-{
-  return WINDOWP (object) ? Qt : Qnil;
-}
-
 DEFUN ("window-valid-p", Fwindow_valid_p, Swindow_valid_p, 1, 1, 0,
        doc: /* Return t if OBJECT is a valid window and nil otherwise.
 A valid window is either a window that displays a buffer or an internal
@@ -7737,7 +7730,6 @@ displayed after a scrolling operation to be somewhat inaccurate.  */);
   defsubr (&Sselected_window);
   defsubr (&Sminibuffer_window);
   defsubr (&Swindow_minibuffer_p);
-  defsubr (&Swindowp);
   defsubr (&Swindow_valid_p);
   defsubr (&Swindow_live_p);
   defsubr (&Swindow_frame);


### PR DESCRIPTION
I followed the tutorial and it seems to work. But I have no idea how the function is_window actually works.