### PR TITLE
Adding nightly validation to autogen.sh. 

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -30,13 +30,16 @@
 
 ### Code:
 
+## Used when remacs is dependent on nightly
+## Will print an error message telling people they need nightly rust
+require_nightly=true
+
 ## Tools we need:
 ## Note that we respect the values of AUTOCONF etc, like autoreconf does.
 progs="autoconf"
 
 ## Minimum versions we need:
 autoconf_min=`sed -n 's/^ *AC_PREREQ(\([0-9\.]*\)).*/\1/p' configure.ac`
-
 
 ## $1 = program, eg "autoconf".
 ## Echo the version string, eg "2.59".
@@ -129,6 +132,15 @@ case $do_autoconf,$do_git in
   false,false)
     do_autoconf=true;;
 esac
+
+if $require_nightly; then
+    echo "Validation Rust install ..."
+    command -v rustc >/dev/null 2>&1 || { echo >&2 "Remacs requires rust to be installed in order to build. Please install it via rustup: https://www.rustup.rs/; Aborting."; exit 1; }
+    command -v cargo >/dev/null 2>&1 || { echo >&2 "I require foo but it's not installed.  Aborting.Remacs requires cargo to be installed in order to build. Please install it via rustup: https://www.rustup.rs/; Aborting."; exit 1; }
+
+    rustc --version | grep nightly || { echo >&2 "Remacs currently requires nightly Rust. If you do not have nightly Rust, you should install rustup at https://www.rustup.rs/, and run 'rustup install nightly && rustup default nightly"; exit 1; }
+    echo "Your system has the required rust installation for building remacs."
+fi
 
 # Generate Autoconf-related files, if requested.
 

--- a/autogen.sh
+++ b/autogen.sh
@@ -134,12 +134,12 @@ case $do_autoconf,$do_git in
     do_autoconf=true;;
 esac
 
-if $require_nightly; then
-    echo "Validating Rust install ..."
-    command -v rustc >/dev/null 2>&1 || { echo >&2 "Remacs requires rust to be installed in order to build. Please install it via rustup: https://www.rustup.rs/; Aborting."; exit 1; }
-    command -v cargo >/dev/null 2>&1 || { echo >&2 "Remacs requires cargo to be installed in order to build. Please install it via rustup: https://www.rustup.rs/; Aborting."; exit 1; }
+echo "Validating Rust install ..."
+command -v rustc >/dev/null 2>&1 || { echo >&2 "Remacs requires rust to be installed in order to build. Please install it via rustup: https://www.rustup.rs/; Aborting."; exit 1; }
+command -v cargo >/dev/null 2>&1 || { echo >&2 "Remacs requires cargo to be installed in order to build. Please install it via rustup: https://www.rustup.rs/; Aborting."; exit 1; }
 
-    rustc --version | grep nightly || { echo >&2 "Remacs currently requires nightly Rust. If you do not have nightly Rust, you should install rustup at https://www.rustup.rs/, and run 'rustup install nightly && rustup override nightly' in the remacs directory."; exit 1; }
+if $require_nightly; then
+    rustc --version | grep nightly || { echo >&2 "Remacs currently requires nightly Rust. If you do not have nightly Rust, you should install rustup at https://www.rustup.rs/, and run 'rustup install nightly && rustup override set nightly' in the remacs directory."; exit 1; }
     echo "Your system has the required rust installation for building remacs."
 fi
 

--- a/autogen.sh
+++ b/autogen.sh
@@ -41,6 +41,7 @@ progs="autoconf"
 ## Minimum versions we need:
 autoconf_min=`sed -n 's/^ *AC_PREREQ(\([0-9\.]*\)).*/\1/p' configure.ac`
 
+
 ## $1 = program, eg "autoconf".
 ## Echo the version string, eg "2.59".
 ## FIXME does not handle things like "1.4a", but AFAIK those are
@@ -134,11 +135,11 @@ case $do_autoconf,$do_git in
 esac
 
 if $require_nightly; then
-    echo "Validation Rust install ..."
+    echo "Validating Rust install ..."
     command -v rustc >/dev/null 2>&1 || { echo >&2 "Remacs requires rust to be installed in order to build. Please install it via rustup: https://www.rustup.rs/; Aborting."; exit 1; }
-    command -v cargo >/dev/null 2>&1 || { echo >&2 "I require foo but it's not installed.  Aborting.Remacs requires cargo to be installed in order to build. Please install it via rustup: https://www.rustup.rs/; Aborting."; exit 1; }
+    command -v cargo >/dev/null 2>&1 || { echo >&2 "Remacs requires cargo to be installed in order to build. Please install it via rustup: https://www.rustup.rs/; Aborting."; exit 1; }
 
-    rustc --version | grep nightly || { echo >&2 "Remacs currently requires nightly Rust. If you do not have nightly Rust, you should install rustup at https://www.rustup.rs/, and run 'rustup install nightly && rustup default nightly"; exit 1; }
+    rustc --version | grep nightly || { echo >&2 "Remacs currently requires nightly Rust. If you do not have nightly Rust, you should install rustup at https://www.rustup.rs/, and run 'rustup install nightly && rustup override nightly' in the remacs directory."; exit 1; }
     echo "Your system has the required rust installation for building remacs."
 fi
 


### PR DESCRIPTION
We have had a number of new contributors not realize that remacs requires nightly rust, and this has caused problems. This should make the build fail fast if nightly is not installed.