### PR TITLE
Port fontp to Rust

### DIFF
--- a/rust_src/remacs-sys/lib.rs
+++ b/rust_src/remacs-sys/lib.rs
@@ -1202,3 +1202,47 @@ extern "C" {
         nchars_return: *mut ptrdiff_t,
     ) -> ptrdiff_t;
 }
+
+/// Contains C definitions from the font.h header.
+pub mod font {
+    use libc::c_int;
+
+    /// Represents the indices of font properties in the contents of a font
+    /// vector.
+    ///
+    /// # C Porting Notes
+    ///
+    /// The equivalent C enum is `font_property_index`. Since it is meant to
+    /// represent indices for three different length vectors, the C definition
+    /// contains duplicate variants, e.g `FONT_OBJLIST_INDEX = FONT_SPEC_MAX`,
+    /// to represent sizes. These have been moved out of this enum and are
+    /// available as constant `c_int` values on this module.
+    #[allow(non_camel_case_types, dead_code)]
+    #[repr(C)]
+    pub enum FontPropertyIndex {
+        FONT_TYPE_INDEX,
+        FONT_FOUNDRY_INDEX,
+        FONT_FAMILY_INDEX,
+        FONT_ADSTYLE_INDEX,
+        FONT_REGISTRY_INDEX,
+        FONT_WEIGHT_INDEX,
+        FONT_SLANT_INDEX,
+        FONT_WIDTH_INDEX,
+        FONT_SIZE_INDEX,
+        FONT_DPI_INDEX,
+        FONT_SPACING_INDEX,
+        FONT_AVGWIDTH_INDEX,
+        FONT_EXTRA_INDEX,
+        // In C, we have FONT_SPEC_MAX, FONT_OBJLIST_INDEX = FONT_SPEC_MAX here.
+        FONT_OBJLIST_INDEX,
+        // In C, we have FONT_ENTITY_MAX, FONT_NAME_INDEX = FONT_ENTITY_MAX here.
+        FONT_NAME_INDEX,
+        FONT_FULLNAME_INDEX,
+        FONT_FILE_INDEX,
+        // In C, we have FONT_OBJECT_MAX here.
+    }
+
+    pub const FONT_SPEC_MAX: c_int = FontPropertyIndex::FONT_OBJLIST_INDEX as c_int;
+    pub const FONT_ENTITY_MAX: c_int = FontPropertyIndex::FONT_NAME_INDEX as c_int;
+    pub const FONT_OBJECT_MAX: c_int = (FontPropertyIndex::FONT_FILE_INDEX as c_int) + 1;
+}

--- a/rust_src/src/fonts.rs
+++ b/rust_src/src/fonts.rs
@@ -1,6 +1,7 @@
 use remacs_macros::lisp_fn;
-use remacs_sys::{font, Qfont_spec, Qfont_entity, Qfont_object, Qsymbolp, wrong_type_argument};
+use remacs_sys::{font, Qfont_spec, Qfont_entity, Qfont_object, wrong_type_argument};
 use lisp::LispObject;
+use symbols::intern;
 use vectors::LispVectorlikeRef;
 
 // A font is not a type in and of itself, it's just a group of three kinds of
@@ -42,9 +43,7 @@ impl FontExtraType {
         } else if extra_type.eq(LispObject::from_raw(unsafe { Qfont_object })) {
             FontExtraType::Object
         } else {
-            // TODO: This should actually be equivalent to
-            // intern("font-extra-type"), not Qsymbolp.
-            unsafe { wrong_type_argument(Qsymbolp, extra_type.to_raw()) }
+            unsafe { wrong_type_argument(intern("font-extra-type").to_raw(), extra_type.to_raw()) }
         }
     }
 }

--- a/rust_src/src/fonts.rs
+++ b/rust_src/src/fonts.rs
@@ -1,6 +1,7 @@
 use remacs_macros::lisp_fn;
 use remacs_sys::{Qfont_spec, Qfont_entity, Qfont_object, Qsymbolp, wrong_type_argument};
 use lisp::LispObject;
+use vectors::LispVectorlikeRef;
 
 // See font_property_index in font.h for details.
 #[allow(non_camel_case_types, dead_code)]
@@ -32,6 +33,30 @@ pub const FONT_SPEC_MAX: i32 = font_property_index::FONT_OBJLIST_INDEX as i32;
 pub const FONT_ENTITY_MAX: i32 = font_property_index::FONT_NAME_INDEX as i32;
 pub const FONT_OBJECT_MAX: i32 = (font_property_index::FONT_FILE_INDEX as i32) + 1;
 
+// A font is not a type in and of itself, it's just a group of three kinds of
+// pseudovector. This newtype allows us to define methods that yield the actual
+// font types: Spec, Entity, and Object.
+pub struct LispFontRef(LispVectorlikeRef);
+
+impl LispFontRef {
+    #[inline]
+    pub fn from_vectorlike(v: LispVectorlikeRef) -> LispFontRef {
+        LispFontRef(v)
+    }
+
+    pub fn is_font_spec(self) -> bool {
+        self.0.pseudovector_size() == FONT_SPEC_MAX as i64
+    }
+
+    pub fn is_font_entity(self) -> bool {
+        self.0.pseudovector_size() == FONT_ENTITY_MAX as i64
+    }
+
+    pub fn is_font_object(self) -> bool {
+        self.0.pseudovector_size() == FONT_OBJECT_MAX as i64
+    }
+}
+
 pub enum FontExtraType {
     Spec,
     Entity,
@@ -61,19 +86,17 @@ impl FontExtraType {
 /// `font-object'.
 #[lisp_fn(min = "1")]
 pub fn fontp(object: LispObject, extra_type: LispObject) -> LispObject {
-    if object.is_font() {
-        if extra_type.eq(LispObject::constant_nil()) {
+    // For compatibility with the C version, checking that object is a font
+    // takes priority over checking that extra_type is well-formed.
+    object.as_font().map_or(LispObject::constant_nil(), |f| {
+        if extra_type.is_nil() {
             LispObject::constant_t()
         } else {
             match FontExtraType::from_symbol_or_error(extra_type) {
-                FontExtraType::Spec => LispObject::from_bool(object.is_font_spec()),
-                FontExtraType::Entity => LispObject::from_bool(object.is_font_entity()),
-                FontExtraType::Object => LispObject::from_bool(object.is_font_object()),
+                FontExtraType::Spec => LispObject::from_bool(f.is_font_spec()),
+                FontExtraType::Entity => LispObject::from_bool(f.is_font_entity()),
+                FontExtraType::Object => LispObject::from_bool(f.is_font_object()),
             }
         }
-    } else {
-        // As with the C version, checking that object is a font takes priority
-        // over checking that extra_type is well-formed.
-        LispObject::constant_nil()
-    }
+    })
 }

--- a/rust_src/src/fonts.rs
+++ b/rust_src/src/fonts.rs
@@ -1,0 +1,64 @@
+use remacs_macros::lisp_fn;
+use remacs_sys::{PseudovecType, Qfont_spec, Qfont_entity, Qfont_object, Qsymbolp,
+                 wrong_type_argument};
+use lisp::{LispObject, Qnil};
+
+// See font_property_index in font.h for details.
+#[allow(non_camel_case_types, dead_code)]
+#[repr(C)]
+enum font_property_index {
+    FONT_TYPE_INDEX,
+    FONT_FOUNDRY_INDEX,
+    FONT_FAMILY_INDEX,
+    FONT_ADSTYLE_INDEX,
+    FONT_REGISTRY_INDEX,
+    FONT_WEIGHT_INDEX,
+    FONT_SLANT_INDEX,
+    FONT_WIDTH_INDEX,
+    FONT_SIZE_INDEX,
+    FONT_DPI_INDEX,
+    FONT_SPACING_INDEX,
+    FONT_AVGWIDTH_INDEX,
+    FONT_EXTRA_INDEX,
+    // In C, we have FONT_SPEC_MAX, FONT_OBJLIST_INDEX = FONT_SPEC_MAX here.
+    FONT_OBJLIST_INDEX,
+    // In C, we have FONT_ENTITY_MAX, FONT_NAME_INDEX = FONT_ENTITY_MAX here.
+    FONT_NAME_INDEX,
+    FONT_FULLNAME_INDEX,
+    FONT_FILE_INDEX,
+    // In C, we have FONT_OBJECT_MAX here.
+}
+
+const FONT_SPEC_MAX: i32 = font_property_index::FONT_OBJLIST_INDEX as i32;
+const FONT_ENTITY_MAX: i32 = font_property_index::FONT_NAME_INDEX as i32;
+const FONT_OBJECT_MAX: i32 = (font_property_index::FONT_FILE_INDEX as i32) + 1;
+
+/// Return t if OBJECT is a font-spec, font-entity, or font-object.
+/// Return nil otherwise.
+/// Optional 2nd argument EXTRA-TYPE, if non-nil, specifies to check
+/// which kind of font it is.  It must be one of `font-spec', `font-entity',
+/// `font-object'.
+#[lisp_fn(min = "1")]
+pub fn fontp(object: LispObject, extra_type: LispObject) -> LispObject {
+    object.as_vectorlike().map_or(Qnil, |v| {
+        if v.is_pseudovector(PseudovecType::PVEC_FONT) {
+            if extra_type.eq(Qnil) {
+                LispObject::constant_t()
+            } else if extra_type.eq(LispObject::from_raw(unsafe { Qfont_spec })) {
+                LispObject::from_bool(v.pseudovector_size() == FONT_SPEC_MAX as i64)
+            } else if extra_type.eq(LispObject::from_raw(unsafe { Qfont_entity })) {
+                LispObject::from_bool(v.pseudovector_size() == FONT_ENTITY_MAX as i64)
+            } else if extra_type.eq(LispObject::from_raw(unsafe { Qfont_object })) {
+                LispObject::from_bool(v.pseudovector_size() == FONT_OBJECT_MAX as i64)
+            } else {
+                // TODO: This should actually be equivalent to
+                // intern("font-extra-type"), not Qsymbolp.
+                unsafe { wrong_type_argument(Qsymbolp, extra_type.to_raw()) }
+            }
+        } else {
+            // As with the C version, checking that object is a font takes priority
+            // over checking that extra_type is well-formed.
+            Qnil
+        }
+    })
+}

--- a/rust_src/src/fonts.rs
+++ b/rust_src/src/fonts.rs
@@ -1,37 +1,7 @@
 use remacs_macros::lisp_fn;
-use remacs_sys::{Qfont_spec, Qfont_entity, Qfont_object, Qsymbolp, wrong_type_argument};
+use remacs_sys::{font, Qfont_spec, Qfont_entity, Qfont_object, Qsymbolp, wrong_type_argument};
 use lisp::LispObject;
 use vectors::LispVectorlikeRef;
-
-// See font_property_index in font.h for details.
-#[allow(non_camel_case_types, dead_code)]
-#[repr(C)]
-enum font_property_index {
-    FONT_TYPE_INDEX,
-    FONT_FOUNDRY_INDEX,
-    FONT_FAMILY_INDEX,
-    FONT_ADSTYLE_INDEX,
-    FONT_REGISTRY_INDEX,
-    FONT_WEIGHT_INDEX,
-    FONT_SLANT_INDEX,
-    FONT_WIDTH_INDEX,
-    FONT_SIZE_INDEX,
-    FONT_DPI_INDEX,
-    FONT_SPACING_INDEX,
-    FONT_AVGWIDTH_INDEX,
-    FONT_EXTRA_INDEX,
-    // In C, we have FONT_SPEC_MAX, FONT_OBJLIST_INDEX = FONT_SPEC_MAX here.
-    FONT_OBJLIST_INDEX,
-    // In C, we have FONT_ENTITY_MAX, FONT_NAME_INDEX = FONT_ENTITY_MAX here.
-    FONT_NAME_INDEX,
-    FONT_FULLNAME_INDEX,
-    FONT_FILE_INDEX,
-    // In C, we have FONT_OBJECT_MAX here.
-}
-
-pub const FONT_SPEC_MAX: i32 = font_property_index::FONT_OBJLIST_INDEX as i32;
-pub const FONT_ENTITY_MAX: i32 = font_property_index::FONT_NAME_INDEX as i32;
-pub const FONT_OBJECT_MAX: i32 = (font_property_index::FONT_FILE_INDEX as i32) + 1;
 
 // A font is not a type in and of itself, it's just a group of three kinds of
 // pseudovector. This newtype allows us to define methods that yield the actual
@@ -45,15 +15,15 @@ impl LispFontRef {
     }
 
     pub fn is_font_spec(self) -> bool {
-        self.0.pseudovector_size() == FONT_SPEC_MAX as i64
+        self.0.pseudovector_size() == font::FONT_SPEC_MAX as i64
     }
 
     pub fn is_font_entity(self) -> bool {
-        self.0.pseudovector_size() == FONT_ENTITY_MAX as i64
+        self.0.pseudovector_size() == font::FONT_ENTITY_MAX as i64
     }
 
     pub fn is_font_object(self) -> bool {
-        self.0.pseudovector_size() == FONT_OBJECT_MAX as i64
+        self.0.pseudovector_size() == font::FONT_OBJECT_MAX as i64
     }
 }
 

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -41,6 +41,7 @@ mod buffers;
 mod windows;
 mod interactive;
 mod process;
+mod fonts;
 
 #[cfg(all(not(test), target_os = "macos"))]
 use alloc_unexecmacosx::OsxUnexecAlloc;
@@ -246,6 +247,7 @@ pub extern "C" fn rust_init_syms() {
         defsubr(&*vectors::Svector_or_char_table_p);
         defsubr(&*vectors::Svectorp);
         defsubr(&*vectors::Slength);
+        defsubr(&*fonts::Sfontp);
         defsubr(&*crypto::Sbuffer_hash);
         defsubr(&*interactive::Sprefix_numeric_value);
 

--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -17,7 +17,7 @@ use vectors::LispVectorlikeRef;
 use buffers::LispBufferRef;
 use windows::LispWindowRef;
 use marker::LispMarkerRef;
-use fonts;
+use fonts::LispFontRef;
 
 use remacs_sys::{EmacsInt, EmacsUint, EmacsDouble, VALMASK, VALBITS, INTTYPEBITS, INTMASK,
                  USE_LSB_TAG, MOST_POSITIVE_FIXNUM, MOST_NEGATIVE_FIXNUM, Lisp_Type,
@@ -485,24 +485,14 @@ impl LispObject {
         })
     }
 
-    pub fn is_font_spec(self) -> bool {
-        self.as_vectorlike().map_or(false, |v| {
-            v.is_pseudovector(PseudovecType::PVEC_FONT) &&
-                v.pseudovector_size() == fonts::FONT_SPEC_MAX as i64
-        })
-    }
-
-    pub fn is_font_entity(self) -> bool {
-        self.as_vectorlike().map_or(false, |v| {
-            v.is_pseudovector(PseudovecType::PVEC_FONT) &&
-                v.pseudovector_size() == fonts::FONT_ENTITY_MAX as i64
-        })
-    }
-
-    pub fn is_font_object(self) -> bool {
-        self.as_vectorlike().map_or(false, |v| {
-            v.is_pseudovector(PseudovecType::PVEC_FONT) &&
-                v.pseudovector_size() == fonts::FONT_OBJECT_MAX as i64
+    pub fn as_font(self) -> Option<LispFontRef> {
+        self.as_vectorlike().map_or(None, |v| if v.is_pseudovector(
+            PseudovecType::PVEC_FONT,
+        )
+        {
+            Some(LispFontRef::from_vectorlike(v))
+        } else {
+            None
         })
     }
 }

--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -17,6 +17,7 @@ use vectors::LispVectorlikeRef;
 use buffers::LispBufferRef;
 use windows::LispWindowRef;
 use marker::LispMarkerRef;
+use fonts;
 
 use remacs_sys::{EmacsInt, EmacsUint, EmacsDouble, VALMASK, VALBITS, INTTYPEBITS, INTMASK,
                  USE_LSB_TAG, MOST_POSITIVE_FIXNUM, MOST_NEGATIVE_FIXNUM, Lisp_Type,
@@ -481,6 +482,27 @@ impl LispObject {
     pub fn is_font(self) -> bool {
         self.as_vectorlike().map_or(false, |v| {
             v.is_pseudovector(PseudovecType::PVEC_FONT)
+        })
+    }
+
+    pub fn is_font_spec(self) -> bool {
+        self.as_vectorlike().map_or(false, |v| {
+            v.is_pseudovector(PseudovecType::PVEC_FONT) &&
+                v.pseudovector_size() == fonts::FONT_SPEC_MAX as i64
+        })
+    }
+
+    pub fn is_font_entity(self) -> bool {
+        self.as_vectorlike().map_or(false, |v| {
+            v.is_pseudovector(PseudovecType::PVEC_FONT) &&
+                v.pseudovector_size() == fonts::FONT_ENTITY_MAX as i64
+        })
+    }
+
+    pub fn is_font_object(self) -> bool {
+        self.as_vectorlike().map_or(false, |v| {
+            v.is_pseudovector(PseudovecType::PVEC_FONT) &&
+                v.pseudovector_size() == fonts::FONT_OBJECT_MAX as i64
         })
     }
 }

--- a/src/font.c
+++ b/src/font.c
@@ -3838,25 +3838,6 @@ font_range (ptrdiff_t pos, ptrdiff_t pos_byte, ptrdiff_t *limit,
 
 /* Lisp API.  */
 
-DEFUN ("fontp", Ffontp, Sfontp, 1, 2, 0,
-       doc: /* Return t if OBJECT is a font-spec, font-entity, or font-object.
-Return nil otherwise.
-Optional 2nd argument EXTRA-TYPE, if non-nil, specifies to check
-which kind of font it is.  It must be one of `font-spec', `font-entity',
-`font-object'.  */)
-  (Lisp_Object object, Lisp_Object extra_type)
-{
-  if (NILP (extra_type))
-    return (FONTP (object) ? Qt : Qnil);
-  if (EQ (extra_type, Qfont_spec))
-    return (FONT_SPEC_P (object) ? Qt : Qnil);
-  if (EQ (extra_type, Qfont_entity))
-    return (FONT_ENTITY_P (object) ? Qt : Qnil);
-  if (EQ (extra_type, Qfont_object))
-    return (FONT_OBJECT_P (object) ? Qt : Qnil);
-  wrong_type_argument (intern ("font-extra-type"), extra_type);
-}
-
 DEFUN ("font-spec", Ffont_spec, Sfont_spec, 0, MANY, 0,
        doc: /* Return a newly created font-spec with arguments as properties.
 
@@ -5354,7 +5335,6 @@ syms_of_font (void)
 #endif	/* HAVE_LIBOTF */
 #endif	/* 0 */
 
-  defsubr (&Sfontp);
   defsubr (&Sfont_spec);
   defsubr (&Sfont_get);
 #ifdef HAVE_WINDOW_SYSTEM


### PR DESCRIPTION
This is my first pass at porting `fontp` to Rust, and should be considered a work in progress. I have a few questions:

1) ~~Should I change the naming convention for the `font_property_index` enum?~~
2) ~~Is there a convention for calling `intern` from Rust code?~~ See #255.
3) ~~Can or should I add `is_font_spec()` (etc) methods to `LispObject` in `lisp.rs`, so that the checking can be moved out of `fontp` and into those methods?~~

This should close #233.