### PR TITLE
Define a thread_state type and the current-buffer function

### DIFF
--- a/rust_src/src/buffers.rs
+++ b/rust_src/src/buffers.rs
@@ -1,11 +1,12 @@
 //! Functions operating on buffers.
 
-use libc::{c_uchar, ptrdiff_t};
+use libc::{c_void, c_uchar, ptrdiff_t};
 
 use lisp::{LispObject, ExternalPtr};
-use remacs_sys::{Lisp_Buffer, Lisp_Type, Vbuffer_alist, current_thread, make_lisp_ptr};
+use remacs_sys::{Lisp_Buffer, Lisp_Type, Vbuffer_alist, make_lisp_ptr};
 use strings::string_equal;
 use lists::{car, cdr};
+use threads::ThreadState;
 
 use remacs_macros::lisp_fn;
 
@@ -107,8 +108,11 @@ pub fn get_buffer(buffer_or_name: LispObject) -> LispObject {
 /// Return the current buffer as a Lisp object.
 #[lisp_fn]
 pub fn current_buffer() -> LispObject {
+    let buffer_ref = ThreadState::current_buffer();
     unsafe {
-        let buffer_ref = (*current_thread).m_current_buffer;
-        LispObject::from_raw(make_lisp_ptr(buffer_ref, Lisp_Type::Lisp_Vectorlike))
+        LispObject::from_raw(make_lisp_ptr(
+            buffer_ref.as_ptr() as *mut c_void,
+            Lisp_Type::Lisp_Vectorlike,
+        ))
     }
 }

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -44,6 +44,7 @@ mod windows;
 mod interactive;
 mod process;
 mod fonts;
+mod threads;
 
 #[cfg(all(not(test), target_os = "macos"))]
 use alloc_unexecmacosx::OsxUnexecAlloc;

--- a/rust_src/src/threads.rs
+++ b/rust_src/src/threads.rs
@@ -1,0 +1,11 @@
+use std::mem;
+use remacs_sys::current_thread;
+use buffers::LispBufferRef;
+
+pub struct ThreadState {}
+
+impl ThreadState {
+    pub fn current_buffer() -> LispBufferRef {
+        unsafe { mem::transmute((*current_thread).m_current_buffer) }
+    }
+}


### PR DESCRIPTION
Defining `current-buffer` in Rust requires us to have the `thread_state` type defined.

This definitely isn't finished yet, but any feedback welcome :)