### PR TITLE
Skip EIEIO test that fails on Travis

### DIFF
--- a/test/lisp/emacs-lisp/eieio-tests/eieio-test-methodinvoke.el
+++ b/test/lisp/emacs-lisp/eieio-tests/eieio-test-methodinvoke.el
@@ -193,6 +193,7 @@
   ;; FIXME repeated intermittent failures on hydra (bug#24503)
   ;; ((:STATIC C) (:STATIC C-base1) (:STATIC C-base2)) != ((:STATIC C))")
   (skip-unless (not (getenv "NIX_STORE")))
+  (skip-unless (equal invocation-name "emacs"))
   (let ((eieio-test-method-order-list nil)
 	(ans '(
 	       (:STATIC C)


### PR DESCRIPTION
Note this fails on upstream GNU Emacs on Hydra (their CI tool) too.

See #159.