### PR TITLE
Adds intern and an intern_static! macro

### DIFF
--- a/rust_src/remacs-sys/lib.rs
+++ b/rust_src/remacs-sys/lib.rs
@@ -1060,6 +1060,8 @@ extern "C" {
     pub fn make_uninit_multibyte_string(nchars: EmacsInt, nbytes: EmacsInt) -> Lisp_Object;
     pub fn string_to_multibyte(string: Lisp_Object) -> Lisp_Object;
 
+    pub fn intern_1(s: *const c_char, length: ptrdiff_t) -> Lisp_Object;
+
     pub fn SYMBOL_NAME(s: Lisp_Object) -> Lisp_Object;
     pub fn CHECK_IMPURE(obj: Lisp_Object, ptr: *const c_void);
     pub fn internal_equal(

--- a/rust_src/src/symbols.rs
+++ b/rust_src/src/symbols.rs
@@ -60,12 +60,14 @@ fn symbol_plist(object: LispObject) -> LispObject {
     object.as_symbol_or_error().get_plist()
 }
 
-/// Intern (e.g. create a symbol from) a string slice.
-pub fn intern(s: &str) -> LispObject {
-    unsafe {
-        LispObject::from_raw(intern_1(
+/// Intern (e.g. create a symbol from) a string.
+#[allow(dead_code)]
+pub fn intern<T: AsRef<str>>(string: T) -> LispObject {
+    let s = string.as_ref();
+    LispObject::from_raw(unsafe {
+        intern_1(
             s.as_ptr() as *const libc::c_char,
             s.len() as libc::ptrdiff_t,
-        ))
-    }
+        )
+    })
 }

--- a/rust_src/src/symbols.rs
+++ b/rust_src/src/symbols.rs
@@ -1,6 +1,7 @@
+use libc;
 use remacs_macros::lisp_fn;
 use lisp::{LispObject, ExternalPtr};
-use remacs_sys::Lisp_Symbol;
+use remacs_sys::{Lisp_Symbol, intern_1};
 
 pub type LispSymbolRef = ExternalPtr<Lisp_Symbol>;
 
@@ -57,4 +58,14 @@ fn symbol_function(object: LispObject) -> LispObject {
 #[lisp_fn]
 fn symbol_plist(object: LispObject) -> LispObject {
     object.as_symbol_or_error().get_plist()
+}
+
+/// Intern (e.g. create a symbol from) a string slice.
+pub fn intern(s: &str) -> LispObject {
+    unsafe {
+        LispObject::from_raw(intern_1(
+            s.as_ptr() as *const libc::c_char,
+            s.len() as libc::ptrdiff_t,
+        ))
+    }
 }


### PR DESCRIPTION
It's a common pattern in the C codebase to call `intern("some static c string")`. I thought that it would be nice to have a similar API available in Rust. Unfortunately, there's no way of doing this with the `std::cstring` interface that avoids heap-allocating and unnecessary copies. I've written a macro that avoids this by concatenating a null byte to the end of a string at compile time, and casting to a `*const c_char`. This allows us to write 

```rust
let symbol = unsafe { intern_static!("my-symbol-1") };
```

This macro is, and always will be, unsafe. If you pass it a string with internal NULL bytes, e.g. `intern("my-\0dangerous-\0string")`, then C will not correctly deduce the length of the string, and we'll leak memory. However, for symbols defined at compile time and clearly audited by the project, I don't think this is a problem.

One could also add a safe, non-static version of `intern` using the `std::cstring` machinery.