### PR TITLE
Port window-live-p to Rust

### DIFF
--- a/rust_src/remacs-sys/lib.rs
+++ b/rust_src/remacs-sys/lib.rs
@@ -124,6 +124,17 @@ pub enum PseudovecType {
     PVEC_FONT, /* Should be last because it's used for range checking.  */
 }
 
+#[repr(C)]
+#[derive(PartialEq, Eq, Copy, Clone, Debug)]
+pub enum TextCursorKinds {
+    DEFAULT_CURSOR = -2,
+    NO_CURSOR = -1,
+    FILLED_BOX_CURSOR,
+    HOLLOW_BOX_CURSOR,
+    BAR_CURSOR,
+    HBAR_CURSOR,
+}
+
 // XXX: this can also be char on some archs
 pub type bits_word = size_t;
 
@@ -284,6 +295,97 @@ pub struct Lisp_Marker {
     pub next: *const Lisp_Marker,
     pub charpos: ptrdiff_t,
     pub bytepos: ptrdiff_t,
+}
+
+/// Represents the cursor position within an Emacs window. For
+/// documentation see stuct cursor_pos in window.h.
+#[repr(C)]
+pub struct CursorPos {
+    // Pixel position.  These are always window relative.
+    x: c_int,
+    y: c_int,
+    // Glyph matrix position.
+    hpos: c_int,
+    vpos: c_int,
+}
+
+/// Represents an Emacs window. For documentation see struct window in
+/// window.h.
+#[repr(C)]
+pub struct Lisp_Window {
+    pub header: Lisp_Vectorlike_Header,
+    pub frame: Lisp_Object,
+    pub next: Lisp_Object,
+    pub prev: Lisp_Object,
+    pub parent: Lisp_Object,
+    pub normal_lines: Lisp_Object,
+    pub normal_cols: Lisp_Object,
+    pub new_total: Lisp_Object,
+    pub new_normal: Lisp_Object,
+    pub new_pixel: Lisp_Object,
+    pub contents: Lisp_Object,
+    pub start: Lisp_Object,
+    pub pointm: Lisp_Object,
+    pub old_pointm: Lisp_Object,
+    pub temslot: Lisp_Object,
+    pub vertical_scroll_bar: Lisp_Object,
+    pub vertical_scroll_bar_type: Lisp_Object,
+    pub horizontal_scroll_bar: Lisp_Object,
+    pub horizontal_scroll_bar_type: Lisp_Object,
+    pub display_table: Lisp_Object,
+    pub dedicated: Lisp_Object,
+    pub redisplay_end_trigger: Lisp_Object,
+    pub combination_limit: Lisp_Object,
+    pub window_parameters: Lisp_Object,
+    pub current_matrix: *mut c_void,
+    pub desired_matrix: *mut c_void,
+    pub prev_buffers: Lisp_Object,
+    pub next_buffers: Lisp_Object,
+    pub use_time: EmacsInt,
+    pub sequence_number: EmacsInt,
+    pub pixel_left: c_int,
+    pub pixel_top: c_int,
+    pub left_col: c_int,
+    pub top_line: c_int,
+    pub pixel_width: c_int,
+    pub pixel_height: c_int,
+    pub pixel_width_before_size_change: c_int,
+    pub pixel_height_before_size_change: c_int,
+    pub total_cols: c_int,
+    pub total_lines: c_int,
+    pub hscroll: ptrdiff_t,
+    pub min_hscroll: ptrdiff_t,
+    pub hscroll_whole: ptrdiff_t,
+    pub last_modified: EmacsInt,
+    pub last_overlay_modified: EmacsInt,
+    pub last_point: ptrdiff_t,
+    pub base_line_number: ptrdiff_t,
+    pub base_line_pos: ptrdiff_t,
+    pub column_number_displayed: ptrdiff_t,
+    pub nrows_scale_factor: c_int,
+    pub ncols_scale_factor: c_int,
+    pub cursor: CursorPos,
+    pub phys_cursor: CursorPos,
+    pub output_cursor: CursorPos,
+    pub last_cursor_vpos: c_int,
+    pub phys_cursor_type: TextCursorKinds,
+    pub phys_cursor_width: c_int,
+    pub phys_cursor_ascent: c_int,
+    pub phys_cursor_height: c_int,
+    pub left_fringe_width: c_int,
+    pub right_fringe_width: c_int,
+    pub left_margin_cols: c_int,
+    pub right_margin_cols: c_int,
+    pub scroll_bar_width: c_int,
+    pub scroll_bar_height: c_int,
+    pub mode_line_height: c_int,
+    pub header_line_height: c_int,
+    pub window_end_pos: ptrdiff_t,
+    pub window_end_vpos: c_int,
+    // XXX: in Emacs, a bitfield of 16 booleans
+    pub flags: u16,
+    pub vscroll: c_int,
+    pub window_end_bytepos: ptrdiff_t,
 }
 
 /// Represents an Emacs buffer. For documentation see struct buffer in

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -147,6 +147,7 @@ pub extern "C" fn rust_init_syms() {
         defsubr(&*buffers::Sbuffer_live_p);
         defsubr(&*buffers::Sget_buffer);
         defsubr(&*windows::Swindowp);
+        defsubr(&*windows::Swindow_live_p);
         defsubr(&*lists::Satom);
         defsubr(&*lists::Slistp);
         defsubr(&*lists::Snlistp);

--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -15,6 +15,7 @@ use multibyte::{Codepoint, LispStringRef, MAX_CHAR};
 use symbols::LispSymbolRef;
 use vectors::LispVectorlikeRef;
 use buffers::LispBufferRef;
+use windows::LispWindowRef;
 use marker::LispMarkerRef;
 
 use remacs_sys::{EmacsInt, EmacsUint, EmacsDouble, VALMASK, VALBITS, INTTYPEBITS, INTMASK,
@@ -459,6 +460,10 @@ impl LispObject {
         self.as_vectorlike().map_or(false, |v| {
             v.is_pseudovector(PseudovecType::PVEC_WINDOW)
         })
+    }
+
+    pub fn as_window(self) -> Option<LispWindowRef> {
+        self.as_vectorlike().map_or(None, |v| v.as_window())
     }
 
     pub fn is_frame(self) -> bool {

--- a/rust_src/src/vectors.rs
+++ b/rust_src/src/vectors.rs
@@ -11,6 +11,7 @@ use lisp::{ExternalPtr, LispObject};
 use multibyte::MAX_CHAR;
 use lists::{sort_list, inorder};
 use buffers::LispBufferRef;
+use windows::LispWindowRef;
 use remacs_sys::{Qsequencep, EmacsInt, wrong_type_argument, error, PSEUDOVECTOR_FLAG,
                  PVEC_TYPE_MASK, PSEUDOVECTOR_AREA_BITS, PSEUDOVECTOR_SIZE_MASK, PseudovecType,
                  Lisp_Vectorlike, Lisp_Vector, Lisp_Bool_Vector, MOST_POSITIVE_FIXNUM};
@@ -58,6 +59,15 @@ impl LispVectorlikeRef {
     #[inline]
     pub fn as_buffer(&self) -> Option<LispBufferRef> {
         if self.is_pseudovector(PseudovecType::PVEC_BUFFER) {
+            Some(unsafe { mem::transmute(*self) })
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    pub fn as_window(&self) -> Option<LispWindowRef> {
+        if self.is_pseudovector(PseudovecType::PVEC_WINDOW) {
             Some(unsafe { mem::transmute(*self) })
         } else {
             None

--- a/rust_src/src/windows.rs
+++ b/rust_src/src/windows.rs
@@ -1,11 +1,30 @@
 //! Functions operating on windows.
 
-use lisp::LispObject;
+use lisp::{LispObject, ExternalPtr};
 use remacs_macros::lisp_fn;
+use remacs_sys::Lisp_Window;
 
+pub type LispWindowRef = ExternalPtr<Lisp_Window>;
+
+impl LispWindowRef {
+    // Check if window is live
+    #[inline]
+    pub fn is_live(self) -> bool {
+        LispObject::from_raw(self.contents).is_buffer()
+    }
+}
 
 /// Return t if OBJECT is a window and nil otherwise.
 #[lisp_fn]
 fn windowp(object: LispObject) -> LispObject {
     LispObject::from_bool(object.is_window())
+}
+
+/// Return t if OBJECT is a live window and nil otherwise.
+///
+/// A live window is a window that displays a buffer.
+/// Internal windows and deleted windows are not live.
+#[lisp_fn]
+pub fn window_live_p(object: LispObject) -> LispObject {
+    LispObject::from_bool(object.as_window().map_or(false, |m| m.is_live()))
 }

--- a/src/window.c
+++ b/src/window.c
@@ -310,15 +310,6 @@ window.  Windows that have been deleted are not valid.  */)
   return WINDOW_VALID_P (object) ? Qt : Qnil;
 }
 
-DEFUN ("window-live-p", Fwindow_live_p, Swindow_live_p, 1, 1, 0,
-       doc: /* Return t if OBJECT is a live window and nil otherwise.
-A live window is a window that displays a buffer.
-Internal windows and deleted windows are not live.  */)
-  (Lisp_Object object)
-{
-  return WINDOW_LIVE_P (object) ? Qt : Qnil;
-}
-
 /* Frames and windows.  */
 DEFUN ("window-frame", Fwindow_frame, Swindow_frame, 0, 1, 0,
        doc: /* Return the frame that window WINDOW is on.
@@ -7731,7 +7722,6 @@ displayed after a scrolling operation to be somewhat inaccurate.  */);
   defsubr (&Sminibuffer_window);
   defsubr (&Swindow_minibuffer_p);
   defsubr (&Swindow_valid_p);
-  defsubr (&Swindow_live_p);
   defsubr (&Swindow_frame);
   defsubr (&Sframe_root_window);
   defsubr (&Sframe_first_window);


### PR DESCRIPTION
This PR ports window-live-p to Rust. Because I followed the approach used by buffer-live-p, it includes a struct Lisp_Window in remacs-sys/lib.rs. If this isn't the right approach let me know, and I'll try again!

It seems to work as expected in ielm.

Closes Issue #232.