### PR TITLE
Port processp

### DIFF
--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -151,6 +151,7 @@ pub extern "C" fn rust_init_syms() {
         defsubr(&*windows::Swindowp);
         defsubr(&*windows::Swindow_live_p);
         defsubr(&*process::Sget_process);
+        defsubr(&*process::Sprocessp);
         defsubr(&*lists::Satom);
         defsubr(&*lists::Slistp);
         defsubr(&*lists::Snlistp);

--- a/rust_src/src/process.rs
+++ b/rust_src/src/process.rs
@@ -5,6 +5,12 @@ use remacs_sys::Vprocess_alist;
 use lisp::LispObject;
 use lists::{assoc, cdr};
 
+/// Return t if OBJECT is a process.
+#[lisp_fn]
+pub fn processp(object: LispObject) -> LispObject {
+    LispObject::from_bool(object.is_process())
+}
+
 /// Return the process named NAME, or nil if there is none.
 #[lisp_fn]
 fn get_process(name: LispObject) -> LispObject {

--- a/src/process.c
+++ b/src/process.c
@@ -929,13 +929,6 @@ free_dns_request (Lisp_Object proc)
 }
 #endif
 
-DEFUN ("processp", Fprocessp, Sprocessp, 1, 1, 0,
-       doc: /* Return t if OBJECT is a process.  */)
-  (Lisp_Object object)
-{
-  return PROCESSP (object) ? Qt : Qnil;
-}
-
 /* This is how commands for the user decode process arguments.  It
    accepts a process, a process name, a buffer, a buffer name, or nil.
    Buffers denote the first process in the buffer, and nil denotes the
@@ -7906,7 +7899,6 @@ non-nil value means that the delay is not reset on write.
 The variable takes effect when `start-process' is called.  */);
   Vprocess_adaptive_read_buffering = Qt;
 
-  defsubr (&Sprocessp);
   defsubr (&Sdelete_process);
   defsubr (&Sprocess_status);
   defsubr (&Sprocess_exit_status);


### PR DESCRIPTION
Porting `processp` to rust per [#229](https://github.com/Wilfred/remacs/issues/229).

Not much more to it.  Went smooth once I found `is_process` :smile:. Great community support, too, thanks!