### PR TITLE
Add some macros for convenience and safety

### DIFF
--- a/rust_src/remacs-sys/lib.rs
+++ b/rust_src/remacs-sys/lib.rs
@@ -1103,8 +1103,10 @@ pub struct emacs_globals {
 extern "C" {
     pub static mut globals: emacs_globals;
     pub static Qt: Lisp_Object;
+    pub static Qerror: Lisp_Object;
     pub static Qarith_error: Lisp_Object;
     pub static Qrange_error: Lisp_Object;
+    pub static Qwrong_type_argument: Lisp_Object;
     pub static Qnumber_or_marker_p: Lisp_Object;
     pub static Qinteger_or_marker_p: Lisp_Object;
     pub static Qconsp: Lisp_Object;
@@ -1154,6 +1156,7 @@ extern "C" {
     pub fn Fcons(car: Lisp_Object, cdr: Lisp_Object) -> Lisp_Object;
     pub fn Fcurrent_buffer() -> Lisp_Object;
     pub fn Fsignal(error_symbol: Lisp_Object, data: Lisp_Object) -> !;
+    pub fn Ffuncall(nargs: ptrdiff_t, args: *mut Lisp_Object) -> Lisp_Object;
 
     pub fn make_float(float_value: c_double) -> Lisp_Object;
     pub fn make_string(s: *const c_char, length: ptrdiff_t) -> Lisp_Object;
@@ -1177,11 +1180,6 @@ extern "C" {
 
     // These signal an error, therefore are marked as non-returning.
     pub fn circular_list(tail: Lisp_Object) -> !;
-    pub fn wrong_type_argument(predicate: Lisp_Object, value: Lisp_Object) -> !;
-    // defined in eval.c, where it can actually take an arbitrary
-    // number of arguments.
-    // TODO: define a Rust version of this that uses Rust strings.
-    pub fn error(m: *const u8, ...) -> !;
     pub fn nsberror(spec: Lisp_Object) -> !;
 
     pub fn emacs_abort() -> !;

--- a/rust_src/remacs-sys/lib.rs
+++ b/rust_src/remacs-sys/lib.rs
@@ -1174,7 +1174,6 @@ extern "C" {
         depth: c_int,
         ht: Lisp_Object,
     ) -> bool;
-    pub fn call2(fn_: Lisp_Object, arg1: Lisp_Object, arg2: Lisp_Object) -> Lisp_Object;
 
     // These signal an error, therefore are marked as non-returning.
     pub fn circular_list(tail: Lisp_Object) -> !;

--- a/rust_src/src/base64.rs
+++ b/rust_src/src/base64.rs
@@ -168,9 +168,7 @@ fn base64_encode_string(string: LispObject, no_line_break: LispObject) -> LispOb
         error!("Multibyte character in data for base64 encoding");
     }
 
-    unsafe {
-        LispObject::from_raw(make_unibyte_string(encoded, encoded_length))
-    }
+    unsafe { LispObject::from_raw(make_unibyte_string(encoded, encoded_length)) }
 }
 
 /// Base64-decode STRING and return the result.
@@ -182,14 +180,13 @@ fn base64_decode_string(string: LispObject) -> LispObject {
     let mut buffer: Vec<c_char> = Vec::with_capacity(length as usize);
 
     let decoded = buffer.as_mut_ptr();
-    let decoded_length = base64_decode_1(string.sdata_ptr(), decoded, length, false, ptr::null_mut());
+    let decoded_length =
+        base64_decode_1(string.sdata_ptr(), decoded, length, false, ptr::null_mut());
 
     if decoded_length > length {
         panic!("Decoded length is above length");
     } else if decoded_length < 0 {
         error!("Invalid base64 data");
     }
-    unsafe {
-        LispObject::from_raw(make_unibyte_string(decoded, decoded_length))
-    }
+    unsafe { LispObject::from_raw(make_unibyte_string(decoded, decoded_length)) }
 }

--- a/rust_src/src/character.rs
+++ b/rust_src/src/character.rs
@@ -3,7 +3,7 @@
 use lisp::LispObject;
 use multibyte::{MAX_CHAR, make_char_multibyte, raw_byte_from_codepoint_safe};
 use remacs_macros::lisp_fn;
-use remacs_sys::{EmacsInt, error};
+use remacs_sys::EmacsInt;
 
 /// Return the character of the maximum code.
 #[lisp_fn]
@@ -32,9 +32,7 @@ fn char_or_string_p(object: LispObject) -> LispObject {
 fn unibyte_char_to_multibyte(ch: LispObject) -> LispObject {
     let c = ch.as_character_or_error();
     if c >= 0x100 {
-        unsafe {
-            error("Not a unibyte character: %d\0".as_ptr(), c);
-        }
+        error!("Not a unibyte character: {}", c);
     }
     LispObject::from_fixnum(make_char_multibyte(c) as EmacsInt)
 }

--- a/rust_src/src/eval.rs
+++ b/rust_src/src/eval.rs
@@ -1,30 +1,39 @@
-//! Generic Lisp eval functions.
+//! Generic Lisp eval functions and macros.
 
-use lisp::LispObject;
-use remacs_sys::Fsignal;
-
-/// Signal an error in Emacs.
+/// Macro to generate an error with a list from any number of arguments.
+/// Replaces xsignal0, etc. in the C layer.
 ///
 /// Like `Fsignal`, but never returns. Can be used for any error
 /// except `Qquit`, which can return from `Fsignal`. See the elisp docstring
 /// for `signal` for an explanation of the arguments.
-fn xsignal(error_symbol: LispObject, data: LispObject) -> ! {
-    unsafe {
-        Fsignal(error_symbol.to_raw(), data.to_raw());
-    }
-}
-
-/// Convenience function for calling `xsignal` with an empty list.
-pub fn xsignal0(error_symbol: LispObject) -> ! {
-    xsignal(error_symbol, LispObject::constant_nil());
-}
-
-/// Convenience function for calling `xsignal` with a two-element list.
-pub fn xsignal2(error_symbol: LispObject, arg1: LispObject, arg2: LispObject) -> ! {
-    xsignal(
-        error_symbol,
-        LispObject::cons(arg1, LispObject::cons(arg2, LispObject::constant_nil())),
-    )
+macro_rules! xsignal {
+    ($symbol:expr) => {{
+        unsafe {
+            ::remacs_sys::Fsignal($symbol, ::remacs_sys::Qnil);
+        }
+    }};
+    ($symbol:expr, $arg:expr) => {{
+        let list = $crate::lisp::LispObject::cons($arg, $crate::lisp::LispObject::constant_nil());
+        unsafe {
+            ::remacs_sys::Fsignal($symbol, list.to_raw());
+        }
+    }};
+    ($symbol:expr, $arg1:expr, $arg2:expr) => {{
+        let list = $crate::lisp::LispObject::cons(
+            $arg1,
+            $crate::lisp::LispObject::cons($arg2, $crate::lisp::LispObject::constant_nil())
+        );
+        unsafe {
+            ::remacs_sys::Fsignal($symbol, list.to_raw());
+        }
+    }};
+    ($symbol:expr, $($arg:expr),*) => {{
+        let mut argsarray = [$($arg),*];
+        unsafe {
+            ::remacs_sys::Fsignal($symbol,
+                                  $crate::lists::list(&mut argsarray[..]).to_raw());
+        }
+    }}
 }
 
 /// Macro to call Lisp functions with any number of arguments.
@@ -37,5 +46,32 @@ macro_rules! call {
                 ::remacs_sys::Ffuncall(argsarray.len() as ::libc::ptrdiff_t, argsarray.as_mut_ptr())
             )
         }
+    }}
+}
+
+/// Macro to format an error message.
+/// Replaces error() in the C layer.
+macro_rules! error {
+    ($str:expr) => {{
+        let strobj = unsafe {
+            ::remacs_sys::make_string($str.as_ptr() as *const i8,
+                                      $str.len() as ::libc::ptrdiff_t)
+        };
+        xsignal!(::remacs_sys::Qerror, $crate::lisp::LispObject::from_raw(strobj));
+    }};
+    ($fmtstr:expr, $($arg:expr),*) => {{
+        let formatted = format!($fmtstr, $($arg),*);
+        let strobj = unsafe {
+            ::remacs_sys::make_string(formatted.as_ptr() as *const i8,
+                                      formatted.len() as ::libc::ptrdiff_t)
+        };
+        xsignal!(::remacs_sys::Qerror, $crate::lisp::LispObject::from_raw(strobj));
+    }}
+}
+
+/// Macro to format a "wrong argument type" error message.
+macro_rules! wrong_type {
+    ($pred:expr, $arg:expr) => {{
+        xsignal!(::remacs_sys::Qwrong_type_argument, LispObject::from_raw(unsafe { $pred }), $arg);
     }}
 }

--- a/rust_src/src/eval.rs
+++ b/rust_src/src/eval.rs
@@ -26,3 +26,16 @@ pub fn xsignal2(error_symbol: LispObject, arg1: LispObject, arg2: LispObject) ->
         LispObject::cons(arg1, LispObject::cons(arg2, LispObject::constant_nil())),
     )
 }
+
+/// Macro to call Lisp functions with any number of arguments.
+/// Replaces CALLN, call1, etc. in the C layer.
+macro_rules! call {
+    ($func:expr, $($arg:expr),*) => {{
+        let mut argsarray = [$func.to_raw(), $($arg.to_raw()),*];
+        unsafe {
+            LispObject::from_raw(
+                ::remacs_sys::Ffuncall(argsarray.len() as ::libc::ptrdiff_t, argsarray.as_mut_ptr())
+            )
+        }
+    }}
+}

--- a/rust_src/src/floatfns.rs
+++ b/rust_src/src/floatfns.rs
@@ -3,11 +3,10 @@
 use std::mem;
 use libc;
 
-use eval::{xsignal0, xsignal2};
 use math::ArithOp;
 use lisp::{LispObject, LispNumber};
 use remacs_sys::{EmacsDouble, EmacsInt, EmacsUint, Lisp_Object, Qnumberp, Qinteger_or_marker_p,
-                 Qarith_error, Qrange_error, wrong_type_argument, build_string,
+                 Qarith_error, Qrange_error, build_string,
                  MOST_NEGATIVE_FIXNUM, MOST_POSITIVE_FIXNUM};
 use remacs_sys::libm;
 use remacs_macros::lisp_fn;
@@ -86,13 +85,13 @@ pub fn float_arith_driver(
                     accum = next;
                 } else {
                     if next == 0. {
-                        xsignal0(LispObject::from_raw(unsafe { Qarith_error }));
+                        xsignal!(Qarith_error);
                     }
                     accum /= next;
                 }
             }
-            ArithOp::Logand | ArithOp::Logior | ArithOp::Logxor => unsafe {
-                wrong_type_argument(Qinteger_or_marker_p, val.to_raw())
+            ArithOp::Logand | ArithOp::Logior | ArithOp::Logxor => {
+                wrong_type!(Qinteger_or_marker_p, val)
             },
         }
     }
@@ -181,9 +180,7 @@ fn float(arg: LispObject) -> LispObject {
     } else if let Some(n) = arg.as_fixnum() {
         LispObject::from_float(n as EmacsDouble)
     } else {
-        unsafe {
-            wrong_type_argument(Qnumberp, arg.to_raw());
-        }
+        wrong_type!(Qnumberp, arg);
     }
 }
 
@@ -263,9 +260,7 @@ fn logb(arg: LispObject) -> LispObject {
             MOST_POSITIVE_FIXNUM
         }
     } else {
-        unsafe {
-            wrong_type_argument(Qnumberp, arg.to_raw());
-        }
+        wrong_type!(Qnumberp, arg)
     };
     LispObject::from_fixnum(res)
 }
@@ -330,14 +325,12 @@ where
         } else if let Some(f) = arg.as_float() {
             d = f;
         } else {
-            unsafe {
-                wrong_type_argument(Qnumberp, arg.to_raw());
-            }
+            wrong_type!(Qnumberp, arg)
         }
     } else {
         if let (Some(arg), Some(div)) = (arg.as_fixnum(), divisor.as_fixnum()) {
             if div == 0 {
-                xsignal0(LispObject::from_raw(unsafe { Qarith_error }));
+                xsignal!(Qarith_error);
             }
             return LispObject::from_fixnum(int_round2(arg, div));
         }
@@ -360,7 +353,7 @@ where
     let errstr = LispObject::from_raw(unsafe {
         build_string(name.as_ptr() as *const libc::c_char)
     });
-    xsignal2(LispObject::from_raw(unsafe { Qrange_error }), errstr, arg)
+    xsignal!(Qrange_error, errstr, arg)
 }
 
 fn ceiling2(i1: EmacsInt, i2: EmacsInt) -> EmacsInt {

--- a/rust_src/src/floatfns.rs
+++ b/rust_src/src/floatfns.rs
@@ -6,8 +6,8 @@ use libc;
 use math::ArithOp;
 use lisp::{LispObject, LispNumber};
 use remacs_sys::{EmacsDouble, EmacsInt, EmacsUint, Lisp_Object, Qnumberp, Qinteger_or_marker_p,
-                 Qarith_error, Qrange_error, build_string,
-                 MOST_NEGATIVE_FIXNUM, MOST_POSITIVE_FIXNUM};
+                 Qarith_error, Qrange_error, build_string, MOST_NEGATIVE_FIXNUM,
+                 MOST_POSITIVE_FIXNUM};
 use remacs_sys::libm;
 use remacs_macros::lisp_fn;
 
@@ -92,7 +92,7 @@ pub fn float_arith_driver(
             }
             ArithOp::Logand | ArithOp::Logior | ArithOp::Logxor => {
                 wrong_type!(Qinteger_or_marker_p, val)
-            },
+            }
         }
     }
     LispObject::from_float(accum)

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -21,9 +21,9 @@ extern crate sha1;
 extern crate sha2;
 extern crate base64 as base64_crate;
 
-mod lisp;
 #[macro_use]
 mod eval;
+mod lisp;
 mod lists;
 mod marker;
 mod floatfns;

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -22,9 +22,10 @@ extern crate sha2;
 extern crate base64 as base64_crate;
 
 mod lisp;
+#[macro_use]
+mod eval;
 mod lists;
 mod marker;
-mod eval;
 mod floatfns;
 mod math;
 mod numbers;

--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -21,10 +21,9 @@ use marker::LispMarkerRef;
 use remacs_sys::{EmacsInt, EmacsUint, EmacsDouble, VALMASK, VALBITS, INTTYPEBITS, INTMASK,
                  USE_LSB_TAG, MOST_POSITIVE_FIXNUM, MOST_NEGATIVE_FIXNUM, Lisp_Type,
                  Lisp_Misc_Any, Lisp_Misc_Type, Lisp_Float, Lisp_Cons, Lisp_Object, lispsym,
-                 make_float, circular_list, internal_equal, Fcons,
-                 CHECK_IMPURE, Qnil, Qt, Qnumberp, Qfloatp, Qstringp, Qsymbolp,
-                 Qnumber_or_marker_p, Qwholenump, Qvectorp, Qcharacterp, Qlistp, Qintegerp,
-                 Qconsp, SYMBOL_NAME, PseudovecType, EqualKind};
+                 make_float, circular_list, internal_equal, Fcons, CHECK_IMPURE, Qnil, Qt,
+                 Qnumberp, Qfloatp, Qstringp, Qsymbolp, Qnumber_or_marker_p, Qwholenump, Qvectorp,
+                 Qcharacterp, Qlistp, Qintegerp, Qconsp, SYMBOL_NAME, PseudovecType, EqualKind};
 
 // TODO: tweak Makefile to rebuild C files if this changes.
 
@@ -697,7 +696,9 @@ impl LispObject {
 
     pub fn any_to_float_or_error(self) -> EmacsDouble {
         self.as_float().unwrap_or_else(|| {
-            self.as_fixnum().unwrap_or_else(|| wrong_type!(Qnumberp, self)) as EmacsDouble
+            self.as_fixnum().unwrap_or_else(
+                || wrong_type!(Qnumberp, self),
+            ) as EmacsDouble
         })
     }
 }

--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -21,7 +21,7 @@ use marker::LispMarkerRef;
 use remacs_sys::{EmacsInt, EmacsUint, EmacsDouble, VALMASK, VALBITS, INTTYPEBITS, INTMASK,
                  USE_LSB_TAG, MOST_POSITIVE_FIXNUM, MOST_NEGATIVE_FIXNUM, Lisp_Type,
                  Lisp_Misc_Any, Lisp_Misc_Type, Lisp_Float, Lisp_Cons, Lisp_Object, lispsym,
-                 wrong_type_argument, make_float, circular_list, internal_equal, Fcons,
+                 make_float, circular_list, internal_equal, Fcons,
                  CHECK_IMPURE, Qnil, Qt, Qnumberp, Qfloatp, Qstringp, Qsymbolp,
                  Qnumber_or_marker_p, Qwholenump, Qvectorp, Qcharacterp, Qlistp, Qintegerp,
                  Qconsp, SYMBOL_NAME, PseudovecType, EqualKind};
@@ -100,17 +100,6 @@ impl LispObject {
     pub fn get_untaggedptr(self) -> *mut c_void {
         (self.to_raw() & VALMASK) as intptr_t as *mut c_void
     }
-
-    // Same as CHECK_TYPE macro,
-    // order of arguments changed
-    #[inline]
-    fn check_type_or_error(self, ok: bool, predicate: Lisp_Object) -> () {
-        if !ok {
-            unsafe {
-                wrong_type_argument(predicate, self.to_raw());
-            }
-        }
-    }
 }
 
 // Symbol support (LispType == Lisp_Symbol == 0)
@@ -121,7 +110,7 @@ impl LispObject {
     }
 
     #[inline]
-    pub fn as_symbol(&self) -> Option<LispSymbolRef> {
+    pub fn as_symbol(self) -> Option<LispSymbolRef> {
         if self.is_symbol() {
             Some(LispSymbolRef::new(
                 unsafe { mem::transmute(self.symbol_ptr_value()) },
@@ -132,11 +121,11 @@ impl LispObject {
     }
 
     #[inline]
-    pub fn as_symbol_or_error(&self) -> LispSymbolRef {
+    pub fn as_symbol_or_error(self) -> LispSymbolRef {
         if self.is_symbol() {
             LispSymbolRef::new(unsafe { mem::transmute(self.symbol_ptr_value()) })
         } else {
-            unsafe { wrong_type_argument(Qsymbolp, self.to_raw()) }
+            wrong_type!(Qsymbolp, self)
         }
     }
 
@@ -323,7 +312,7 @@ impl LispObject {
         if self.is_fixnum() {
             unsafe { self.to_fixnum_unchecked() }
         } else {
-            unsafe { wrong_type_argument(Qintegerp, self.to_raw()) }
+            wrong_type!(Qintegerp, self)
         }
     }
 
@@ -343,7 +332,7 @@ impl LispObject {
         if self.is_natnum() {
             unsafe { self.to_fixnum_unchecked() }
         } else {
-            unsafe { wrong_type_argument(Qwholenump, self.to_raw()) }
+            wrong_type!(Qwholenump, self)
         }
     }
 }
@@ -377,7 +366,7 @@ impl LispObject {
         if self.is_vectorlike() {
             LispVectorlikeRef::new(unsafe { mem::transmute(self.get_untaggedptr()) })
         } else {
-            unsafe { wrong_type_argument(Qvectorp, self.to_raw()) }
+            wrong_type!(Qvectorp, self)
         }
     }
 }
@@ -530,7 +519,7 @@ impl Iterator for TailsIter {
             None => {
                 if !self.safe {
                     if self.tail.is_not_nil() {
-                        unsafe { wrong_type_argument(Qlistp, self.list.to_raw()) }
+                        wrong_type!(Qlistp, self.list)
                     }
                 }
                 return None;
@@ -586,7 +575,7 @@ impl LispObject {
         if self.is_cons() {
             LispCons(self)
         } else {
-            unsafe { wrong_type_argument(Qconsp, self.to_raw()) }
+            wrong_type!(Qconsp, self)
         }
     }
 
@@ -695,7 +684,7 @@ impl LispObject {
         if self.is_float() {
             unsafe { self.get_float_data_unchecked() }
         } else {
-            unsafe { wrong_type_argument(Qfloatp, self.to_raw()) }
+            wrong_type!(Qfloatp, self)
         }
     }
 
@@ -708,9 +697,7 @@ impl LispObject {
 
     pub fn any_to_float_or_error(self) -> EmacsDouble {
         self.as_float().unwrap_or_else(|| {
-            self.as_fixnum().unwrap_or_else(|| unsafe {
-                wrong_type_argument(Qnumberp, self.to_raw())
-            }) as EmacsDouble
+            self.as_fixnum().unwrap_or_else(|| wrong_type!(Qnumberp, self)) as EmacsDouble
         })
     }
 }
@@ -739,7 +726,7 @@ impl LispObject {
         if self.is_string() {
             LispStringRef::new(unsafe { mem::transmute(self.get_untaggedptr()) })
         } else {
-            unsafe { wrong_type_argument(Qstringp, self.to_raw()) }
+            wrong_type!(Qstringp, self)
         }
     }
 }
@@ -764,7 +751,7 @@ impl LispObject {
         } else if let Some(f) = self.as_float() {
             LispNumber::Float(f)
         } else {
-            unsafe { wrong_type_argument(Qnumberp, self.to_raw()) }
+            wrong_type!(Qnumberp, self)
         }
     }
 
@@ -777,7 +764,7 @@ impl LispObject {
         } else if let Some(m) = self.as_marker() {
             LispNumber::Fixnum(m.position() as EmacsInt)
         } else {
-            unsafe { wrong_type_argument(Qnumber_or_marker_p, self.to_raw()) }
+            wrong_type!(Qnumber_or_marker_p, self)
         }
     }
 
@@ -822,8 +809,8 @@ impl LispObject {
     /// Similar to CHECK_CHARACTER
     #[inline]
     pub fn as_character_or_error(self) -> Codepoint {
-        unsafe {
-            self.check_type_or_error(self.is_character(), Qcharacterp);
+        if !self.is_character() {
+            wrong_type!(Qcharacterp, self)
         }
         self.as_fixnum().unwrap() as Codepoint
     }

--- a/rust_src/src/lists.rs
+++ b/rust_src/src/lists.rs
@@ -1,7 +1,7 @@
 //! Operations on lists.
 
 use lisp::{LispObject, LispCons};
-use remacs_sys::{wrong_type_argument, Qlistp, EmacsInt};
+use remacs_sys::{Qlistp, EmacsInt};
 use remacs_macros::lisp_fn;
 
 /// Return t if OBJECT is not a cons cell.  This includes nil.
@@ -102,7 +102,7 @@ fn nthcdr(n: LispObject, list: LispObject) -> LispObject {
         match tail.as_cons() {
             None => {
                 if tail.is_not_nil() {
-                    unsafe { wrong_type_argument(Qlistp, list.to_raw()) }
+                    wrong_type!(Qlistp, list)
                 }
                 return tail;
             }
@@ -329,7 +329,7 @@ where
                     // need an extra call to CHECK_LIST_END here to catch odd-length lists
                     // (like Emacs we signal the somewhat confusing `wrong-type-argument')
                     if tail.as_obj().is_not_nil() {
-                        unsafe { wrong_type_argument(Qlistp, plist.to_raw()) }
+                        wrong_type!(Qlistp, plist)
                     }
                     break;
                 }
@@ -401,7 +401,7 @@ fn put(symbol: LispObject, propname: LispObject, value: LispObject) -> LispObjec
 /// Any number of arguments, even zero arguments, are allowed.
 /// usage: (list &rest OBJECTS)
 #[lisp_fn]
-fn list(args: &mut [LispObject]) -> LispObject {
+pub fn list(args: &mut [LispObject]) -> LispObject {
     args.iter().rev().fold(
         LispObject::constant_nil(),
         |list, &arg| LispObject::cons(arg, list),

--- a/rust_src/src/lists.rs
+++ b/rust_src/src/lists.rs
@@ -1,7 +1,7 @@
 //! Operations on lists.
 
 use lisp::{LispObject, LispCons};
-use remacs_sys::{wrong_type_argument, Qlistp, EmacsInt, call2};
+use remacs_sys::{wrong_type_argument, Qlistp, EmacsInt};
 use remacs_macros::lisp_fn;
 
 /// Return t if OBJECT is not a cons cell.  This includes nil.
@@ -186,8 +186,7 @@ pub fn assoc(key: LispObject, list: LispObject, testfn: LispObject) -> LispObjec
             let is_equal = if testfn.is_nil() {
                 key.eq(item_cons.car()) || key.equal(item_cons.car())
             } else {
-                let res = unsafe { call2(testfn.to_raw(), key.to_raw(), item_cons.car().to_raw()) };
-                LispObject::from_raw(res).is_not_nil()
+                call!(testfn, key, item_cons.car()).is_not_nil()
             };
             if is_equal {
                 return item;
@@ -446,8 +445,7 @@ pub fn sort_list(list: LispObject, pred: LispObject) -> LispObject {
 
 // also needed by vectors.rs
 pub fn inorder(pred: LispObject, a: LispObject, b: LispObject) -> bool {
-    let res = unsafe { call2(pred.to_raw(), b.to_raw(), a.to_raw()) };
-    LispObject::from_raw(res).is_nil()
+    call!(pred, b, a).is_nil()
 }
 
 /// Merge step of linked-list sorting.

--- a/rust_src/src/marker.rs
+++ b/rust_src/src/marker.rs
@@ -1,7 +1,7 @@
 use libc::ptrdiff_t;
 
 use lisp::{LispObject, ExternalPtr};
-use remacs_sys::{error, Lisp_Marker};
+use remacs_sys::Lisp_Marker;
 use remacs_macros::lisp_fn;
 
 pub type LispMarkerRef = ExternalPtr<Lisp_Marker>;
@@ -11,9 +11,7 @@ impl LispMarkerRef {
     pub fn position(self) -> ptrdiff_t {
         let buf = self.buffer;
         if buf.is_null() {
-            unsafe {
-                error("Marker does not point anywhere\0".as_ptr());
-            }
+            error!("Marker does not point anywhere");
         }
 
         // TODO: add assertions that marker_position in marker.c has.

--- a/rust_src/src/math.rs
+++ b/rust_src/src/math.rs
@@ -2,8 +2,7 @@
 
 use floatfns;
 use lisp::{LispObject, LispNumber};
-use eval::xsignal0;
-use remacs_sys::{EmacsInt, Qarith_error, Qnumberp, wrong_type_argument};
+use remacs_sys::{EmacsInt, Qarith_error, Qnumberp};
 use remacs_macros::lisp_fn;
 
 /// Return X modulo Y.
@@ -18,9 +17,7 @@ fn lisp_mod(x: LispObject, y: LispObject) -> LispObject {
     ) {
         (LispNumber::Fixnum(mut i1), LispNumber::Fixnum(i2)) => {
             if i2 == 0 {
-                unsafe {
-                    xsignal0(LispObject::from_raw(Qarith_error));
-                }
+                xsignal!(Qarith_error);
             }
 
             i1 %= i2;
@@ -114,9 +111,7 @@ fn arith_driver(code: ArithOp, args: &[LispObject]) -> LispObject {
                             accum = next;
                         } else {
                             if next == 0 {
-                                unsafe {
-                                    xsignal0(LispObject::from_raw(Qarith_error));
-                                }
+                                xsignal!(Qarith_error);
                             }
                             if accum.checked_div(next).is_none() {
                                 overflow = true;
@@ -248,9 +243,7 @@ fn abs(arg: LispObject) -> LispObject {
     } else if let Some(n) = arg.as_fixnum() {
         LispObject::from_fixnum(n.abs())
     } else {
-        unsafe {
-            wrong_type_argument(Qnumberp, arg.to_raw());
-        }
+        wrong_type!(Qnumberp, arg);
     }
 }
 

--- a/rust_src/src/multibyte.rs
+++ b/rust_src/src/multibyte.rs
@@ -38,7 +38,7 @@ use libc::{ptrdiff_t, c_char, c_uchar, c_uint, c_int};
 
 use lisp::ExternalPtr;
 use remacs_sys::{CHAR_MODIFIER_MASK, CHAR_SHIFT, CHAR_CTL, emacs_abort, CHARACTERBITS, EmacsInt,
-                 Lisp_String, error};
+                 Lisp_String};
 
 pub type LispStringRef = ExternalPtr<Lisp_String>;
 
@@ -160,7 +160,7 @@ impl LispStringRef {
 }
 
 fn string_overflow() -> ! {
-    unsafe { error("Maximum string size exceeded\0".as_ptr()) }
+    error!("Maximum string size exceeded")
 }
 
 /// Parse unibyte string at STR of LEN bytes, and return the number of
@@ -257,7 +257,7 @@ fn write_codepoint(to: &mut [c_uchar], cp: Codepoint) -> usize {
         to[0] = 0xC0 | ((b >> 6) & 1);
         2
     } else {
-        unsafe { error("Invalid character: %x\0".as_ptr(), cp) }
+        error!("Invalid character: {:#x}", cp)
     }
 }
 

--- a/rust_src/src/strings.rs
+++ b/rust_src/src/strings.rs
@@ -122,9 +122,7 @@ fn string_to_unibyte(string: LispObject) -> LispObject {
             error!("Can't convert {}th character to unibyte", converted_size);
         }
 
-        let raw_ptr = unsafe {
-            make_unibyte_string(buffer.as_ptr() as *const libc::c_char, size)
-        };
+        let raw_ptr = unsafe { make_unibyte_string(buffer.as_ptr() as *const libc::c_char, size) };
         LispObject::from_raw(raw_ptr)
     } else {
         string

--- a/rust_src/src/strings.rs
+++ b/rust_src/src/strings.rs
@@ -6,7 +6,7 @@ use libc::{self, c_void};
 
 use lisp::LispObject;
 use multibyte;
-use remacs_sys::{SYMBOL_NAME, EmacsInt, error, make_unibyte_string, make_uninit_multibyte_string,
+use remacs_sys::{SYMBOL_NAME, EmacsInt, make_unibyte_string, make_uninit_multibyte_string,
                  string_to_multibyte as c_string_to_multibyte};
 use remacs_macros::lisp_fn;
 
@@ -118,17 +118,14 @@ fn string_to_unibyte(string: LispObject) -> LispObject {
         let converted_size =
             multibyte::str_to_unibyte(lispstr.const_data_ptr(), buffer.as_mut_ptr(), size);
 
-        unsafe {
-            if converted_size < size {
-                error(
-                    "Can't convert %ldth character to unibyte\0".as_ptr(),
-                    converted_size,
-                );
-            }
-
-            let raw_ptr = make_unibyte_string(buffer.as_ptr() as *const libc::c_char, size);
-            LispObject::from_raw(raw_ptr)
+        if converted_size < size {
+            error!("Can't convert {}th character to unibyte", converted_size);
         }
+
+        let raw_ptr = unsafe {
+            make_unibyte_string(buffer.as_ptr() as *const libc::c_char, size)
+        };
+        LispObject::from_raw(raw_ptr)
     } else {
         string
     }

--- a/rust_src/src/vectors.rs
+++ b/rust_src/src/vectors.rs
@@ -12,9 +12,9 @@ use multibyte::MAX_CHAR;
 use lists::{sort_list, inorder};
 use buffers::LispBufferRef;
 use windows::LispWindowRef;
-use remacs_sys::{Qsequencep, EmacsInt, PSEUDOVECTOR_FLAG,
-                 PVEC_TYPE_MASK, PSEUDOVECTOR_AREA_BITS, PSEUDOVECTOR_SIZE_MASK, PseudovecType,
-                 Lisp_Vectorlike, Lisp_Vector, Lisp_Bool_Vector, MOST_POSITIVE_FIXNUM};
+use remacs_sys::{Qsequencep, EmacsInt, PSEUDOVECTOR_FLAG, PVEC_TYPE_MASK, PSEUDOVECTOR_AREA_BITS,
+                 PSEUDOVECTOR_SIZE_MASK, PseudovecType, Lisp_Vectorlike, Lisp_Vector,
+                 Lisp_Bool_Vector, MOST_POSITIVE_FIXNUM};
 use remacs_macros::lisp_fn;
 
 pub type LispVectorlikeRef = ExternalPtr<Lisp_Vectorlike>;

--- a/rust_src/src/vectors.rs
+++ b/rust_src/src/vectors.rs
@@ -127,7 +127,7 @@ impl LispBoolVecRef {
 /// the number of bytes in the string; it is the number of characters.
 /// To get the number of bytes, use `string-bytes'.
 #[lisp_fn]
-fn length(sequence: LispObject) -> LispObject {
+pub fn length(sequence: LispObject) -> LispObject {
     if let Some(s) = sequence.as_string() {
         return LispObject::from_natnum(s.len_chars() as EmacsInt);
     } else if let Some(vl) = sequence.as_vectorlike() {

--- a/rust_src/src/vectors.rs
+++ b/rust_src/src/vectors.rs
@@ -12,7 +12,7 @@ use multibyte::MAX_CHAR;
 use lists::{sort_list, inorder};
 use buffers::LispBufferRef;
 use windows::LispWindowRef;
-use remacs_sys::{Qsequencep, EmacsInt, wrong_type_argument, error, PSEUDOVECTOR_FLAG,
+use remacs_sys::{Qsequencep, EmacsInt, PSEUDOVECTOR_FLAG,
                  PVEC_TYPE_MASK, PSEUDOVECTOR_AREA_BITS, PSEUDOVECTOR_SIZE_MASK, PseudovecType,
                  Lisp_Vectorlike, Lisp_Vector, Lisp_Bool_Vector, MOST_POSITIVE_FIXNUM};
 use remacs_macros::lisp_fn;
@@ -145,15 +145,13 @@ pub fn length(sequence: LispObject) -> LispObject {
     } else if let Some(_) = sequence.as_cons() {
         let len = sequence.iter_tails().count();
         if len > MOST_POSITIVE_FIXNUM as usize {
-            unsafe {
-                error("List too long\0".as_ptr());
-            }
+            error!("List too long");
         }
         return LispObject::from_natnum(len as EmacsInt);
     } else if sequence.is_nil() {
         return LispObject::from_natnum(0);
     }
-    unsafe { wrong_type_argument(Qsequencep, sequence.to_raw()) }
+    wrong_type!(Qsequencep, sequence)
 }
 
 /// Sort SEQ, stably, comparing elements using PREDICATE.
@@ -183,7 +181,7 @@ fn sort(seq: LispObject, predicate: LispObject) -> LispObject {
     } else if seq.is_nil() {
         seq
     } else {
-        unsafe { wrong_type_argument(Qsequencep, seq.to_raw()) }
+        wrong_type!(Qsequencep, seq)
     }
 }
 


### PR DESCRIPTION
Vararg constructs in C should be replaced by macros, such as `error(fmt, ...)` which now uses Rust's formatting machinery.

Multitudes of functions with the same purpose like `xsignalN` and `callN` can also be replaced by macros on the Rust side.