### PR TITLE
Add LispObarrayRef and port intern functions to Rust

### DIFF
--- a/rust_src/remacs-sys/lib.rs
+++ b/rust_src/remacs-sys/lib.rs
@@ -1352,6 +1352,7 @@ extern "C" {
     pub fn Ffind_operation_coding_system(nargs: ptrdiff_t, args: *mut Lisp_Object) -> Lisp_Object;
     pub fn Flocal_variable_p(variable: Lisp_Object, buffer: Lisp_Object) -> Lisp_Object;
     pub fn Ffuncall(nargs: ptrdiff_t, args: *mut Lisp_Object) -> Lisp_Object;
+    pub fn Fpurecopy(string: Lisp_Object) -> Lisp_Object;
 
     pub fn make_float(float_value: c_double) -> Lisp_Object;
     pub fn make_string(s: *const c_char, length: ptrdiff_t) -> Lisp_Object;
@@ -1397,7 +1398,19 @@ extern "C" {
         props: bool,
     ) -> Lisp_Object;
 
-    pub fn intern_1(s: *const c_char, length: ptrdiff_t) -> Lisp_Object;
+    pub fn check_obarray(obarray: Lisp_Object) -> Lisp_Object;
+    pub fn check_vobarray() -> Lisp_Object;
+    pub fn intern_driver(
+        string: Lisp_Object,
+        obarray: Lisp_Object,
+        index: Lisp_Object,
+    ) -> Lisp_Object;
+    pub fn oblookup(
+        obarray: Lisp_Object,
+        s: *const c_char,
+        size: ptrdiff_t,
+        size_bytes: ptrdiff_t,
+    ) -> Lisp_Object;
 
     pub fn SYMBOL_NAME(s: Lisp_Object) -> Lisp_Object;
     pub fn CHECK_IMPURE(obj: Lisp_Object, ptr: *const c_void);

--- a/rust_src/remacs-sys/lib.rs
+++ b/rust_src/remacs-sys/lib.rs
@@ -1316,6 +1316,7 @@ extern "C" {
     pub static Qframe: Lisp_Object;
     pub static Qvector: Lisp_Object;
     pub static Qchar_table: Lisp_Object;
+    pub static Qcategory_table: Lisp_Object;
     pub static Qbool_vector: Lisp_Object;
     pub static Qhash_table: Lisp_Object;
     pub static Qthread: Lisp_Object;

--- a/rust_src/src/category.rs
+++ b/rust_src/src/category.rs
@@ -1,0 +1,22 @@
+//! Routines to deal with category tables.
+
+use remacs_macros::lisp_fn;
+use remacs_sys::Qcategory_table;
+use lisp::LispObject;
+use threads::ThreadState;
+
+/// Return t if ARG is a category table.
+#[lisp_fn]
+fn category_table_p(arg: LispObject) -> LispObject {
+    LispObject::from_bool(arg.as_char_table().map_or(false, |table| {
+        LispObject::from_raw(table.purpose).eq(unsafe { LispObject::from_raw(Qcategory_table) })
+    }))
+}
+
+/// Return the current category table.
+/// This is the one specified by the current buffer.
+#[lisp_fn]
+fn category_table() -> LispObject {
+    let buffer_ref = ThreadState::current_buffer();
+    LispObject::from_raw(buffer_ref.category_table)
+}

--- a/rust_src/src/fonts.rs
+++ b/rust_src/src/fonts.rs
@@ -1,7 +1,7 @@
 use remacs_macros::lisp_fn;
 use remacs_sys::{font, Qfont_spec, Qfont_entity, Qfont_object};
 use lisp::LispObject;
-use symbols::intern;
+use lisp::intern;
 use vectors::LispVectorlikeRef;
 
 // A font is not a type in and of itself, it's just a group of three kinds of

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -48,6 +48,7 @@ mod process;
 mod fonts;
 mod threads;
 mod chartable;
+mod category;
 
 #[cfg(all(not(test), target_os = "macos"))]
 use alloc_unexecmacosx::OsxUnexecAlloc;
@@ -125,6 +126,9 @@ pub use buffers::Fcurrent_buffer;
 
 // used in chartab.c
 pub use chartable::Fset_char_table_parent;
+
+// used in category.c
+pub use category::Fcategory_table_p;
 
 // Used in process.c
 pub use str2sig::str2sig;
@@ -264,6 +268,8 @@ pub extern "C" fn rust_init_syms() {
         defsubr(&*chartable::Schar_table_subtype);
         defsubr(&*chartable::Schar_table_parent);
         defsubr(&*chartable::Sset_char_table_parent);
+        defsubr(&*category::Scategory_table_p);
+        defsubr(&*category::Scategory_table);
 
         defsubr(&*floatfns::Sisnan);
         defsubr(&*floatfns::Sacos);

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -49,6 +49,7 @@ mod fonts;
 mod threads;
 mod chartable;
 mod category;
+mod obarray;
 
 #[cfg(all(not(test), target_os = "macos"))]
 use alloc_unexecmacosx::OsxUnexecAlloc;
@@ -123,6 +124,9 @@ pub use vectors::Fsort;
 pub use lists::merge;
 pub use buffers::Fget_buffer;
 pub use buffers::Fcurrent_buffer;
+pub use obarray::intern_1;
+pub use obarray::Fintern;
+pub use obarray::Fintern_soft;
 
 // used in chartab.c
 pub use chartable::Fset_char_table_parent;
@@ -270,6 +274,8 @@ pub extern "C" fn rust_init_syms() {
         defsubr(&*chartable::Sset_char_table_parent);
         defsubr(&*category::Scategory_table_p);
         defsubr(&*category::Scategory_table);
+        defsubr(&*obarray::Sintern_soft);
+        defsubr(&*obarray::Sintern);
 
         defsubr(&*floatfns::Sisnan);
         defsubr(&*floatfns::Sacos);

--- a/rust_src/src/obarray.rs
+++ b/rust_src/src/obarray.rs
@@ -1,0 +1,148 @@
+use libc;
+use remacs_macros::lisp_fn;
+use lisp::LispObject;
+use remacs_sys::{Lisp_Object, check_obarray, check_vobarray, Fpurecopy, globals, intern_driver,
+                 make_unibyte_string, oblookup};
+
+/// A lisp object containing an `obarray`.
+pub struct LispObarrayRef(LispObject);
+
+impl LispObarrayRef {
+    /// Return a reference to the Lisp variable `obarray`.
+    pub fn constant_obarray() -> LispObarrayRef {
+        LispObarrayRef(LispObject::from_raw(unsafe { check_vobarray() }))
+    }
+
+    /// Return a reference corresponding to OBJECT, or raise an error if it is
+    /// not a `LispObarrayRef`.
+    ///
+    /// # C Porting Notes
+    ///
+    /// This is a wrapper around the C function `check_obarray` instead of a
+    /// translation, so that fatal errors are handled in the same fashion.
+    pub fn from_object_or_error(object: LispObject) -> LispObarrayRef {
+        LispObarrayRef(LispObject::from_raw(
+            unsafe { check_obarray(object.to_raw()) },
+        ))
+    }
+
+    /// Return the symbol that matches C string S, of length LEN. If there is no
+    /// such symbol, return the integer bucket number of where the symbol would
+    /// be if it were present.
+    ///
+    /// # C Porting Notes
+    ///
+    /// This is a wrapper around the C function `oblookup`. It uses LEN as both
+    /// the byte and char length, i.e. S is treated as a unibyte string.
+    pub fn lookup_cstring(&self, s: *const libc::c_char, len: libc::ptrdiff_t) -> LispObject {
+        LispObject::from_raw(unsafe { oblookup(self.0.to_raw(), s, len, len) })
+    }
+
+    /// Intern the C string S, of length LEN. That is, return the new or
+    /// existing symbol with that name in this `LispObarrayRef`.
+    ///
+    /// # C Porting Notes
+    ///
+    /// This is makes use of the C function `intern_driver`. It uses LEN as both
+    /// the byte and char length, i.e. S is treated as a unibyte string.
+    pub fn intern_cstring(&mut self, s: *const libc::c_char, len: libc::ptrdiff_t) -> LispObject {
+        let tem = self.lookup_cstring(s, len);
+        if tem.is_symbol() {
+            tem
+        } else {
+            // The above `oblookup' was done on the basis of nchars==nbytes, so
+            // the string has to be unibyte.
+            LispObject::from_raw(unsafe {
+                intern_driver(make_unibyte_string(s, len), self.0.to_raw(), tem.to_raw())
+            })
+        }
+    }
+
+    /// Return the symbol that matches NAME (either a symbol or string). If
+    /// there is no such symbol, return the integer bucket number of where the
+    /// symbol would be if it were present.
+    ///
+    /// # C Porting Notes
+    ///
+    /// This is a wrapper around the C function `oblookup`. It is capable of
+    /// handling multibyte strings, unlike intern_1 and friends.
+    pub fn lookup(&self, name: LispObject) -> LispObject {
+        let string = name.symbol_or_string_as_string();
+        LispObject::from_raw(unsafe {
+            oblookup(
+                self.0.to_raw(),
+                string.const_sdata_ptr(),
+                string.len_chars(),
+                string.len_bytes(),
+            )
+        })
+    }
+
+    /// Intern the string or symbol STRING. That is, return the new or existing
+    /// symbol with that name in this `LispObarrayRef`. If Emacs is loading Lisp
+    /// code to dump to an executable (ie. `purify-flag` is `t`), the symbol
+    /// name will be transferred to pure storage.
+    ///
+    /// # C Porting Notes
+    ///
+    /// This is makes use of the C function `intern_driver`. It is capable of
+    /// handling multibyte strings, unlike `intern_cstring`.
+    pub fn intern(&mut self, string: LispObject) -> LispObject {
+        let tem = self.lookup(string);
+        if tem.is_symbol() {
+            tem
+        } else if LispObject::from_raw(unsafe { globals.f_Vpurify_flag }).is_not_nil() {
+            // When Emacs is running lisp code to dump to an executable, make
+            // use of pure storage.
+            LispObject::from_raw(unsafe {
+                intern_driver(Fpurecopy(string.to_raw()), self.0.to_raw(), tem.to_raw())
+            })
+        } else {
+            LispObject::from_raw(unsafe {
+                intern_driver(string.to_raw(), self.0.to_raw(), tem.to_raw())
+            })
+        }
+    }
+}
+
+/// Intern the C string `s`: return a symbol with that name, interned in the
+/// current obarray.
+#[no_mangle]
+pub extern "C" fn intern_1(s: *const libc::c_char, len: libc::ptrdiff_t) -> Lisp_Object {
+    LispObarrayRef::constant_obarray()
+        .intern_cstring(s, len)
+        .to_raw()
+}
+
+/// Return the canonical symbol named NAME, or nil if none exists.
+/// NAME may be a string or a symbol.  If it is a symbol, that exact
+/// symbol is searched for.
+/// A second optional argument specifies the obarray to use;
+/// it defaults to the value of `obarray'.
+#[lisp_fn(min = "1")]
+fn intern_soft(name: LispObject, obarray: LispObject) -> LispObject {
+    let tem = if obarray.is_nil() {
+        LispObarrayRef::constant_obarray().lookup(name)
+    } else {
+        LispObarrayRef::from_object_or_error(obarray).lookup(name)
+    };
+
+    if tem.is_integer() || (name.is_symbol() && !name.eq(tem)) {
+        LispObject::constant_nil()
+    } else {
+        tem
+    }
+}
+
+/// Return the canonical symbol whose name is STRING.
+/// If there is none, one is created by this function and returned.
+/// A second optional argument specifies the obarray to use;
+/// it defaults to the value of `obarray'.
+#[lisp_fn(min = "1")]
+fn intern(string: LispObject, obarray: LispObject) -> LispObject {
+    if obarray.is_nil() {
+        LispObarrayRef::constant_obarray().intern(string)
+    } else {
+        LispObarrayRef::from_object_or_error(obarray).intern(string)
+    }
+}

--- a/rust_src/src/symbols.rs
+++ b/rust_src/src/symbols.rs
@@ -1,7 +1,6 @@
-use libc;
 use remacs_macros::lisp_fn;
 use lisp::{LispObject, ExternalPtr};
-use remacs_sys::{Lisp_Symbol, intern_1};
+use remacs_sys::Lisp_Symbol;
 
 pub type LispSymbolRef = ExternalPtr<Lisp_Symbol>;
 
@@ -58,16 +57,4 @@ fn symbol_function(object: LispObject) -> LispObject {
 #[lisp_fn]
 fn symbol_plist(object: LispObject) -> LispObject {
     object.as_symbol_or_error().get_plist()
-}
-
-/// Intern (e.g. create a symbol from) a string.
-#[allow(dead_code)]
-pub fn intern<T: AsRef<str>>(string: T) -> LispObject {
-    let s = string.as_ref();
-    LispObject::from_raw(unsafe {
-        intern_1(
-            s.as_ptr() as *const libc::c_char,
-            s.len() as libc::ptrdiff_t,
-        )
-    })
 }

--- a/src/category.c
+++ b/src/category.c
@@ -173,16 +173,6 @@ it defaults to the current buffer's category table.  */)
 
 /* Category-table staff.  */
 
-DEFUN ("category-table-p", Fcategory_table_p, Scategory_table_p, 1, 1, 0,
-       doc: /* Return t if ARG is a category table.  */)
-  (Lisp_Object arg)
-{
-  if (CHAR_TABLE_P (arg)
-      && EQ (XCHAR_TABLE (arg)->purpose, Qcategory_table))
-    return Qt;
-  return Qnil;
-}
-
 /* If TABLE is nil, return the current category table.  If TABLE is
    not nil, check the validity of TABLE as a category table.  If
    valid, return TABLE itself, but if not valid, signal an error of
@@ -195,14 +185,6 @@ check_category_table (Lisp_Object table)
     return BVAR (current_buffer, category_table);
   CHECK_TYPE (!NILP (Fcategory_table_p (table)), Qcategory_table_p, table);
   return table;
-}
-
-DEFUN ("category-table", Fcategory_table, Scategory_table, 0, 0, 0,
-       doc: /* Return the current category table.
-This is the one specified by the current buffer.  */)
-  (void)
-{
-  return BVAR (current_buffer, category_table);
 }
 
 DEFUN ("standard-category-table", Fstandard_category_table,
@@ -504,8 +486,6 @@ See the documentation of the variable `word-combining-categories'.  */);
   defsubr (&Sdefine_category);
   defsubr (&Scategory_docstring);
   defsubr (&Sget_unused_category);
-  defsubr (&Scategory_table_p);
-  defsubr (&Scategory_table);
   defsubr (&Sstandard_category_table);
   defsubr (&Scopy_category_table);
   defsubr (&Smake_category_table);

--- a/src/lisp.h
+++ b/src/lisp.h
@@ -3738,6 +3738,7 @@ extern ptrdiff_t evxprintf (char **, ptrdiff_t *, char const *, ptrdiff_t,
 
 /* Defined in lread.c.  */
 extern Lisp_Object check_obarray (Lisp_Object);
+extern Lisp_Object check_vobarray (void);
 extern Lisp_Object intern_1 (const char *, ptrdiff_t);
 extern Lisp_Object intern_c_string_1 (const char *, ptrdiff_t);
 extern Lisp_Object intern_driver (Lisp_Object, Lisp_Object, Lisp_Object);

--- a/src/lread.c
+++ b/src/lread.c
@@ -4009,6 +4009,14 @@ check_obarray (Lisp_Object obarray)
   return obarray;
 }
 
+/* Like check_obarray, but for the global Vobarray. */
+
+Lisp_Object
+check_vobarray(void)
+{
+  return check_obarray (Vobarray);
+}
+
 /* Intern symbol SYM in OBARRAY using bucket INDEX.  */
 
 static Lisp_Object
@@ -4045,19 +4053,6 @@ intern_driver (Lisp_Object string, Lisp_Object obarray, Lisp_Object index)
    interned in the current obarray.  */
 
 Lisp_Object
-intern_1 (const char *str, ptrdiff_t len)
-{
-  Lisp_Object obarray = check_obarray (Vobarray);
-  Lisp_Object tem = oblookup (obarray, str, len, len);
-
-  return (SYMBOLP (tem) ? tem
-	  /* The above `oblookup' was done on the basis of nchars==nbytes, so
-	     the string has to be unibyte.  */
-	  : intern_driver (make_unibyte_string (str, len),
-			   obarray, tem));
-}
-
-Lisp_Object
 intern_c_string_1 (const char *str, ptrdiff_t len)
 {
   Lisp_Object obarray = check_obarray (Vobarray);
@@ -4089,53 +4084,7 @@ define_symbol (Lisp_Object sym, char const *str)
       intern_sym (sym, initial_obarray, bucket);
     }
 }
-
-DEFUN ("intern", Fintern, Sintern, 1, 2, 0,
-       doc: /* Return the canonical symbol whose name is STRING.
-If there is none, one is created by this function and returned.
-A second optional argument specifies the obarray to use;
-it defaults to the value of `obarray'.  */)
-  (Lisp_Object string, Lisp_Object obarray)
-{
-  Lisp_Object tem;
 
-  obarray = check_obarray (NILP (obarray) ? Vobarray : obarray);
-  CHECK_STRING (string);
-
-  tem = oblookup (obarray, SSDATA (string), SCHARS (string), SBYTES (string));
-  if (!SYMBOLP (tem))
-    tem = intern_driver (NILP (Vpurify_flag) ? string : Fpurecopy (string),
-			 obarray, tem);
-  return tem;
-}
-
-DEFUN ("intern-soft", Fintern_soft, Sintern_soft, 1, 2, 0,
-       doc: /* Return the canonical symbol named NAME, or nil if none exists.
-NAME may be a string or a symbol.  If it is a symbol, that exact
-symbol is searched for.
-A second optional argument specifies the obarray to use;
-it defaults to the value of `obarray'.  */)
-  (Lisp_Object name, Lisp_Object obarray)
-{
-  register Lisp_Object tem, string;
-
-  if (NILP (obarray)) obarray = Vobarray;
-  obarray = check_obarray (obarray);
-
-  if (!SYMBOLP (name))
-    {
-      CHECK_STRING (name);
-      string = name;
-    }
-  else
-    string = SYMBOL_NAME (name);
-
-  tem = oblookup (obarray, SSDATA (string), SCHARS (string), SBYTES (string));
-  if (INTEGERP (tem) || (SYMBOLP (name) && !EQ (name, tem)))
-    return Qnil;
-  else
-    return tem;
-}
 
 DEFUN ("unintern", Funintern, Sunintern, 1, 2, 0,
        doc: /* Delete the symbol named NAME, if any, from OBARRAY.
@@ -4719,8 +4668,6 @@ syms_of_lread (void)
   defsubr (&Sread);
   defsubr (&Sread_from_string);
   defsubr (&Slread__substitute_object_in_subtree);
-  defsubr (&Sintern);
-  defsubr (&Sintern_soft);
   defsubr (&Sunintern);
   defsubr (&Sget_load_suffixes);
   defsubr (&Sload);


### PR DESCRIPTION
This PR ports a chunk of the obarray-related code from `lread.c` to Rust, including the lisp functions `intern` and `intern-soft`. I had to add some extern functions to the C code in order to get access to some global state.