### PR TITLE
Fix for build being broken due to bad call to wrong_type_argument. 

### DIFF
--- a/rust_src/src/fonts.rs
+++ b/rust_src/src/fonts.rs
@@ -1,5 +1,5 @@
 use remacs_macros::lisp_fn;
-use remacs_sys::{font, Qfont_spec, Qfont_entity, Qfont_object, wrong_type_argument};
+use remacs_sys::{font, Qfont_spec, Qfont_entity, Qfont_object};
 use lisp::LispObject;
 use symbols::intern;
 use vectors::LispVectorlikeRef;
@@ -35,6 +35,8 @@ pub enum FontExtraType {
 }
 
 impl FontExtraType {
+    // Needed for wrong_type! that is using a safe predicate. This may change in the future.
+    #[allow(unused_unsafe)]
     pub fn from_symbol_or_error(extra_type: LispObject) -> FontExtraType {
         if extra_type.eq(LispObject::from_raw(unsafe { Qfont_spec })) {
             FontExtraType::Spec
@@ -43,7 +45,7 @@ impl FontExtraType {
         } else if extra_type.eq(LispObject::from_raw(unsafe { Qfont_object })) {
             FontExtraType::Object
         } else {
-            unsafe { wrong_type_argument(intern("font-extra-type").to_raw(), extra_type.to_raw()) }
+            wrong_type!(intern("font-extra-type").to_raw(), extra_type);
         }
     }
 }


### PR DESCRIPTION
Looks like we merged two PRs around the same time, and missed a call to wrong_type_argument. This PR corrects that.

I had to add an #[allow(unused_unsafe)] to from_symbol_or_error, since this call to wrong_type_argument doesn't have an unsafe predicate. We could try and work around this with macro magic, or traits, but I figured this was the easiest way for now since 99% of the uses cases need that unsafe block. 