### PR TITLE
fix 32-bit arm compilation

### DIFF
--- a/rust_src/src/crypto/mod.rs
+++ b/rust_src/src/crypto/mod.rs
@@ -394,7 +394,7 @@ fn _secure_hash(algorithm: HashAlg, input: &[u8], hex: bool) -> LispObject {
     } else {
         digest_size as EmacsInt
     };
-    let digest = LispObject::from_raw(unsafe { make_uninit_string(buffer_size as i64) });
+    let digest = LispObject::from_raw(unsafe { make_uninit_string(buffer_size as EmacsInt) });
     let digest_str = digest.as_string_or_error();
     hash_func(input, digest_str.as_mut_slice());
     if hex {

--- a/rust_src/src/eval.rs
+++ b/rust_src/src/eval.rs
@@ -54,7 +54,7 @@ macro_rules! call {
 macro_rules! error {
     ($str:expr) => {{
         let strobj = unsafe {
-            ::remacs_sys::make_string($str.as_ptr() as *const i8,
+            ::remacs_sys::make_string($str.as_ptr() as *const ::libc::c_char,
                                       $str.len() as ::libc::ptrdiff_t)
         };
         xsignal!(::remacs_sys::Qerror, $crate::lisp::LispObject::from_raw(strobj));
@@ -62,7 +62,7 @@ macro_rules! error {
     ($fmtstr:expr, $($arg:expr),*) => {{
         let formatted = format!($fmtstr, $($arg),*);
         let strobj = unsafe {
-            ::remacs_sys::make_string(formatted.as_ptr() as *const i8,
+            ::remacs_sys::make_string(formatted.as_ptr() as *const ::libc::c_char,
                                       formatted.len() as ::libc::ptrdiff_t)
         };
         xsignal!(::remacs_sys::Qerror, $crate::lisp::LispObject::from_raw(strobj));

--- a/rust_src/src/fonts.rs
+++ b/rust_src/src/fonts.rs
@@ -1,5 +1,5 @@
 use remacs_macros::lisp_fn;
-use remacs_sys::{font, Qfont_spec, Qfont_entity, Qfont_object};
+use remacs_sys::{font, EmacsInt, Qfont_spec, Qfont_entity, Qfont_object};
 use lisp::LispObject;
 use lisp::intern;
 use vectors::LispVectorlikeRef;
@@ -16,15 +16,15 @@ impl LispFontRef {
     }
 
     pub fn is_font_spec(self) -> bool {
-        self.0.pseudovector_size() == font::FONT_SPEC_MAX as i64
+        self.0.pseudovector_size() == font::FONT_SPEC_MAX as EmacsInt
     }
 
     pub fn is_font_entity(self) -> bool {
-        self.0.pseudovector_size() == font::FONT_ENTITY_MAX as i64
+        self.0.pseudovector_size() == font::FONT_ENTITY_MAX as EmacsInt
     }
 
     pub fn is_font_object(self) -> bool {
-        self.0.pseudovector_size() == font::FONT_OBJECT_MAX as i64
+        self.0.pseudovector_size() == font::FONT_OBJECT_MAX as EmacsInt
     }
 }
 


### PR DESCRIPTION
libc's underlying type differs between x86-64 (i8) and arm (u8).