### PR TITLE
Translate validate_region

### DIFF
--- a/rust_src/src/buffers.rs
+++ b/rust_src/src/buffers.rs
@@ -3,10 +3,12 @@
 use libc::{c_void, c_uchar, ptrdiff_t};
 
 use lisp::{LispObject, ExternalPtr};
-use remacs_sys::{Lisp_Buffer, Lisp_Type, Vbuffer_alist, EmacsInt, make_lisp_ptr};
+use remacs_sys::{Lisp_Object, EmacsInt, Lisp_Buffer, Lisp_Type, Vbuffer_alist, make_lisp_ptr};
 use strings::string_equal;
 use lists::{car, cdr};
 use threads::ThreadState;
+
+use std::mem;
 
 use remacs_macros::lisp_fn;
 
@@ -210,4 +212,30 @@ fn buffer_modified_tick(buffer: LispObject) -> LispObject {
 #[lisp_fn(min = "0")]
 fn buffer_chars_modified_tick(buffer: LispObject) -> LispObject {
     LispObject::from_fixnum(buffer.as_buffer_or_current_buffer().chars_modiff())
+}
+
+#[no_mangle]
+pub extern "C" fn validate_region(b: *mut Lisp_Object, e: *mut Lisp_Object) {
+    let start = LispObject::from_raw(unsafe { *b });
+    let stop = LispObject::from_raw(unsafe { *e });
+
+    let mut beg = start.as_fixnum_coerce_marker_or_error();
+    let mut end = stop.as_fixnum_coerce_marker_or_error();
+
+    if beg > end {
+        mem::swap(&mut beg, &mut end);
+    }
+
+    unsafe {
+        *b = LispObject::from_fixnum(beg).to_raw();
+        *e = LispObject::from_fixnum(end).to_raw();
+    }
+
+    let buf = ThreadState::current_buffer();
+    let begv = buf.begv as EmacsInt;
+    let zv = buf.zv as EmacsInt;
+
+    if !(begv <= beg && end <= zv) {
+        args_out_of_range!(current_buffer(), start, stop);
+    }
 }

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -71,6 +71,8 @@ pub use buffers::Fbuffer_modified_p;
 // used in process.c
 pub use buffers::Fbuffer_name;
 
+pub use buffers::validate_region;
+
 // Used in nsfns.m
 pub use buffers::Fbuffer_file_name;
 

--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -26,9 +26,9 @@ use remacs_sys::{EmacsInt, EmacsUint, EmacsDouble, VALMASK, VALBITS, INTTYPEBITS
                  USE_LSB_TAG, MOST_POSITIVE_FIXNUM, MOST_NEGATIVE_FIXNUM, Lisp_Type,
                  Lisp_Misc_Any, Lisp_Misc_Type, Lisp_Float, Lisp_Cons, Lisp_Object, lispsym,
                  make_float, circular_list, internal_equal, Fcons, CHECK_IMPURE, Qnil, Qt,
-                 Qnumberp, Qfloatp, Qstringp, Qsymbolp, Qnumber_or_marker_p, Qwholenump, Qvectorp,
-                 Qcharacterp, Qlistp, Qintegerp, Qhash_table_p, Qchar_table_p, Qconsp, Qbufferp,
-                 SYMBOL_NAME, PseudovecType, EqualKind};
+                 Qnumberp, Qfloatp, Qstringp, Qsymbolp, Qnumber_or_marker_p, Qinteger_or_marker_p,
+                 Qwholenump, Qvectorp, Qcharacterp, Qlistp, Qintegerp, Qhash_table_p,
+                 Qchar_table_p, Qconsp, Qbufferp, SYMBOL_NAME, PseudovecType, EqualKind};
 
 // TODO: tweak Makefile to rebuild C files if this changes.
 
@@ -337,6 +337,17 @@ impl LispObject {
             unsafe { self.to_fixnum_unchecked() }
         } else {
             wrong_type!(Qintegerp, self)
+        }
+    }
+
+    #[inline]
+    pub fn as_fixnum_coerce_marker_or_error(self) -> EmacsInt {
+        if let Some(n) = self.as_fixnum() {
+            n
+        } else if let Some(m) = self.as_marker() {
+            m.position() as EmacsInt
+        } else {
+            wrong_type!(Qinteger_or_marker_p, self);
         }
     }
 

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -2092,22 +2092,6 @@ so the buffer is truly empty after this.  */)
   return Qnil;
 }
 
-void
-validate_region (register Lisp_Object *b, register Lisp_Object *e)
-{
-  CHECK_NUMBER_COERCE_MARKER (*b);
-  CHECK_NUMBER_COERCE_MARKER (*e);
-
-  if (XINT (*b) > XINT (*e))
-    {
-      Lisp_Object tem;
-      tem = *b;  *b = *e;  *e = tem;
-    }
-
-  if (! (BEGV <= XINT (*b) && XINT (*e) <= ZV))
-    args_out_of_range_3 (Fcurrent_buffer (), *b, *e);
-}
-
 /* Advance BYTE_POS up to a character boundary
    and return the adjusted position.  */
 


### PR DESCRIPTION
I think the code as it is now should be functionally equal to the C code. It might be a little less efficient as we are setting the `*b` and `*e` on every validation regardless if something changed or not. 