### PR TITLE
port marker-position

### DIFF
--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -135,6 +135,7 @@ pub use obarray::intern_1;
 pub use obarray::Fintern;
 pub use obarray::Fintern_soft;
 pub use marker::Fmarker_position;
+pub use marker::Fmarker_buffer;
 
 // Used in fileio.c
 pub use editfns::Fpoint;
@@ -250,6 +251,7 @@ pub extern "C" fn rust_init_syms() {
         defsubr(&*lists::Ssafe_length);
         defsubr(&*marker::Smarkerp);
         defsubr(&*marker::Smarker_position);
+        defsubr(&*marker::Smarker_buffer);
         defsubr(&*strings::Sstringp);
         defsubr(&*strings::Smultibyte_string_p);
         defsubr(&*base64::Sbase64_encode_string);

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -134,6 +134,7 @@ pub use buffers::Fcurrent_buffer;
 pub use obarray::intern_1;
 pub use obarray::Fintern;
 pub use obarray::Fintern_soft;
+pub use marker::Fmarker_position;
 
 // Used in fileio.c
 pub use editfns::Fpoint;

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -247,6 +247,7 @@ pub extern "C" fn rust_init_syms() {
         defsubr(&*lists::Smake_list);
         defsubr(&*lists::Ssafe_length);
         defsubr(&*marker::Smarkerp);
+        defsubr(&*marker::Smarker_position);
         defsubr(&*strings::Sstringp);
         defsubr(&*strings::Smultibyte_string_p);
         defsubr(&*base64::Sbase64_encode_string);

--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -28,7 +28,7 @@ use remacs_sys::{EmacsInt, EmacsUint, EmacsDouble, VALMASK, VALBITS, INTTYPEBITS
                  make_float, circular_list, internal_equal, Fcons, CHECK_IMPURE, Qnil, Qt,
                  Qnumberp, Qfloatp, Qstringp, Qsymbolp, Qnumber_or_marker_p, Qwholenump, Qvectorp,
                  Qcharacterp, Qlistp, Qintegerp, Qhash_table_p, Qchar_table_p, Qconsp, Qbufferp,
-                 SYMBOL_NAME, PseudovecType, EqualKind};
+                 Qmarkerp, SYMBOL_NAME, PseudovecType, EqualKind};
 
 // TODO: tweak Makefile to rebuild C files if this changes.
 
@@ -847,7 +847,7 @@ impl LispObject {
         } else if let Some(f) = self.as_float() {
             LispNumber::Float(f)
         } else if let Some(m) = self.as_marker() {
-            LispNumber::Fixnum(m.position() as EmacsInt)
+            LispNumber::Fixnum(m.charpos_or_error() as EmacsInt)
         } else {
             wrong_type!(Qnumber_or_marker_p, self)
         }
@@ -879,6 +879,12 @@ impl LispObject {
             } else {
                 None
             },
+        )
+    }
+
+    pub fn as_marker_or_error(self) -> LispMarkerRef {
+        self.as_marker().unwrap_or_else(
+            || wrong_type!(Qmarkerp, self),
         )
     }
 

--- a/rust_src/src/marker.rs
+++ b/rust_src/src/marker.rs
@@ -12,8 +12,7 @@ pub type LispMarkerRef = ExternalPtr<Lisp_Marker>;
 
 impl LispMarkerRef {
     pub fn charpos(self) -> Option<ptrdiff_t> {
-        let buf = self.buffer;
-        if buf.is_null() {
+        if self.buffer.is_null() {
             None
         } else {
             Some(self.charpos)
@@ -21,8 +20,7 @@ impl LispMarkerRef {
     }
 
     pub fn charpos_or_error(self) -> ptrdiff_t {
-        let buf = self.buffer;
-        if buf.is_null() {
+        if self.buffer.is_null() {
             error!("Marker does not point anywhere");
         }
 
@@ -35,7 +33,7 @@ impl LispMarkerRef {
         if buf.is_null() {
             None
         } else {
-            Some(unsafe { mem::transmute(self.buffer) })
+            Some(unsafe { mem::transmute(buf) })
         }
 
     }

--- a/rust_src/src/marker.rs
+++ b/rust_src/src/marker.rs
@@ -1,7 +1,7 @@
 use libc::ptrdiff_t;
 
 use lisp::{LispObject, ExternalPtr};
-use remacs_sys::Lisp_Marker;
+use remacs_sys::{Lisp_Marker, EmacsInt, Qmarkerp};
 use remacs_macros::lisp_fn;
 
 pub type LispMarkerRef = ExternalPtr<Lisp_Marker>;
@@ -17,10 +17,33 @@ impl LispMarkerRef {
         // TODO: add assertions that marker_position in marker.c has.
         self.charpos
     }
+
+    pub fn charpos(self) -> Option<ptrdiff_t> {
+        let buf = self.buffer;
+        if buf.is_null() {
+            None
+        } else {
+            Some(self.charpos)
+        }
+    }
 }
 
 /// Return t if OBJECT is a marker (editor pointer).
 #[lisp_fn]
 fn markerp(object: LispObject) -> LispObject {
     LispObject::from_bool(object.is_marker())
+}
+
+/// Return the position of MARKER, or nil if it points nowhere.
+#[lisp_fn]
+fn marker_position(object: LispObject) -> LispObject {
+    if object.is_marker() {
+        let pos = object.as_marker().unwrap().charpos();
+        match pos {
+            None => LispObject::constant_nil(),
+            _ => LispObject::from_natnum(pos.unwrap() as EmacsInt),
+        }
+    } else {
+        wrong_type!(Qmarkerp, object)
+    }
 }

--- a/rust_src/src/marker.rs
+++ b/rust_src/src/marker.rs
@@ -1,8 +1,12 @@
-use libc::ptrdiff_t;
+use libc::{c_void, ptrdiff_t};
+use std::mem;
 
+use remacs_sys::make_lisp_ptr;
 use lisp::{LispObject, ExternalPtr};
-use remacs_sys::{Lisp_Marker, EmacsInt};
+use remacs_sys::{Lisp_Marker, EmacsInt, Lisp_Type};
 use remacs_macros::lisp_fn;
+
+use buffers::LispBufferRef;
 
 pub type LispMarkerRef = ExternalPtr<Lisp_Marker>;
 
@@ -25,6 +29,16 @@ impl LispMarkerRef {
         // TODO: add assertions that marker_position in marker.c has.
         self.charpos
     }
+
+    pub fn buffer(self) -> Option<LispBufferRef> {
+        let buf = self.buffer;
+        if buf.is_null() {
+            None
+        } else {
+            Some(unsafe { mem::transmute(self.buffer) })
+        }
+
+    }
 }
 
 /// Return t if OBJECT is a marker (editor pointer).
@@ -38,7 +52,23 @@ fn markerp(object: LispObject) -> LispObject {
 fn marker_position(object: LispObject) -> LispObject {
     let pos = object.as_marker_or_error().charpos();
     match pos {
+        Some(p) => LispObject::from_natnum(p as EmacsInt),
         None => LispObject::constant_nil(),
-        _ => LispObject::from_natnum(pos.unwrap() as EmacsInt),
+    }
+}
+
+/// Return the buffer that MARKER points into, or nil if none.
+/// Returns nil if MARKER points into a dead buffer.
+#[lisp_fn]
+fn marker_buffer(object: LispObject) -> LispObject {
+    let buf = object.as_marker_or_error().buffer();
+    match buf {
+        Some(b) => unsafe {
+            LispObject::from_raw(make_lisp_ptr(
+                b.as_ptr() as *mut c_void,
+                Lisp_Type::Lisp_Vectorlike,
+            ))
+        },
+        None => LispObject::constant_nil(),
     }
 }

--- a/rust_src/src/math.rs
+++ b/rust_src/src/math.rs
@@ -213,7 +213,7 @@ fn minmax_driver(args: &[LispObject], comparison: ArithComparison) -> LispObject
     }
     // we should return the same object if it's not a marker
     if let Some(m) = accum.as_marker() {
-        LispObject::from_fixnum(m.position() as EmacsInt)
+        LispObject::from_fixnum(m.charpos_or_error() as EmacsInt)
     } else {
         accum
     }

--- a/src/marker.c
+++ b/src/marker.c
@@ -761,7 +761,6 @@ verify_bytepos (ptrdiff_t charpos)
 void
 syms_of_marker (void)
 {
-  defsubr (&Smarker_position);
   defsubr (&Smarker_buffer);
   defsubr (&Sset_marker);
   defsubr (&Scopy_marker);

--- a/src/marker.c
+++ b/src/marker.c
@@ -391,26 +391,6 @@ buf_bytepos_to_charpos (struct buffer *b, ptrdiff_t bytepos)
 
 /* Operations on markers. */
 
-DEFUN ("marker-buffer", Fmarker_buffer, Smarker_buffer, 1, 1, 0,
-       doc: /* Return the buffer that MARKER points into, or nil if none.
-Returns nil if MARKER points into a dead buffer.  */)
-  (register Lisp_Object marker)
-{
-  register Lisp_Object buf;
-  CHECK_MARKER (marker);
-  if (XMARKER (marker)->buffer)
-    {
-      XSETBUFFER (buf, XMARKER (marker)->buffer);
-      /* If the buffer is dead, we're in trouble: the buffer pointer here
-	 does not preserve the buffer from being GC'd (it's weak), so
-	 markers have to be unlinked from their buffer as soon as the buffer
-	 is killed.  */
-      eassert (BUFFER_LIVE_P (XBUFFER (buf)));
-      return buf;
-    }
-  return Qnil;
-}
-
 /* Change M so it points to B at CHARPOS and BYTEPOS.  */
 
 static void
@@ -750,7 +730,6 @@ verify_bytepos (ptrdiff_t charpos)
 void
 syms_of_marker (void)
 {
-  defsubr (&Smarker_buffer);
   defsubr (&Sset_marker);
   defsubr (&Scopy_marker);
   defsubr (&Smarker_insertion_type);

--- a/src/marker.c
+++ b/src/marker.c
@@ -411,17 +411,6 @@ Returns nil if MARKER points into a dead buffer.  */)
   return Qnil;
 }
 
-DEFUN ("marker-position", Fmarker_position, Smarker_position, 1, 1, 0,
-       doc: /* Return the position of MARKER, or nil if it points nowhere.  */)
-  (Lisp_Object marker)
-{
-  CHECK_MARKER (marker);
-  if (XMARKER (marker)->buffer)
-    return make_number (XMARKER (marker)->charpos);
-
-  return Qnil;
-}
-
 /* Change M so it points to B at CHARPOS and BYTEPOS.  */
 
 static void


### PR DESCRIPTION
I would do it this way and change the old method to charpos_or_error ? As `Fmarker_position` is still used, I couldn't remove marker-position.