### PR TITLE
Port bolp and eolp to rust

### DIFF
--- a/rust_src/src/buffers.rs
+++ b/rust_src/src/buffers.rs
@@ -99,13 +99,13 @@ impl LispBufferRef {
 
     #[inline]
     pub fn fetch_byte(&self, n: ptrdiff_t) -> u8 {
-        let base_addr = if n >= self.gpt_byte() {
+        let offset = if n >= self.gpt_byte() {
             self.gap_size()
         } else {
             0
         };
 
-        unsafe { self.beg_addr().offset(base_addr + n - self.beg_byte()) as u8 }
+        unsafe { self.beg_addr().offset(offset + n - self.beg_byte()) as u8 }
     }
 }
 

--- a/rust_src/src/buffers.rs
+++ b/rust_src/src/buffers.rs
@@ -96,6 +96,19 @@ impl LispBufferRef {
     pub fn is_live(self) -> bool {
         LispObject::from_raw(self.name).is_not_nil()
     }
+
+    #[inline]
+    pub fn fetch_byte(&self, n: ptrdiff_t) -> u8 {
+        let base_addr = unsafe {
+            if n  >= self.gpt_byte() {
+                self.gap_size()
+            } else {
+                0
+            } };
+        let byte_addr = (base_addr + n +
+                         self.beg_addr() as ptrdiff_t - self.beg_byte()) as *const u8;
+        unsafe {(*byte_addr) as u8 }
+    }
 }
 
 impl LispObject {

--- a/rust_src/src/buffers.rs
+++ b/rust_src/src/buffers.rs
@@ -42,6 +42,11 @@ impl LispBufferRef {
     }
 
     #[inline]
+    pub fn gap_size(&self) -> ptrdiff_t {
+        unsafe { (*self.text).gap_size }
+    }
+
+    #[inline]
     pub fn gap_end_addr(&self) -> *mut c_uchar {
         unsafe {
             (*self.text).beg.offset(

--- a/rust_src/src/buffers.rs
+++ b/rust_src/src/buffers.rs
@@ -107,7 +107,7 @@ impl LispBufferRef {
             0
         };
 
-        unsafe { self.beg_addr().offset(offset + n - self.beg_byte()) as u8 }
+        unsafe { *(self.beg_addr().offset(offset + n - self.beg_byte())) as u8 }
     }
 }
 

--- a/rust_src/src/buffers.rs
+++ b/rust_src/src/buffers.rs
@@ -99,12 +99,12 @@ impl LispBufferRef {
 
     #[inline]
     pub fn fetch_byte(&self, n: ptrdiff_t) -> u8 {
-        let base_addr = unsafe {
+        let base_addr =
             if n  >= self.gpt_byte() {
                 self.gap_size()
             } else {
                 0
-            } };
+            };
         let byte_addr = (base_addr + n +
                          self.beg_addr() as ptrdiff_t - self.beg_byte()) as *const u8;
         unsafe {(*byte_addr) as u8 }

--- a/rust_src/src/buffers.rs
+++ b/rust_src/src/buffers.rs
@@ -99,15 +99,13 @@ impl LispBufferRef {
 
     #[inline]
     pub fn fetch_byte(&self, n: ptrdiff_t) -> u8 {
-        let base_addr =
-            if n  >= self.gpt_byte() {
-                self.gap_size()
-            } else {
-                0
-            };
-        let byte_addr = (base_addr + n +
-                         self.beg_addr() as ptrdiff_t - self.beg_byte()) as *const u8;
-        unsafe {(*byte_addr) as u8 }
+        let base_addr = if n >= self.gpt_byte() {
+            self.gap_size()
+        } else {
+            0
+        };
+
+        unsafe { self.beg_addr().offset(base_addr + n - self.beg_byte()) as u8 }
     }
 }
 

--- a/rust_src/src/editfns.rs
+++ b/rust_src/src/editfns.rs
@@ -54,9 +54,9 @@ pub fn bobp() -> LispObject {
 #[lisp_fn]
 pub fn bolp() -> LispObject {
     let buffer_ref = ThreadState::current_buffer();
-    let pt_byte = buffer_ref.pt_byte - 1;
-    LispObject::from_bool(buffer_ref.pt == buffer_ref.begv ||
-                          buffer_ref.fetch_byte(pt_byte) as char == '\n')
+    LispObject::from_bool(
+        buffer_ref.pt == buffer_ref.begv || buffer_ref.fetch_byte(buffer_ref.pt_byte - 1) == b'\n',
+    )
 }
 
 /// Return t if point is at the end of a line.
@@ -64,7 +64,7 @@ pub fn bolp() -> LispObject {
 #[lisp_fn]
 pub fn eolp() -> LispObject {
     let buffer_ref = ThreadState::current_buffer();
-    let pt_byte = buffer_ref.pt_byte;
-    LispObject::from_bool(buffer_ref.pt == buffer_ref.zv() ||
-                          buffer_ref.fetch_byte(pt_byte) as char == '\n')
+    LispObject::from_bool(
+        buffer_ref.pt == buffer_ref.zv() || buffer_ref.fetch_byte(buffer_ref.pt_byte) == b'\n',
+    )
 }

--- a/rust_src/src/editfns.rs
+++ b/rust_src/src/editfns.rs
@@ -54,16 +54,7 @@ pub fn bobp() -> LispObject {
 #[lisp_fn]
 pub fn bolp() -> LispObject {
     let buffer_ref = ThreadState::current_buffer();
-    let pt_byte = buffer_ref.pt_byte - 1;
-
-    let addr = unsafe {
-        if pt_byte >= buffer_ref.gpt_byte() {
-            buffer_ref.gap_size()
-        } else {
-            0
-        } };
-
+    let pt_byte = (buffer_ref.pt_byte - 1);
     LispObject::from_bool(buffer_ref.pt == buffer_ref.begv ||
-                          (addr as u8 + pt_byte as u8  + buffer_ref.beg_addr() as u8 - buffer_ref.beg_byte() as u8) == '\n')
-     // LispObject::from_bool(true)
+                          buffer_ref.fetch_byte(pt_byte) as char == '\n')
 }

--- a/rust_src/src/editfns.rs
+++ b/rust_src/src/editfns.rs
@@ -49,3 +49,21 @@ pub fn bobp() -> LispObject {
     let buffer_ref = ThreadState::current_buffer();
     LispObject::from_bool(buffer_ref.pt == buffer_ref.begv)
 }
+
+/// Return t if point is at the beginning of a line.
+#[lisp_fn]
+pub fn bolp() -> LispObject {
+    let buffer_ref = ThreadState::current_buffer();
+    let pt_byte = buffer_ref.pt_byte - 1;
+
+    let addr = unsafe {
+        if pt_byte >= buffer_ref.gpt_byte() {
+            buffer_ref.gap_size()
+        } else {
+            0
+        } };
+
+    LispObject::from_bool(buffer_ref.pt == buffer_ref.begv ||
+                          (addr as u8 + pt_byte as u8  + buffer_ref.beg_addr() as u8 - buffer_ref.beg_byte() as u8) == '\n')
+     // LispObject::from_bool(true)
+}

--- a/rust_src/src/editfns.rs
+++ b/rust_src/src/editfns.rs
@@ -58,3 +58,13 @@ pub fn bolp() -> LispObject {
     LispObject::from_bool(buffer_ref.pt == buffer_ref.begv ||
                           buffer_ref.fetch_byte(pt_byte) as char == '\n')
 }
+
+/// Return t if point is at the end of a line.
+///`End of a line' includes point being at the end of the buffer.
+#[lisp_fn]
+pub fn eolp() -> LispObject {
+    let buffer_ref = ThreadState::current_buffer();
+    let pt_byte = (buffer_ref.pt_byte);
+    LispObject::from_bool(buffer_ref.pt == buffer_ref.zv() ||
+                          buffer_ref.fetch_byte(pt_byte) as char == '\n')
+}

--- a/rust_src/src/editfns.rs
+++ b/rust_src/src/editfns.rs
@@ -54,7 +54,7 @@ pub fn bobp() -> LispObject {
 #[lisp_fn]
 pub fn bolp() -> LispObject {
     let buffer_ref = ThreadState::current_buffer();
-    let pt_byte = (buffer_ref.pt_byte - 1);
+    let pt_byte = buffer_ref.pt_byte - 1;
     LispObject::from_bool(buffer_ref.pt == buffer_ref.begv ||
                           buffer_ref.fetch_byte(pt_byte) as char == '\n')
 }
@@ -64,7 +64,7 @@ pub fn bolp() -> LispObject {
 #[lisp_fn]
 pub fn eolp() -> LispObject {
     let buffer_ref = ThreadState::current_buffer();
-    let pt_byte = (buffer_ref.pt_byte);
+    let pt_byte = buffer_ref.pt_byte;
     LispObject::from_bool(buffer_ref.pt == buffer_ref.zv() ||
                           buffer_ref.fetch_byte(pt_byte) as char == '\n')
 }

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -162,6 +162,7 @@ pub use multibyte::str_to_unibyte;
 
 // Used in window.c, macros.c
 pub use interactive::Fprefix_numeric_value;
+pub use editfns::Fbolp;
 
 extern "C" {
     fn defsubr(sname: *const Lisp_Subr);
@@ -319,5 +320,6 @@ pub extern "C" fn rust_init_syms() {
         defsubr(&*editfns::Sbuffer_size);
         defsubr(&*editfns::Seobp);
         defsubr(&*editfns::Sbobp);
+        defsubr(&*editfns::Sbolp);
     }
 }

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -163,6 +163,7 @@ pub use multibyte::str_to_unibyte;
 // Used in window.c, macros.c
 pub use interactive::Fprefix_numeric_value;
 pub use editfns::Fbolp;
+pub use editfns::Feolp;
 
 extern "C" {
     fn defsubr(sname: *const Lisp_Subr);
@@ -321,5 +322,6 @@ pub extern "C" fn rust_init_syms() {
         defsubr(&*editfns::Seobp);
         defsubr(&*editfns::Sbobp);
         defsubr(&*editfns::Sbolp);
+        defsubr(&*editfns::Seolp);
     }
 }

--- a/src/editfns.c
+++ b/src/editfns.c
@@ -1176,15 +1176,15 @@ At the beginning of the buffer or accessible region, return 0.  */)
 /*   return Qnil; */
 /* } */
 
-DEFUN ("eolp", Feolp, Seolp, 0, 0, 0,
-       doc: /* Return t if point is at the end of a line.
-`End of a line' includes point being at the end of the buffer.  */)
-  (void)
-{
-  if (PT == ZV || FETCH_BYTE (PT_BYTE) == '\n')
-    return Qt;
-  return Qnil;
-}
+/* DEFUN ("eolp", Feolp, Seolp, 0, 0, 0, */
+/*        doc: /\* Return t if point is at the end of a line. */
+/* `End of a line' includes point being at the end of the buffer.  *\/) */
+/*   (void) */
+/* { */
+/*   if (PT == ZV || FETCH_BYTE (PT_BYTE) == '\n') */
+/*     return Qt; */
+/*   return Qnil; */
+/* } */
 
 DEFUN ("char-after", Fchar_after, Schar_after, 0, 1, 0,
        doc: /* Return character in current buffer at position POS.
@@ -5409,7 +5409,6 @@ functions if all the text being accessed has this property.  */);
   defsubr (&Sposition_bytes);
   defsubr (&Sbyte_to_position);
 
-  defsubr (&Seolp);
   defsubr (&Sfollowing_char);
   defsubr (&Sprevious_char);
   defsubr (&Schar_after);

--- a/src/editfns.c
+++ b/src/editfns.c
@@ -1167,14 +1167,14 @@ At the beginning of the buffer or accessible region, return 0.  */)
   return temp;
 }
 
-DEFUN ("bolp", Fbolp, Sbolp, 0, 0, 0,
-       doc: /* Return t if point is at the beginning of a line.  */)
-  (void)
-{
-  if (PT == BEGV || FETCH_BYTE (PT_BYTE - 1) == '\n')
-    return Qt;
-  return Qnil;
-}
+/* DEFUN ("bolp", Fbolp, Sbolp, 0, 0, 0, */
+/*        doc: /\* Return t if point is at the beginning of a line.  *\/) */
+/*   (void) */
+/* { */
+/*   if (PT == BEGV || FETCH_BYTE (PT_BYTE - 1) == '\n') */
+/*     return Qt; */
+/*   return Qnil; */
+/* } */
 
 DEFUN ("eolp", Feolp, Seolp, 0, 0, 0,
        doc: /* Return t if point is at the end of a line.
@@ -5409,7 +5409,6 @@ functions if all the text being accessed has this property.  */);
   defsubr (&Sposition_bytes);
   defsubr (&Sbyte_to_position);
 
-  defsubr (&Sbolp);
   defsubr (&Seolp);
   defsubr (&Sfollowing_char);
   defsubr (&Sprevious_char);

--- a/src/editfns.c
+++ b/src/editfns.c
@@ -1167,25 +1167,6 @@ At the beginning of the buffer or accessible region, return 0.  */)
   return temp;
 }
 
-/* DEFUN ("bolp", Fbolp, Sbolp, 0, 0, 0, */
-/*        doc: /\* Return t if point is at the beginning of a line.  *\/) */
-/*   (void) */
-/* { */
-/*   if (PT == BEGV || FETCH_BYTE (PT_BYTE - 1) == '\n') */
-/*     return Qt; */
-/*   return Qnil; */
-/* } */
-
-/* DEFUN ("eolp", Feolp, Seolp, 0, 0, 0, */
-/*        doc: /\* Return t if point is at the end of a line. */
-/* `End of a line' includes point being at the end of the buffer.  *\/) */
-/*   (void) */
-/* { */
-/*   if (PT == ZV || FETCH_BYTE (PT_BYTE) == '\n') */
-/*     return Qt; */
-/*   return Qnil; */
-/* } */
-
 DEFUN ("char-after", Fchar_after, Schar_after, 0, 1, 0,
        doc: /* Return character in current buffer at position POS.
 POS is an integer or a marker and defaults to point.


### PR DESCRIPTION
With the PR as it is, I get `^^^^^^^^^^ expected u8, found char`, which makes sense because I'm comparing the address offset address with the char '\n' itself.   

I couldn't find the function that would get the char at a given addr (something with a signature like: buffer.char_at_addr(addr)).    Do we have such function? 

Also, is that use of unsafe, safe? :) or at least, sensible?