### PR TITLE
Fix new warning on latest Rust nightly

### DIFF
--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -13,7 +13,11 @@ extern crate alloc_unexecmacosx;
 extern crate lazy_static;
 
 extern crate remacs_sys;
+
+// Needed for linking.
+#[allow(unused_extern_crates)]
 extern crate remacs_lib;
+
 extern crate remacs_macros;
 extern crate libc;
 extern crate md5;


### PR DESCRIPTION
This changed in https://github.com/rust-lang/rust/pull/42588.