### PR TITLE
WIP: Port markers to rust

### DIFF
--- a/rust_src/src/editfns.rs
+++ b/rust_src/src/editfns.rs
@@ -77,6 +77,15 @@ pub fn point_min() -> LispObject {
     LispObject::from_natnum(ThreadState::current_buffer().begv as EmacsInt)
 }
 
+/// Return a marker to the minimum permissible value of point in this
+/// buffer.  This is the beginning, unless narrowing (a buffer
+/// restriction) is in effect.
+#[lisp_fn]
+pub fn point_min_marker() -> LispObject {
+    let buffer = ThreadState::current_buffer();
+    build_marker(buffer, buffer.begv, buffer.beg_byte())
+}
+
 /// Return the maximum permissible value of point in the current
 /// buffer.  This is (1+ (buffer-size)), unless narrowing (a buffer
 /// restriction) is in effect, in which case it is less.

--- a/rust_src/src/editfns.rs
+++ b/rust_src/src/editfns.rs
@@ -5,6 +5,7 @@ use lisp::LispObject;
 use remacs_sys::EmacsInt;
 use threads::ThreadState;
 use buffers::get_buffer;
+use marker::build_marker;
 
 
 /// Return value of point, as an integer.

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -334,6 +334,7 @@ pub extern "C" fn rust_init_syms() {
         defsubr(&*editfns::Sbolp);
         defsubr(&*editfns::Seolp);
         defsubr(&*editfns::Spoint_min);
+        defsubr(&*editfns::Spoint_min_marker);
         defsubr(&*editfns::Spoint_max);
     }
 }

--- a/rust_src/src/marker.rs
+++ b/rust_src/src/marker.rs
@@ -3,7 +3,7 @@ use std::mem;
 
 use remacs_sys::make_lisp_ptr;
 use lisp::{LispObject, ExternalPtr};
-use remacs_sys::{Lisp_Marker, EmacsInt, Lisp_Type};
+use remacs_sys::{Lisp_Misc_Type, Lisp_Marker, EmacsInt, Lisp_Type};
 use remacs_macros::lisp_fn;
 
 use buffers::LispBufferRef;
@@ -39,16 +39,22 @@ impl LispMarkerRef {
     }
 }
 
-fn build_marker(buf: LispObject, charpos: ptrdiff_t, byte_pos: ptrdiff_t) -> LispObject {
+/// Return a newly allocated marker which points into BUF at character
+/// position CHARPOS and byte position BYTEPOS.
+pub fn build_marker(buf: LispBufferRef, charpos: ptrdiff_t, byte_pos: ptrdiff_t) -> Lisp_Marker {
+    debug_assert!(buf.is_live());
+    debug_assert!(charpos <= byte_pos);
+
     let m = Lisp_Marker{
-        ty: Marker,
+        ty: Lisp_Misc_Type::Marker,
         padding: 0,
         buffer: buf,
         charpos: charpos,
         bytepos: byte_pos,
-        next: buf.text.markers,
+        next: unsafe{ *buf.text }.markers,
     };
-    buf.text.markers = m;
+    unsafe{ *buf.text }.markers = m;
+    // (buf.text).markers = m;
     m
 }
 

--- a/rust_src/src/marker.rs
+++ b/rust_src/src/marker.rs
@@ -39,6 +39,19 @@ impl LispMarkerRef {
     }
 }
 
+fn build_marker(buf: LispObject, charpos: ptrdiff_t, byte_pos: ptrdiff_t) -> LispObject {
+    let m = Lisp_Marker{
+        ty: Marker,
+        padding: 0,
+        buffer: buf,
+        charpos: charpos,
+        bytepos: byte_pos,
+        next: buf.text.markers,
+    };
+    buf.text.markers = m;
+    m
+}
+
 /// Return t if OBJECT is a marker (editor pointer).
 #[lisp_fn]
 fn markerp(object: LispObject) -> LispObject {

--- a/src/editfns.c
+++ b/src/editfns.c
@@ -1045,13 +1045,13 @@ usage: (save-current-buffer &rest BODY)  */)
   return unbind_to (count, Fprogn (args));
 }
 
-DEFUN ("point-min-marker", Fpoint_min_marker, Spoint_min_marker, 0, 0, 0,
-       doc: /* Return a marker to the minimum permissible value of point in this buffer.
-This is the beginning, unless narrowing (a buffer restriction) is in effect.  */)
-  (void)
-{
-  return build_marker (current_buffer, BEGV, BEGV_BYTE);
-}
+/* DEFUN ("point-min-marker", Fpoint_min_marker, Spoint_min_marker, 0, 0, 0, */
+/*        doc: /\* Return a marker to the minimum permissible value of point in this buffer. */
+/* This is the beginning, unless narrowing (a buffer restriction) is in effect.  *\/) */
+/*   (void) */
+/* { */
+/*   return build_marker (current_buffer, BEGV, BEGV_BYTE); */
+/* } */
 
 DEFUN ("point-max-marker", Fpoint_max_marker, Spoint_max_marker, 0, 0, 0,
        doc: /* Return a marker to the maximum permissible value of point in this buffer.
@@ -5360,7 +5360,7 @@ functions if all the text being accessed has this property.  */);
   defsubr (&Ssave_excursion);
   defsubr (&Ssave_current_buffer);
 
-  defsubr (&Spoint_min_marker);
+  /* defsubr (&Spoint_min_marker); */
   defsubr (&Spoint_max_marker);
   defsubr (&Sgap_position);
   defsubr (&Sgap_size);


### PR DESCRIPTION
This might be a bit too much for me, but I'm giving it a try.

In https://github.com/Wilfred/remacs/blob/master/rust_src/remacs-sys/lib.rs#L287 , the fields 'insertion_type' and 'need_adjustment', are not migrated. is it because we won't need that in Rust, or it is something we have to do and what's there is a hack?

Any tip/advice/alert for porting markers?