### PR TITLE
Adding ability to mock extern "C" functions 

### DIFF
--- a/rust_src/Cargo.lock
+++ b/rust_src/Cargo.lock
@@ -7,6 +7,7 @@ dependencies = [
  "lazy_static 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "md5 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mock_derive 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "remacs-lib 0.1.0",
  "remacs-macros 0.1.0",
@@ -105,6 +106,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "md5"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "mock_derive"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "nodrop"
@@ -230,6 +241,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum lazy_static 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4732c563b9a21a406565c4747daa7b46742f082911ae4753f390dc9ec7ee1a97"
 "checksum libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)" = "88ee81885f9f04bff991e306fea7c1c60a5f0f9e409e99f6b40e3311a3363135"
 "checksum md5 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "11f2f3240857d306c26118e2e92a5eaf8990df379e3d96573ee6c92cdbf58a81"
+"checksum mock_derive 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b7f76cd7faa2dbfc958d4c5a92faba8d630028b10c565a7543b085a25f3fc3"
 "checksum nodrop 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "52cd74cd09beba596430cc6e3091b74007169a56246e1262f0ba451ea95117b2"
 "checksum odds 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)" = "c3df9b730298cea3a1c3faa90b7e2f9df3a9c400d0936d6015e6165734eefcba"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"

--- a/rust_src/Cargo.toml
+++ b/rust_src/Cargo.toml
@@ -18,6 +18,7 @@ md5 = "0.3.5"
 base64 = "0.6.0"
 sha1 = "0.2.0"
 sha2 = "0.4.2"
+mock_derive = "0.6.1"
 
 # Only want this local crate as dependency on Mac OS X
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/rust_src/src/functions.rs
+++ b/rust_src/src/functions.rs
@@ -1,0 +1,89 @@
+/// This module is loaded only in #[cfg(test)]. It contains C functions to be mocked in our tests
+/// as part of our mocking library. Due to the fact that cfg(test) does not cascade to dependent crates,
+/// we need to duplicate the extern "C" block found in remacs-sys here, so that our coding proc macro
+/// can generate the boilerplate we need for testing.
+
+/// Adding a function to this block does not real harm, however we should always define these
+/// functions in remacs-sys, and all use directives should reference remacs-sys and not this module.
+use libc::{c_char, c_int, c_double, c_void, ptrdiff_t};
+use remacs_sys::*;
+use mock_derive::mock;
+
+#[allow(dead_code)]
+#[mock]
+extern "C" {
+    pub fn make_float(float_value: c_double) -> Lisp_Object;
+    pub fn make_string(s: *const c_char, length: ptrdiff_t) -> Lisp_Object;
+    pub fn make_lisp_ptr(ptr: *const c_void, ty: Lisp_Type) -> Lisp_Object;
+    pub fn build_string(s: *const c_char) -> Lisp_Object;
+    pub fn make_unibyte_string(s: *const c_char, length: ptrdiff_t) -> Lisp_Object;
+    pub fn make_uninit_string(length: EmacsInt) -> Lisp_Object;
+    pub fn make_uninit_multibyte_string(nchars: EmacsInt, nbytes: EmacsInt) -> Lisp_Object;
+    pub fn make_specified_string(
+        contents: *const c_char,
+        nchars: ptrdiff_t,
+        nbytes: ptrdiff_t,
+        multibyte: bool,
+    ) -> Lisp_Object;
+    pub fn string_to_multibyte(string: Lisp_Object) -> Lisp_Object;
+
+    pub fn preferred_coding_system() -> Lisp_Object;
+    pub fn Fcoding_system_p(o: Lisp_Object) -> Lisp_Object;
+    pub fn code_convert_string(
+        string: Lisp_Object,
+        coding_system: Lisp_Object,
+        dst_object: Lisp_Object,
+        encodep: bool,
+        nocopy: bool,
+        norecord: bool,
+    ) -> Lisp_Object;
+    pub fn validate_subarray(
+        array: Lisp_Object,
+        from: Lisp_Object,
+        to: Lisp_Object,
+        size: ptrdiff_t,
+        ifrom: &mut ptrdiff_t,
+        ito: &mut ptrdiff_t,
+    );
+    pub fn string_char_to_byte(string: Lisp_Object, char_index: ptrdiff_t)
+                               -> ptrdiff_t;
+
+    pub fn record_unwind_current_buffer();
+    pub fn set_buffer_internal(buffer: *const c_void); // TODO: buffer*
+    pub fn make_buffer_string(
+        start: ptrdiff_t,
+        end: ptrdiff_t,
+        props: bool,
+    ) -> Lisp_Object;
+
+    pub fn check_obarray(obarray: Lisp_Object) -> Lisp_Object;
+    pub fn check_vobarray() -> Lisp_Object;
+    pub fn intern_driver(
+        string: Lisp_Object,
+        obarray: Lisp_Object,
+        index: Lisp_Object,
+    ) -> Lisp_Object;
+    pub fn oblookup(
+        obarray: Lisp_Object,
+        s: *const c_char,
+        size: ptrdiff_t,
+        size_bytes: ptrdiff_t,
+    ) -> Lisp_Object;
+
+    pub fn SYMBOL_NAME(s: Lisp_Object) -> Lisp_Object;
+    pub fn CHECK_IMPURE(obj: Lisp_Object, ptr: *const c_void);
+    pub fn internal_equal(
+        o1: Lisp_Object,
+        o2: Lisp_Object,
+        kind: EqualKind,
+        depth: c_int,
+        ht: Lisp_Object,
+    ) -> bool;
+
+    pub fn allocate_pseudovector(
+        vecsize: c_int,
+        offset1: c_int,
+        offset2: c_int,
+        pvec_type: PseudovecType,
+    ) -> *mut Lisp_Vector;
+}

--- a/rust_src/src/functions.rs
+++ b/rust_src/src/functions.rs
@@ -1,89 +1,18 @@
-/// This module is loaded only in #[cfg(test)]. It contains C functions to be mocked in our tests
-/// as part of our mocking library. Due to the fact that cfg(test) does not cascade to dependent crates,
-/// we need to duplicate the extern "C" block found in remacs-sys here, so that our coding proc macro
-/// can generate the boilerplate we need for testing.
+/// This module is loaded only in #[cfg(test)].
+/// It contains the definitions of C functions to be mocked in our tests
+/// Due to the fact that cfg(test) does not cascade to dependent crates,
+/// we need to duplicate the extern "C" block found in remacs-sys,
+/// so that our the #[mock] macro can generate the code
+/// we need for mocking in our tests.
 
-/// Adding a function to this block does not real harm, however we should always define these
-/// functions in remacs-sys, and all use directives should reference remacs-sys and not this module.
-use libc::{c_char, c_int, c_double, c_void, ptrdiff_t};
-use remacs_sys::*;
+/// Adding a function to this block is harmless.
+/// This module is only for testing, and you should add all
+/// definitions to remacs-sys first and foremost.
+use libc::c_double;
+use remacs_sys::Lisp_Object;
 use mock_derive::mock;
 
-#[allow(dead_code)]
 #[mock]
 extern "C" {
     pub fn make_float(float_value: c_double) -> Lisp_Object;
-    pub fn make_string(s: *const c_char, length: ptrdiff_t) -> Lisp_Object;
-    pub fn make_lisp_ptr(ptr: *const c_void, ty: Lisp_Type) -> Lisp_Object;
-    pub fn build_string(s: *const c_char) -> Lisp_Object;
-    pub fn make_unibyte_string(s: *const c_char, length: ptrdiff_t) -> Lisp_Object;
-    pub fn make_uninit_string(length: EmacsInt) -> Lisp_Object;
-    pub fn make_uninit_multibyte_string(nchars: EmacsInt, nbytes: EmacsInt) -> Lisp_Object;
-    pub fn make_specified_string(
-        contents: *const c_char,
-        nchars: ptrdiff_t,
-        nbytes: ptrdiff_t,
-        multibyte: bool,
-    ) -> Lisp_Object;
-    pub fn string_to_multibyte(string: Lisp_Object) -> Lisp_Object;
-
-    pub fn preferred_coding_system() -> Lisp_Object;
-    pub fn Fcoding_system_p(o: Lisp_Object) -> Lisp_Object;
-    pub fn code_convert_string(
-        string: Lisp_Object,
-        coding_system: Lisp_Object,
-        dst_object: Lisp_Object,
-        encodep: bool,
-        nocopy: bool,
-        norecord: bool,
-    ) -> Lisp_Object;
-    pub fn validate_subarray(
-        array: Lisp_Object,
-        from: Lisp_Object,
-        to: Lisp_Object,
-        size: ptrdiff_t,
-        ifrom: &mut ptrdiff_t,
-        ito: &mut ptrdiff_t,
-    );
-    pub fn string_char_to_byte(string: Lisp_Object, char_index: ptrdiff_t)
-                               -> ptrdiff_t;
-
-    pub fn record_unwind_current_buffer();
-    pub fn set_buffer_internal(buffer: *const c_void); // TODO: buffer*
-    pub fn make_buffer_string(
-        start: ptrdiff_t,
-        end: ptrdiff_t,
-        props: bool,
-    ) -> Lisp_Object;
-
-    pub fn check_obarray(obarray: Lisp_Object) -> Lisp_Object;
-    pub fn check_vobarray() -> Lisp_Object;
-    pub fn intern_driver(
-        string: Lisp_Object,
-        obarray: Lisp_Object,
-        index: Lisp_Object,
-    ) -> Lisp_Object;
-    pub fn oblookup(
-        obarray: Lisp_Object,
-        s: *const c_char,
-        size: ptrdiff_t,
-        size_bytes: ptrdiff_t,
-    ) -> Lisp_Object;
-
-    pub fn SYMBOL_NAME(s: Lisp_Object) -> Lisp_Object;
-    pub fn CHECK_IMPURE(obj: Lisp_Object, ptr: *const c_void);
-    pub fn internal_equal(
-        o1: Lisp_Object,
-        o2: Lisp_Object,
-        kind: EqualKind,
-        depth: c_int,
-        ht: Lisp_Object,
-    ) -> bool;
-
-    pub fn allocate_pseudovector(
-        vecsize: c_int,
-        offset1: c_int,
-        offset2: c_int,
-        pvec_type: PseudovecType,
-    ) -> *mut Lisp_Vector;
 }

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -26,6 +26,12 @@ extern crate sha1;
 extern crate sha2;
 extern crate base64 as base64_crate;
 
+#[cfg(test)]
+extern crate mock_derive;
+
+#[cfg(test)]
+mod functions;
+
 #[macro_use]
 mod eval;
 mod lisp;

--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -1052,13 +1052,15 @@ fn test_basic_float() {
         .called_once()
         .return_result_of(move || {
             // Fake an allocated float by just putting it on the heap and leaking it.
-            let boxed = Box::new(Lisp_Float { data: unsafe { mem::transmute(8.0) } });
+            let boxed = Box::new(Lisp_Float { data: unsafe { mem::transmute(val) } });
             let raw = ExternalPtr::new(Box::into_raw(boxed));
             LispObject::tag_ptr(raw, Lisp_Type::Lisp_Float).to_raw()
         });
 
     ExternCMocks::set_make_float(mock);
-    
-    let result = LispObject::from_float(8.0);
+
+    let result = LispObject::from_float(val);
     assert!(result.is_float() && result.as_float() == Some(val));
+
+    ExternCMocks::clear_make_float();
 }


### PR DESCRIPTION
Adding ability to mock extern "C" functions  defined by the emacs C layer. This is done via a mocking library using proc macros. Adding a basic test as an example.

This is the solution that was discussed in https://github.com/Wilfred/remacs/issues/299 It is using a library that I maintain, which can be found here: https://github.com/DavidDeSimone/mock_derive