### PR TITLE
Add cargo bin directory to path before checking rustfmt

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -8,8 +8,6 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 set -e
 set -x
 
-export PATH=$PATH:~/.cargo/bin
-
 echo "Checking formatting"
 cd "$DIR/rust_src"
 cargo fmt -- --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ addons:
 env:
   # Ensure that we build without warnings.
   - CARGO_FLAGS="--features 'strict'"
+  - PATH=$PATH:$HOME/.cargo/bin
 
 before_script:
   # Install rustfmt 0.9.0 if it isn't already installed on


### PR DESCRIPTION
`which rustfmt` always fails as `$HOME/.cargo/bin` is not in `PATH`. As a result `rustfmt` is always reinstalled.