### PR TITLE
Use Travis build stages

### DIFF
--- a/.travis-format.sh
+++ b/.travis-format.sh
@@ -2,9 +2,8 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-# This is separate from .travis.yml so we terminate as soon as
-# anything errors.
-# See https://github.com/travis-ci/travis-ci/issues/1066
+# This is a standalone script so we terminate as soon as anything
+# errors. See https://github.com/travis-ci/travis-ci/issues/1066
 set -e
 set -x
 
@@ -28,16 +27,3 @@ cargo fmt -- --write-mode=diff lib.rs
 
 cd "$DIR/rust_src/alloc_unexecmacosx"
 cargo fmt -- --write-mode=diff
-
-cd "$DIR"
-echo 'Configuring Emacs for building'
-./autogen.sh
-# These configure flags are only required on OS X.
-# TODO: remove them.
-./configure --without-makeinfo --with-xpm=no --with-gif=no --with-gnutls=no
-
-echo 'Building Emacs'
-make -j 3
-
-echo 'Running C and Rust tests'
-make check

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,26 @@ env:
   - CARGO_FLAGS="--features 'strict'"
 
 before_script:
-  # Install rustfmt 0.9.0 if it isn't already installed on
-  # Travis. This can be slow to install, so raise the Travis timeout.
-  - (which rustfmt && rustfmt --version && [[ "$(rustfmt --version)" =~ "0.9.0" ]]) || travis_wait cargo install --force rustfmt --vers 0.9.0
+  # These configure flags are only required on OS X.
+  # TODO: remove them.
+  - ./autogen.sh && ./configure --without-makeinfo --with-xpm=no --with-gif=no --with-gnutls=no
 
 script:
-  - ./.travis.sh
+  - make -j 3 && echo '==> Running tests' && make check
+
+# Run rustfmt first.
+stages:
+  - rustfmt
+  - test
+
+jobs:
+  include:
+    - stage: rustfmt
+      # Install rustfmt 0.9.0 if it isn't already installed on
+      # Travis. This can be slow to install, so raise the Travis timeout.
+      before_script: (which rustfmt && rustfmt --version && [[ "$(rustfmt --version)" =~ "0.9.0" ]]) || travis_wait cargo install --force rustfmt --vers 0.9.0
+      script: ./.travis-format.sh
+      os: linux
 
 notifications:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,9 @@ env:
   - CARGO_FLAGS="--features 'strict'"
 
 before_script:
-  # These configure flags are only required on OS X.
-  # TODO: remove them.
-  - ./autogen.sh && ./configure --without-makeinfo --with-xpm=no --with-gif=no --with-gnutls=no
+  - if [ $TRAVIS_OS_NAME = linux ]; then ./autogen.sh && ./configure; fi
+  # TODO: add the necessary dependencies so we can use the same configure flags on OS X.
+  - if [ $TRAVIS_OS_NAME = osx ]; then ./autogen.sh && ./configure --without-makeinfo --with-xpm=no --with-gif=no --with-gnutls=no; fi
 
 script:
   - make -j 3 && echo '==> Running tests' && make check


### PR DESCRIPTION
This should help new contributors, who are often caught out by Travis
requiring rustfmt. Using separate stages with clear names should be
easier than trying to read the (somewhat noisy) logs.

Whilst build stages are a beta feature:
https://docs.travis-ci.com/user/build-stages/ they have been available
for several months, since May 2017:
https://blog.travis-ci.com/2017-05-11-introducing-build-stages