### PR TITLE
Fixing remacs build on mingw.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5219,12 +5219,15 @@ AC_SUBST(CARGO_FLAGS)
 
 case "${opsys}" in
   darwin) RUST_DEPS="-ldl -lresolv"
+  	REMACSLIB_NAME="libremacs_lib.a"
         REMACSLIB_CFLAGS="-pthread" ;;
   gnu*) RUST_DEPS="-ldl -lrt"
+    	REMACSLIB_NAME="libremacs_lib.a"
         REMACSLIB_CFLAGS="-pthread" ;;
 esac
 
 if test "${HAVE_W32}" = "yes"; then
+    REMACSLIB_NAME="remacs_lib.lib"
     RUST_DEPS="$RUST_DEPS -lws2_32 -luserenv"
 fi
 
@@ -5237,6 +5240,7 @@ LDFLAGS="$LDFLAGS $LDFLAGS_REMACS"
 AC_SUBST(LIB_REMACS)
 AC_SUBST(RUST_DEPS)
 AC_SUBST(REMACSLIB_CFLAGS)
+AC_SUBST(REMACSLIB_NAME)
 
 if test "${opsys}" = "mingw32"; then
   CPPFLAGS="$CPPFLAGS -DUSE_CRT_DLL=1 -I \${abs_top_srcdir}/nt/inc"

--- a/lib-src/Makefile.in
+++ b/lib-src/Makefile.in
@@ -36,6 +36,7 @@ CARGO_BUILD=@CARGO_BUILD@
 CARGO_CLEAN=@CARGO_CLEAN@
 CARGO_TEST=@CARGO_TEST@
 CARGO_FLAGS=@CARGO_FLAGS@
+REMACSLIB_NAME=@REMACSLIB_NAME@
 
 ifeq ($(findstring --release,$(CARGO_FLAGS)),--release)
 CARGO_BUILD_DIR=release
@@ -192,7 +193,7 @@ SCRIPTS= rcs2log
 EXE_FILES = ${INSTALLABLES} ${UTILITIES} ${DONT_INSTALL}
 
 # Rust files to be linked as part of the executables
-RUST_ARCHIVE = ../rust_src/remacs-lib/target/$(CARGO_BUILD_DIR)/libremacs_lib.a
+RUST_ARCHIVE = ../rust_src/remacs-lib/target/$(CARGO_BUILD_DIR)/$(REMACSLIB_NAME)
 RUST_LIB = $(RUST_ARCHIVE) @RUST_DEPS@
 
 # Specify additional -D flags for movemail. Options:

--- a/rust_src/remacs-lib/Cargo.toml
+++ b/rust_src/remacs-lib/Cargo.toml
@@ -3,7 +3,7 @@ name = "remacs-lib"
 version = "0.1.0"
 
 [dependencies]
-rand = "0.3"
+rand = "0.3.15"
 libc = "0.2"
 errno = "0.2.3"
 
@@ -14,3 +14,11 @@ crate-type = ["staticlib", "rlib"]
 [features]
 # Treat warnings as a build error on Travis.
 strict = []
+
+[profile.release]
+panic = "abort"
+lto = true
+
+[profile.dev]
+panic = "abort"
+lto = true

--- a/rust_src/remacs-lib/lib.rs
+++ b/rust_src/remacs-lib/lib.rs
@@ -20,3 +20,14 @@ pub use math::rust_count_one_bits;
 
 // Used by make-docfile
 pub use docfile::scan_rust_file;
+
+#[cfg(all(not(test), target_os = "windows"))]
+extern "C" {
+    fn ___chkstk();
+}
+
+#[cfg(all(not(test), target_os = "windows"))]
+#[no_mangle]
+pub unsafe extern "C" fn __chkstk() {
+    ___chkstk();
+}

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -41,6 +41,7 @@ MKDIR_P = @MKDIR_P@
 # linked with Emacs or is duplicated by the other stuff below.
 # LIBS = @LIBS@
 LIBOBJS = @LIBOBJS@
+REMACSLIB_NAME=@REMACSLIB_NAME@
 
 rust_srcdir=$(top_srcdir)/rust_src
 lispsource = $(top_srcdir)/lisp
@@ -604,7 +605,7 @@ $(RUSTFLAGS_FILE) : FORCE
 macosx_alloc_dir=$(rust_srcdir)/alloc_unexecmacosx
 MACOSX_ALLOC_INPUTS=$(macosx_alloc_dir)/src/** $(macosx_alloc_dir)/Cargo.*
 cargo_manifest=$(rust_srcdir)/Cargo.toml
-LIBREMACS_ARCHIVE=$(rust_srcdir)/target/$(CARGO_BUILD_DIR)/libremacs.a
+LIBREMACS_ARCHIVE=$(rust_srcdir)/target/$(CARGO_BUILD_DIR)/$(REMACSLIB_NAME)
 $(LIBREMACS_ARCHIVE): $(rust_srcdir)/src/** $(rust_srcdir)/remacs-sys/*.rs $(rust_srcdir)/remacs-sys/Cargo.* $(rust_srcdir)/Cargo.* $(MACOSX_ALLOC_INPUTS)
 	RUSTFLAGS=$(RUSTFLAGS) \
 	$(CARGO_BUILD) $(CARGO_FLAGS) --manifest-path $(cargo_manifest)


### PR DESCRIPTION
 Fixes https://github.com/Wilfred/remacs/issues/330. The problem here is that cargo will create static libs named "x_lib.lib" instead of the expected "libx_lib.a" on gnu/linux or osx.

NOTE: While temacs will be able to build with this patch, we will not finish building our final emacs executable. This is further discussed here: https://github.com/Wilfred/remacs/issues/337

