### PR TITLE
Port current-column to Rust

### DIFF
--- a/rust_src/remacs-sys/lib.rs
+++ b/rust_src/remacs-sys/lib.rs
@@ -1032,6 +1032,8 @@ extern "C" {
         start_byte: *mut ptrdiff_t,
         end_byte: *mut ptrdiff_t,
     ) -> *mut c_char;
+
+    pub fn current_column() -> ptrdiff_t;
 }
 
 /// Contains C definitions from the font.h header.

--- a/rust_src/src/indent.rs
+++ b/rust_src/src/indent.rs
@@ -1,0 +1,25 @@
+use remacs_macros::lisp_fn;
+use lisp::LispObject;
+use remacs_sys;
+use remacs_sys::MOST_POSITIVE_FIXNUM;
+use remacs_sys::EmacsInt;
+
+/// Return the horizontal position of point.  Beginning of line is
+/// column 0.  This is calculated by adding together the widths of all
+/// the displayed representations of the character between the start
+/// of the previous line and point (e.g., control characters will have
+/// a width of 2 or 4, tabs will have a variable width).
+/// Ignores finite width of frame, which means that this function may
+/// return values greater than (frame-width).
+/// Whether the line is visible (if `selective-display' is t) has no
+/// effect; however, ^M is treated as end of line when
+/// `selective-display' is t.
+/// Text that has an invisible property is considered as having width
+/// 0, unless `buffer-invisibility-spec' specifies that it is replaced
+/// by an ellipsis.
+#[lisp_fn]
+fn current_column() -> LispObject {
+    let col = unsafe { remacs_sys::current_column() };
+    assert!(col <= MOST_POSITIVE_FIXNUM as isize);
+    LispObject::from_fixnum(col as EmacsInt)
+}

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -65,6 +65,7 @@ mod util;
 mod minibuf;
 mod cmds;
 mod data;
+mod indent;
 
 #[cfg(all(not(test), target_os = "macos"))]
 use alloc_unexecmacosx::OsxUnexecAlloc;
@@ -401,5 +402,6 @@ pub extern "C" fn rust_init_syms() {
         defsubr(&*threads::Sthread_name);
         defsubr(&*cmds::Sforward_point);
         defsubr(&*data::Sindirect_function);
+        defsubr(&*indent::Scurrent_column);
     }
 }

--- a/src/indent.c
+++ b/src/indent.c
@@ -300,26 +300,6 @@ skip_invisible (ptrdiff_t pos, ptrdiff_t *next_boundary_p, ptrdiff_t to, Lisp_Ob
       }									\
   } while (0)
 
-
-DEFUN ("current-column", Fcurrent_column, Scurrent_column, 0, 0, 0,
-       doc: /* Return the horizontal position of point.  Beginning of line is column 0.
-This is calculated by adding together the widths of all the displayed
-representations of the character between the start of the previous line
-and point (e.g., control characters will have a width of 2 or 4, tabs
-will have a variable width).
-Ignores finite width of frame, which means that this function may return
-values greater than (frame-width).
-Whether the line is visible (if `selective-display' is t) has no effect;
-however, ^M is treated as end of line when `selective-display' is t.
-Text that has an invisible property is considered as having width 0, unless
-`buffer-invisibility-spec' specifies that it is replaced by an ellipsis.  */)
-  (void)
-{
-  Lisp_Object temp;
-  XSETFASTINT (temp, current_column ());
-  return temp;
-}
-
 /* Cancel any recorded value of the horizontal position.  */
 
 void
@@ -2357,7 +2337,6 @@ syms_of_indent (void)
 
   defsubr (&Scurrent_indentation);
   defsubr (&Sindent_to);
-  defsubr (&Scurrent_column);
   defsubr (&Smove_to_column);
   defsubr (&Sline_number_display_width);
   defsubr (&Svertical_motion);


### PR DESCRIPTION
Adds a binding to the C API to `remacs-sys`, and adds a new `indent`
module.

Closes #327.