### PR TITLE
WIP Port set-buffer-redisplay

### DIFF
--- a/rust_src/remacs-sys/lib.rs
+++ b/rust_src/remacs-sys/lib.rs
@@ -35,16 +35,16 @@ pub const CHAR_HYPER: char_bits = 0x1000000;
 pub const CHAR_SHIFT: char_bits = 0x2000000;
 pub const CHAR_CTL: char_bits = 0x4000000;
 pub const CHAR_META: char_bits = 0x8000000;
-pub const CHAR_MODIFIER_MASK: char_bits =
-    CHAR_ALT | CHAR_SUPER | CHAR_HYPER | CHAR_SHIFT | CHAR_CTL | CHAR_META;
+pub const CHAR_MODIFIER_MASK: char_bits = CHAR_ALT | CHAR_SUPER | CHAR_HYPER | CHAR_SHIFT |
+    CHAR_CTL | CHAR_META;
 pub const CHARACTERBITS: char_bits = 22;
 
 pub const PSEUDOVECTOR_FLAG: ptrdiff_t = std::isize::MAX - std::isize::MAX / 2;
 pub const PSEUDOVECTOR_SIZE_BITS: ptrdiff_t = 12;
 pub const PSEUDOVECTOR_SIZE_MASK: ptrdiff_t = (1 << PSEUDOVECTOR_SIZE_BITS) - 1;
 pub const PSEUDOVECTOR_REST_BITS: ptrdiff_t = 12;
-pub const PSEUDOVECTOR_REST_MASK: ptrdiff_t =
-    (((1 << PSEUDOVECTOR_REST_BITS) - 1) << PSEUDOVECTOR_SIZE_BITS);
+pub const PSEUDOVECTOR_REST_MASK: ptrdiff_t = (((1 << PSEUDOVECTOR_REST_BITS) - 1) <<
+                                                   PSEUDOVECTOR_SIZE_BITS);
 pub const PSEUDOVECTOR_AREA_BITS: ptrdiff_t = PSEUDOVECTOR_SIZE_BITS + PSEUDOVECTOR_REST_BITS;
 pub const PVEC_TYPE_MASK: ptrdiff_t = 0x3f << PSEUDOVECTOR_AREA_BITS;
 
@@ -197,8 +197,8 @@ pub struct Lisp_String {
 pub union SymbolUnion {
     pub value: Lisp_Object,
     pub alias: *mut Lisp_Symbol,
-    pub blv: *mut c_void, // @TODO implement Lisp_Buffer_Local_Value
-    pub fwd: *mut c_void, // @TODO implement Lisp_Fwd
+pub blv: *mut c_void, // @TODO implement Lisp_Buffer_Local_Value
+pub fwd: *mut c_void, // @TODO implement Lisp_Fwd
 }
 
 /// Interned state of a symbol.
@@ -543,6 +543,8 @@ pub struct Lisp_Buffer {
     pub overlay_center: ptrdiff_t,
 
     pub undo_list: Lisp_Object,
+
+    pub prevent_redisplay_optimizations_p: bool,
 }
 
 /// Represents text contents of an Emacs buffer. For documentation see
@@ -620,7 +622,7 @@ pub enum EqualKind {
 pub struct re_registers {
     pub num_regs: libc::c_uint,
     pub start: *mut c_void, // TODO
-    pub end: *mut c_void,   // TODO
+    pub end: *mut c_void, // TODO
 }
 
 #[repr(C)]
@@ -1198,6 +1200,8 @@ extern "C" {
         inhibit_capture_property: Lisp_Object,
     ) -> Lisp_Object;
     pub fn Fline_end_position(n: Lisp_Object) -> Lisp_Object;
+
+    pub fn bset_update_mode_line(buffer: *mut Lisp_Buffer) -> Lisp_Object;
 }
 
 /// Contains C definitions from the font.h header.

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -73,6 +73,7 @@ mod threads;
 mod util;
 mod vectors;
 mod windows;
+mod xdisp;
 
 #[cfg(all(not(test), target_os = "macos"))]
 use alloc_unexecmacosx::OsxUnexecAlloc;

--- a/rust_src/src/xdisp.rs
+++ b/rust_src/src/xdisp.rs
@@ -1,0 +1,21 @@
+use lisp::LispObject;
+use lisp::defsubr;
+use remacs_macros::lisp_fn;
+use remacs_sys::bset_update_mode_line;
+use threads::ThreadState;
+
+/// Mark the current buffer for redisplay.
+/// This function may be passed to `add-variable-watcher`.
+#[lisp_fn]
+fn set_buffer_redisplay(
+    _symbol: LispObject,
+    _newval: LispObject,
+    _op: LispObject,
+    _where: LispObject,
+) -> LispObject {
+    unsafe { bset_update_mode_line(ThreadState::current_buffer().as_mut()) };
+    ThreadState::current_buffer().prevent_redisplay_optimizations_p = true;
+    LispObject::constant_nil()
+}
+
+include!(concat!(env!("OUT_DIR"), "/xdisp_exports.rs"));

--- a/src/xdisp.c
+++ b/src/xdisp.c
@@ -623,17 +623,6 @@ bset_update_mode_line (struct buffer *b)
   b->text->redisplay = true;
 }
 
-DEFUN ("set-buffer-redisplay", Fset_buffer_redisplay,
-       Sset_buffer_redisplay, 4, 4, 0,
-       doc: /* Mark the current buffer for redisplay.
-This function may be passed to `add-variable-watcher'.  */)
-  (Lisp_Object symbol, Lisp_Object newval, Lisp_Object op, Lisp_Object where)
-{
-  bset_update_mode_line (current_buffer);
-  current_buffer->prevent_redisplay_optimizations_p = true;
-  return Qnil;
-}
-
 #ifdef GLYPH_DEBUG
 
 /* True means print traces of redisplay if compiled with
@@ -32161,7 +32150,6 @@ They are still logged to the *Messages* buffer.  */);
   message_dolog_marker3 = Fmake_marker ();
   staticpro (&message_dolog_marker3);
 
-  defsubr (&Sset_buffer_redisplay);
 #ifdef GLYPH_DEBUG
   defsubr (&Sdump_frame_glyph_matrix);
   defsubr (&Sdump_glyph_matrix);


### PR DESCRIPTION
the caveat with this change is that it uses `current_buffer().as_ptr() as *const _ as  *const c_void` to pass the buffer ptr, which I picked up from elsewhere in remacs. My rust-fu isn't up to par yet to figure out in a reasonable amount of time how to properly do this.