### PR TITLE
Porting puthash/maphash/hash_table_count

### DIFF
--- a/rust_src/remacs-sys/lib.rs
+++ b/rust_src/remacs-sys/lib.rs
@@ -1145,6 +1145,15 @@ extern "C" {
         hash: *mut EmacsUint,
     ) -> ptrdiff_t;
 
+    pub fn hash_put(
+        h: *mut Lisp_Hash_Table,
+        key: Lisp_Object,
+        value: Lisp_Object,
+        hash: EmacsUint,
+    ) -> ptrdiff_t;
+
+    pub fn gc_aset(array: Lisp_Object, idx: ptrdiff_t, val: Lisp_Object);
+
     pub fn hash_remove_from_table(h: *mut Lisp_Hash_Table, key: Lisp_Object);
     pub fn set_point_both(charpos: ptrdiff_t, bytepos: ptrdiff_t);
     pub fn buf_charpos_to_bytepos(buffer: *const Lisp_Buffer, charpos: ptrdiff_t) -> ptrdiff_t;

--- a/rust_src/src/hashtable.rs
+++ b/rust_src/src/hashtable.rs
@@ -249,3 +249,9 @@ fn maphash(function: LispObject, table: LispObject) -> LispObject {
 fn hash_table_p(obj: LispObject) -> LispObject {
     LispObject::from_bool(obj.is_hash_table())
 }
+
+/// Return the number of elements in TABLE.
+#[lisp_fn]
+fn hash_table_count(table: LispObject) -> LispObject {
+    LispObject::from_natnum(table.as_hash_table_or_error().count as EmacsInt)
+}

--- a/rust_src/src/hashtable.rs
+++ b/rust_src/src/hashtable.rs
@@ -101,7 +101,7 @@ impl LispHashTableRef {
     }
 }
 
-/// An iterator used for iterating over the indicies
+/// An iterator used for iterating over the indices
 /// of the 'key_and_value' vector of a Lisp_Hash_Table.
 /// Equivalent to a 'for (i = 0; i < HASH_TABLE_SIZE(h); ++i)'
 /// loop in the C layer.
@@ -147,7 +147,7 @@ impl<'a> Iterator for KeyAndValueIter<'a> {
 }
 
 impl LispHashTableRef {
-    pub fn indicies(&self) -> HashTableIter {
+    pub fn indices(&self) -> HashTableIter {
         HashTableIter {
             table: self,
             current: 0,
@@ -155,7 +155,7 @@ impl LispHashTableRef {
     }
 
     pub fn iter(&self) -> KeyAndValueIter {
-        KeyAndValueIter(self.indicies())
+        KeyAndValueIter(self.indices())
     }
 }
 

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -364,6 +364,7 @@ pub extern "C" fn rust_init_syms() {
         defsubr(&*hashtable::Sremhash);
         defsubr(&*hashtable::Shash_table_p);
         defsubr(&*hashtable::Sputhash);
+        defsubr(&*hashtable::Smaphash);
         defsubr(&*fonts::Sfontp);
         defsubr(&*crypto::Smd5);
         defsubr(&*crypto::Ssecure_hash);

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -211,8 +211,10 @@ pub use windows::Fwindow_minibuffer_p;
 // Used in term.c, dired.c
 pub use objects::Fidentity;
 
+// Used in xdisp.c, coding.c, et. al.
 pub use hashtable::Fgethash;
 pub use hashtable::Fremhash;
+pub use hashtable::Fputhash;
 
 #[cfg(test)]
 pub use functions::make_float;
@@ -361,6 +363,7 @@ pub extern "C" fn rust_init_syms() {
         defsubr(&*hashtable::Sgethash);
         defsubr(&*hashtable::Sremhash);
         defsubr(&*hashtable::Shash_table_p);
+        defsubr(&*hashtable::Sputhash);
         defsubr(&*fonts::Sfontp);
         defsubr(&*crypto::Smd5);
         defsubr(&*crypto::Ssecure_hash);

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -365,6 +365,7 @@ pub extern "C" fn rust_init_syms() {
         defsubr(&*hashtable::Shash_table_p);
         defsubr(&*hashtable::Sputhash);
         defsubr(&*hashtable::Smaphash);
+        defsubr(&*hashtable::Shash_table_count);
         defsubr(&*fonts::Sfontp);
         defsubr(&*crypto::Smd5);
         defsubr(&*crypto::Ssecure_hash);

--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -13,7 +13,7 @@ use libc::{c_char, c_void, intptr_t, ptrdiff_t, uintptr_t};
 
 use multibyte::{Codepoint, LispStringRef, MAX_CHAR};
 use symbols::LispSymbolRef;
-use vectors::LispVectorlikeRef;
+use vectors::{LispVectorlikeRef, LispVectorRef};
 use buffers::{LispBufferRef, LispOverlayRef};
 use windows::LispWindowRef;
 use frames::LispFrameRef;
@@ -419,6 +419,14 @@ impl LispObject {
         } else {
             wrong_type!(Qvectorp, self)
         }
+    }
+
+    pub unsafe fn as_vectorlike_unchecked(self) -> LispVectorlikeRef {
+        LispVectorlikeRef::new(mem::transmute(self.get_untaggedptr()))
+    }
+
+    pub unsafe fn as_vector_unchecked(self) -> LispVectorRef {
+        self.as_vectorlike_unchecked().as_vector_unchecked()
     }
 }
 

--- a/rust_src/src/vectors.rs
+++ b/rust_src/src/vectors.rs
@@ -41,6 +41,11 @@ impl LispVectorlikeRef {
     }
 
     #[inline]
+    pub unsafe fn as_vector_unchecked(&self) -> LispVectorRef {
+        mem::transmute::<_, LispVectorRef>(*self)
+    }
+
+    #[inline]
     pub fn is_pseudovector(&self, tp: PseudovecType) -> bool {
         self.header.size & (PSEUDOVECTOR_FLAG | PVEC_TYPE_MASK) ==
             (PSEUDOVECTOR_FLAG | ((tp as isize) << PSEUDOVECTOR_AREA_BITS))

--- a/src/fns.c
+++ b/src/fns.c
@@ -3448,26 +3448,6 @@ DEFUN ("clrhash", Fclrhash, Sclrhash, 1, 1, 0,
   return table;
 }
 
-DEFUN ("puthash", Fputhash, Sputhash, 3, 3, 0,
-       doc: /* Associate KEY with VALUE in hash table TABLE.
-If KEY is already present in table, replace its current value with
-VALUE.  In any case, return VALUE.  */)
-  (Lisp_Object key, Lisp_Object value, Lisp_Object table)
-{
-  struct Lisp_Hash_Table *h = check_hash_table (table);
-  CHECK_IMPURE (table, h);
-
-  ptrdiff_t i;
-  EMACS_UINT hash;
-  i = hash_lookup (h, key, &hash);
-  if (i >= 0)
-    set_hash_value_slot (h, i, value);
-  else
-    hash_put (h, key, value, hash);
-
-  return value;
-}
-
 DEFUN ("maphash", Fmaphash, Smaphash, 2, 2, 0,
        doc: /* Call FUNCTION for all entries in hash table TABLE.
 FUNCTION is called with two arguments, KEY and VALUE.
@@ -3737,7 +3717,6 @@ syms_of_fns (void)
   defsubr (&Shash_table_test);
   defsubr (&Shash_table_weakness);
   defsubr (&Sclrhash);
-  defsubr (&Sputhash);
   defsubr (&Smaphash);
   defsubr (&Sdefine_hash_table_test);
 

--- a/src/fns.c
+++ b/src/fns.c
@@ -3376,14 +3376,6 @@ usage: (make-hash-table &rest KEYWORD-ARGS)  */)
                           pure);
 }
 
-DEFUN ("hash-table-count", Fhash_table_count, Shash_table_count, 1, 1, 0,
-       doc: /* Return the number of elements in TABLE.  */)
-  (Lisp_Object table)
-{
-  return make_number (check_hash_table (table)->count);
-}
-
-
 DEFUN ("hash-table-rehash-size", Fhash_table_rehash_size,
        Shash_table_rehash_size, 1, 1, 0,
        doc: /* Return the current rehash size of TABLE.  */)
@@ -3694,7 +3686,6 @@ syms_of_fns (void)
   defsubr (&Ssxhash_eql);
   defsubr (&Ssxhash_equal);
   defsubr (&Smake_hash_table);
-  defsubr (&Shash_table_count);
   defsubr (&Shash_table_rehash_size);
   defsubr (&Shash_table_rehash_threshold);
   defsubr (&Shash_table_size);

--- a/src/fns.c
+++ b/src/fns.c
@@ -3448,22 +3448,6 @@ DEFUN ("clrhash", Fclrhash, Sclrhash, 1, 1, 0,
   return table;
 }
 
-DEFUN ("maphash", Fmaphash, Smaphash, 2, 2, 0,
-       doc: /* Call FUNCTION for all entries in hash table TABLE.
-FUNCTION is called with two arguments, KEY and VALUE.
-`maphash' always returns nil.  */)
-  (Lisp_Object function, Lisp_Object table)
-{
-  struct Lisp_Hash_Table *h = check_hash_table (table);
-
-  for (ptrdiff_t i = 0; i < HASH_TABLE_SIZE (h); ++i)
-    if (!NILP (HASH_HASH (h, i)))
-      call2 (function, HASH_KEY (h, i), HASH_VALUE (h, i));
-
-  return Qnil;
-}
-
-
 DEFUN ("define-hash-table-test", Fdefine_hash_table_test,
        Sdefine_hash_table_test, 3, 3, 0,
        doc: /* Define a new hash table test with name NAME, a symbol.
@@ -3717,7 +3701,6 @@ syms_of_fns (void)
   defsubr (&Shash_table_test);
   defsubr (&Shash_table_weakness);
   defsubr (&Sclrhash);
-  defsubr (&Smaphash);
   defsubr (&Sdefine_hash_table_test);
 
   /* Crypto and hashing stuff.  */


### PR DESCRIPTION
One common pattern in C to loop over key/value pairs in a Lisp_Hash_Table is:

``` c
for (i = 0; i < HASH_TABLE_SIZE (h); ++i) 
  {
    if (NILP (HASH_HASH (h, i))
      continue;

    key = HASH_KEY (h, i);
    value = HASH_VALUE (h, i);
    // ...
  }
```

I believe it would be more idomatic Rust to use an iterator, so I wrote one. There is a base iterator, that iterates over the indices of `key_and_value`. This iterator is used to implement a key and value iterator. Usage looks like

``` rust
for (key, value) in hash_table.iter() {
// ...
}

```