### PR TITLE
Updating the 'lisp_fn' macro to support interactive functions.

### DIFF
--- a/rust_src/remacs-macros/lib.rs
+++ b/rust_src/remacs-macros/lib.rs
@@ -24,6 +24,12 @@ pub fn lisp_fn(attr_ts: TokenStream, fn_ts: TokenStream) -> TokenStream {
     let mut rargs = quote::Tokens::new();
     let mut body = quote::Tokens::new();
     let max_args = function.args.len() as i16;
+    let intspec = if let Some(intspec) = lisp_fn_args.intspec {
+        quote!{ (#intspec).as_ptr() as *const ::libc::c_char }
+    } else {
+        quote!{ ::std::ptr::null() }
+    };
+    
     match function.fntype {
         function::LispFnType::Normal(_) => {
             for ident in function.args {
@@ -87,7 +93,7 @@ pub fn lisp_fn(attr_ts: TokenStream, fn_ts: TokenStream) -> TokenStream {
                 min_args: #min_args,
                 max_args: #max_args,
                 symbol_name: (#symbol_name).as_ptr() as *const ::libc::c_char,
-                intspec: ::std::ptr::null(),
+                intspec: #intspec,
                 doc: ::std::ptr::null(),
             };
         }

--- a/rust_src/remacs-macros/lib.rs
+++ b/rust_src/remacs-macros/lib.rs
@@ -25,7 +25,8 @@ pub fn lisp_fn(attr_ts: TokenStream, fn_ts: TokenStream) -> TokenStream {
     let mut body = quote::Tokens::new();
     let max_args = function.args.len() as i16;
     let intspec = if let Some(intspec) = lisp_fn_args.intspec {
-        quote!{ (#intspec).as_ptr() as *const ::libc::c_char }
+        let cbyte_intspec = CByteLiteral(intspec.as_str());
+        quote!{ (#cbyte_intspec).as_ptr() as *const ::libc::c_char }
     } else {
         quote!{ ::std::ptr::null() }
     };

--- a/rust_src/remacs-macros/lib.rs
+++ b/rust_src/remacs-macros/lib.rs
@@ -29,7 +29,7 @@ pub fn lisp_fn(attr_ts: TokenStream, fn_ts: TokenStream) -> TokenStream {
     } else {
         quote!{ ::std::ptr::null() }
     };
-    
+
     match function.fntype {
         function::LispFnType::Normal(_) => {
             for ident in function.args {

--- a/rust_src/remacs-macros/lisp_attr.rs
+++ b/rust_src/remacs-macros/lisp_attr.rs
@@ -51,8 +51,8 @@ fn parse_kv(kv_list: Vec<(syn::Ident, syn::StrLit)>, function: &Function) -> Lis
     LispFnArgs {
         name: name.unwrap_or_else(|| function.name.to_string().replace("_", "-")),
         c_name: c_name.unwrap_or_else(|| function.name.to_string()),
-        min: min,
-        intspec: intspec,
+        min,
+        intspec,
     }
 }
 

--- a/rust_src/remacs-macros/lisp_attr.rs
+++ b/rust_src/remacs-macros/lisp_attr.rs
@@ -16,7 +16,9 @@ pub struct LispFnArgs {
     /// If not given, all arguments are required for normal functions,
     /// and no arguments are required for MANY functions.
     pub min: i16,
-    /// Used to define if the lisp function is interactive.
+    /// The interactive specification. This may be a normal prompt
+    /// string, such as `"bBuffer: "` or an elisp form as a string.
+    /// If the function is not interactive, this should be None.
     pub intspec: Option<String>,
 }
 

--- a/rust_src/remacs-macros/lisp_attr.rs
+++ b/rust_src/remacs-macros/lisp_attr.rs
@@ -16,6 +16,8 @@ pub struct LispFnArgs {
     /// If not given, all arguments are required for normal functions,
     /// and no arguments are required for MANY functions.
     pub min: i16,
+    /// Used to define if the lisp function is interactive.
+    pub intspec: Option<String>,
 }
 
 pub fn parse(input: &str, function: &Function) -> Result<LispFnArgs, &'static str> {
@@ -30,6 +32,7 @@ pub fn parse(input: &str, function: &Function) -> Result<LispFnArgs, &'static st
 fn parse_kv(kv_list: Vec<(syn::Ident, syn::StrLit)>, function: &Function) -> LispFnArgs {
     let mut name = None;
     let mut c_name = None;
+    let mut intspec = None;
     let mut min = match function.fntype {
         LispFnType::Many => 0,
         LispFnType::Normal(n) => n,
@@ -39,6 +42,7 @@ fn parse_kv(kv_list: Vec<(syn::Ident, syn::StrLit)>, function: &Function) -> Lis
             "name" => name = Some(string.value),
             "c_name" => c_name = Some(string.value),
             "min" => min = i16::from_str(&string.value).unwrap(),
+            "intspec" => intspec = Some(string.value),
             _ => (), // TODO: throw a warning?
         }
     }
@@ -46,6 +50,7 @@ fn parse_kv(kv_list: Vec<(syn::Ident, syn::StrLit)>, function: &Function) -> Lis
         name: name.unwrap_or_else(|| function.name.to_string().replace("_", "-")),
         c_name: c_name.unwrap_or_else(|| function.name.to_string()),
         min: min,
+        intspec: intspec,
     }
 }
 


### PR DESCRIPTION
An example would be 
``` rust
#[lisp_fn(intspec="r")]
fn blah....
```

To define the function as interactive, acting on the current region. 