### PR TITLE
Close #375 Port process-buffer to rust

### DIFF
--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -259,6 +259,7 @@ pub extern "C" fn rust_init_syms() {
         defsubr(&*process::Sget_process);
         defsubr(&*process::Sprocessp);
         defsubr(&*process::Sprocess_name);
+        defsubr(&*process::Sprocess_buffer);
         defsubr(&*process::Sget_buffer_process);
         defsubr(&*lists::Satom);
         defsubr(&*lists::Slistp);

--- a/rust_src/src/process.rs
+++ b/rust_src/src/process.rs
@@ -49,6 +49,13 @@ fn process_name(process: LispObject) -> LispObject {
     process.as_process_or_error().name()
 }
 
+/// Return the buffer PROCESS is associated with.
+/// The default process filter inserts output from PROCESS into this buffer.
+#[lisp_fn]
+fn process_buffer(process: LispObject) -> LispObject {
+    process.as_process_or_error().buffer()
+}
+
 /// Return the (or a) live process associated with BUFFER.
 /// BUFFER may be a buffer or the name of one.
 /// Return nil if all processes associated with BUFFER have been

--- a/src/process.c
+++ b/src/process.c
@@ -1168,15 +1168,6 @@ Return BUFFER.  */)
   return buffer;
 }
 
-DEFUN ("process-buffer", Fprocess_buffer, Sprocess_buffer,
-       1, 1, 0,
-       doc: /* Return the buffer PROCESS is associated with.
-The default process filter inserts output from PROCESS into this buffer.  */)
-  (register Lisp_Object process)
-{
-  CHECK_PROCESS (process);
-  return XPROCESS (process)->buffer;
-}
 
 DEFUN ("process-mark", Fprocess_mark, Sprocess_mark,
        1, 1, 0,
@@ -7908,7 +7899,6 @@ returns non-`nil'.  */);
   defsubr (&Sprocess_tty_name);
   defsubr (&Sprocess_command);
   defsubr (&Sset_process_buffer);
-  defsubr (&Sprocess_buffer);
   defsubr (&Sprocess_mark);
   defsubr (&Sset_process_filter);
   defsubr (&Sprocess_filter);


### PR DESCRIPTION
I'm renewing my interest in practicing rust, I'm an early beginner in it.
I followed the porting of process-name, this compiled and seems to work.
Is there a way to write tests for this? I very naively used `(run-python)` to have a process launched and then `(process-buffer (get-buffer-process "*Python*"))` to use this function. 

A side question. Why are Pull Requests at this beginner level not squashed when merged? It makes it quite complicated when reviewing the history see various commits that where the trials of the same patch. Having some cleanup of the commit history seems to help in the long run. Squashing on merge is very simple on github.