### PR TITLE
Bump rustfmt to nightly version and run it.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,13 @@ stages:
 jobs:
   include:
     - stage: rustfmt
+      # rustfmt doesn't know where to look for libraries yet.
+      # See https://github.com/rust-lang-nursery/rustfmt/issues/1707#issuecomment-310005652
+      env:
+        LD_LIBRARY_PATH=$(rustc --print sysroot)/lib:$LD_LIBRARY_PATH
       # Install rustfmt 0.9.0 if it isn't already installed on
       # Travis. This can be slow to install, so raise the Travis timeout.
-      before_script: (which rustfmt && rustfmt --version && [[ "$(rustfmt --version)" =~ "0.9.0" ]]) || travis_wait cargo install --force rustfmt --vers 0.9.0
+      before_script: (which rustfmt && rustfmt --version && [[ "$(rustfmt --version)" =~ "0.2.9" ]]) || travis_wait cargo install --force rustfmt-nightly --vers 0.2.9
       script: ./.travis-format.sh
       os: linux
 

--- a/README.md
+++ b/README.md
@@ -322,12 +322,20 @@ to be exported with the correct ABI.
 ### Source code style guide
 
 In order to pass Travis checks on pull requests, the source has to
-be formatted according to the default style of `rustfmt`, version 0.9.
+be formatted according to the default style of `rustfmt-nightly`, version 0.2.9.
 To do that, install `rustfmt`:
 
 ```
-$ cargo install rustfmt
+$ cargo install rustfmt-nightly
 ```
+
+Please note that this is not the old `-nightly` version of the
+`rustfmt` crate, 0.9.0. It is a different crate with a lower version
+number which is in fact newer. See
+https://users.rust-lang.org/t/rustfmt-releases/11357 and the linked
+blog post for details. In short, `rustfmt` is being written with a new
+API which only supports nightly at the moment and the split crate
+situation will be resolved eventually.
 
 Then you can run this in the checkout root to reformat all Rust code:
 

--- a/rust_src/alloc_unexecmacosx/src/lib.rs
+++ b/rust_src/alloc_unexecmacosx/src/lib.rs
@@ -41,7 +41,9 @@ unsafe impl<'a> Alloc for &'a OsxUnexecAlloc {
     ) -> Result<*mut u8, AllocErr> {
         let addr = unexec_realloc(ptr as *mut libc::c_void, new_layout.size() as libc::size_t);
         if addr.is_null() {
-            return Err(AllocErr::Exhausted { request: new_layout });
+            return Err(AllocErr::Exhausted {
+                request: new_layout,
+            });
         }
 
         assert_eq!(addr as usize & (new_layout.align() - 1), 0);

--- a/rust_src/remacs-lib/docfile.rs
+++ b/rust_src/remacs-lib/docfile.rs
@@ -5,7 +5,7 @@ use libc::{c_char, c_int};
 
 use std::collections::HashMap;
 use std::fs::File;
-use std::io::{BufRead, BufReader, Write, stdout};
+use std::io::{stdout, BufRead, BufReader, Write};
 use std::ffi::{CStr, CString};
 use std::mem;
 use std::ptr;
@@ -102,10 +102,9 @@ pub extern "C" fn scan_rust_file(
             // Split arg names and types
             let splitters = [':', ','];
             let args = sig.split_terminator(&splitters[..]).collect::<Vec<_>>();
-            let lisp_name = attr_props.get("name").map_or_else(
-                || name.replace("_", "-"),
-                |&name| name.into(),
-            );
+            let lisp_name = attr_props
+                .get("name")
+                .map_or_else(|| name.replace("_", "-"), |&name| name.into());
             let c_name = format!("F{}", attr_props.get("c_name").unwrap_or(&name));
 
             let nargs = args.len() / 2;

--- a/rust_src/remacs-lib/files.rs
+++ b/rust_src/remacs-lib/files.rs
@@ -4,10 +4,10 @@ use errno;
 use std::ffi::{CStr, CString};
 use std::io;
 
-use libc::{self, c_int, c_char, EEXIST, EINVAL};
+use libc::{self, c_char, c_int, EEXIST, EINVAL};
 
 #[cfg(unix)]
-use libc::{O_CLOEXEC, O_EXCL, O_RDWR, O_CREAT, open};
+use libc::{open, O_CLOEXEC, O_CREAT, O_EXCL, O_RDWR};
 
 #[cfg(windows)]
 extern "C" {

--- a/rust_src/remacs-lib/lib.rs
+++ b/rust_src/remacs-lib/lib.rs
@@ -1,12 +1,11 @@
 #![allow(non_upper_case_globals)]
 #![allow(non_snake_case)]
 #![allow(private_no_mangle_fns)]
-
 #![cfg_attr(feature = "strict", deny(warnings))]
 
+extern crate errno;
 extern crate libc;
 extern crate rand;
-extern crate errno;
 
 mod files;
 mod math;

--- a/rust_src/remacs-macros/lib.rs
+++ b/rust_src/remacs-macros/lib.rs
@@ -1,12 +1,12 @@
 #![feature(proc_macro)]
 #![recursion_limit = "128"]
 
-#[macro_use]
-extern crate synom;
-extern crate syn;
+extern crate proc_macro;
 #[macro_use]
 extern crate quote;
-extern crate proc_macro;
+extern crate syn;
+#[macro_use]
+extern crate synom;
 
 use proc_macro::TokenStream;
 use std::str::FromStr;
@@ -32,25 +32,21 @@ pub fn lisp_fn(attr_ts: TokenStream, fn_ts: TokenStream) -> TokenStream {
     };
 
     match function.fntype {
-        function::LispFnType::Normal(_) => {
-            for ident in function.args {
-                let arg = quote! { #ident: ::remacs_sys::Lisp_Object, };
-                cargs.append(arg);
+        function::LispFnType::Normal(_) => for ident in function.args {
+            let arg = quote! { #ident: ::remacs_sys::Lisp_Object, };
+            cargs.append(arg);
 
-                let arg = quote! { ::lisp::LispObject::from(#ident), };
-                rargs.append(arg);
-            }
-        }
+            let arg = quote! { ::lisp::LispObject::from(#ident), };
+            rargs.append(arg);
+        },
         function::LispFnType::Many => {
-            let args =
-                quote! {
+            let args = quote! {
                 nargs: ::libc::ptrdiff_t,
                 args: *mut ::remacs_sys::Lisp_Object,
             };
             cargs.append(args);
 
-            let b =
-                quote! {
+            let b = quote! {
                 let args = unsafe {
                     ::std::slice::from_raw_parts_mut::<::remacs_sys::Lisp_Object>(
                         args, nargs as usize)
@@ -74,8 +70,7 @@ pub fn lisp_fn(attr_ts: TokenStream, fn_ts: TokenStream) -> TokenStream {
     };
     let symbol_name = CByteLiteral(&lisp_fn_args.name);
 
-    let tokens =
-        quote! {
+    let tokens = quote! {
         #[no_mangle]
         pub extern "C" fn #fname(#cargs) -> ::remacs_sys::Lisp_Object {
             #body

--- a/rust_src/remacs-sys/build.rs
+++ b/rust_src/remacs-sys/build.rs
@@ -1,7 +1,7 @@
 extern crate libc;
 
 use std::env;
-use std::io::{Write, BufRead, BufReader};
+use std::io::{BufRead, BufReader, Write};
 use std::fs::File;
 use std::path::PathBuf;
 use std::mem::size_of;
@@ -91,7 +91,6 @@ fn generate_definitions() {
         "pub const USE_LSB_TAG: bool = {};\n",
         if use_lsb_tag { "true" } else { "false" }
     ).expect("Write error!");
-
 }
 
 fn generate_globals() {

--- a/rust_src/remacs-sys/lib.rs
+++ b/rust_src/remacs-sys/lib.rs
@@ -18,8 +18,8 @@ extern crate libc;
 
 pub mod libm;
 
-use libc::{c_char, c_uchar, c_short, c_int, c_double, c_float, c_void, ptrdiff_t, size_t, off_t,
-           time_t, timespec, intmax_t};
+use libc::{c_char, c_double, c_float, c_int, c_short, c_uchar, c_void, intmax_t, off_t, ptrdiff_t,
+           size_t, time_t, timespec};
 
 
 include!(concat!(env!("OUT_DIR"), "/definitions.rs"));
@@ -36,16 +36,16 @@ pub const CHAR_HYPER: char_bits = 0x1000000;
 pub const CHAR_SHIFT: char_bits = 0x2000000;
 pub const CHAR_CTL: char_bits = 0x4000000;
 pub const CHAR_META: char_bits = 0x8000000;
-pub const CHAR_MODIFIER_MASK: char_bits = CHAR_ALT | CHAR_SUPER | CHAR_HYPER | CHAR_SHIFT |
-    CHAR_CTL | CHAR_META;
+pub const CHAR_MODIFIER_MASK: char_bits =
+    CHAR_ALT | CHAR_SUPER | CHAR_HYPER | CHAR_SHIFT | CHAR_CTL | CHAR_META;
 pub const CHARACTERBITS: char_bits = 22;
 
 pub const PSEUDOVECTOR_FLAG: ptrdiff_t = std::isize::MAX - std::isize::MAX / 2;
 pub const PSEUDOVECTOR_SIZE_BITS: ptrdiff_t = 12;
 pub const PSEUDOVECTOR_SIZE_MASK: ptrdiff_t = (1 << PSEUDOVECTOR_SIZE_BITS) - 1;
 pub const PSEUDOVECTOR_REST_BITS: ptrdiff_t = 12;
-pub const PSEUDOVECTOR_REST_MASK: ptrdiff_t = (((1 << PSEUDOVECTOR_REST_BITS) - 1) <<
-                                                   PSEUDOVECTOR_SIZE_BITS);
+pub const PSEUDOVECTOR_REST_MASK: ptrdiff_t =
+    (((1 << PSEUDOVECTOR_REST_BITS) - 1) << PSEUDOVECTOR_SIZE_BITS);
 pub const PSEUDOVECTOR_AREA_BITS: ptrdiff_t = PSEUDOVECTOR_SIZE_BITS + PSEUDOVECTOR_REST_BITS;
 pub const PVEC_TYPE_MASK: ptrdiff_t = 0x3f << PSEUDOVECTOR_AREA_BITS;
 
@@ -68,8 +68,7 @@ pub const WAIT_READING_MAX: i64 = std::i64::MAX;
 /// Bit pattern used in the least significant bits of a lisp object,
 /// to denote its type.
 #[repr(u8)]
-#[derive(PartialEq, Eq)]
-#[derive(Copy, Clone, Debug)]
+#[derive(PartialEq, Eq, Copy, Clone, Debug)]
 pub enum Lisp_Type {
     // Symbol.  XSYMBOL (object) points to a struct Lisp_Symbol.
     Lisp_Symbol = 0,
@@ -199,8 +198,8 @@ pub struct Lisp_String {
 pub union SymbolUnion {
     pub value: Lisp_Object,
     pub alias: *mut Lisp_Symbol,
-pub blv: *mut c_void, // @TODO implement Lisp_Buffer_Local_Value
-pub fwd: *mut c_void, // @TODO implement Lisp_Fwd
+    pub blv: *mut c_void, // @TODO implement Lisp_Buffer_Local_Value
+    pub fwd: *mut c_void, // @TODO implement Lisp_Fwd
 }
 
 /// Interned state of a symbol.
@@ -610,7 +609,7 @@ pub enum EqualKind {
 pub struct re_registers {
     pub num_regs: libc::c_uint,
     pub start: *mut c_void, // TODO
-    pub end: *mut c_void, // TODO
+    pub end: *mut c_void,   // TODO
 }
 
 #[repr(C)]

--- a/rust_src/remacs-sys/libm.rs
+++ b/rust_src/remacs-sys/libm.rs
@@ -2,7 +2,7 @@ use std::mem;
 use libc::c_int;
 
 mod sys {
-    use libc::{c_int, c_double};
+    use libc::{c_double, c_int};
 
     #[link_name = "m"]
     extern "C" {

--- a/rust_src/src/base64.rs
+++ b/rust_src/src/base64.rs
@@ -2,12 +2,12 @@
 
 use std::ptr;
 use std::slice;
-use libc::{ptrdiff_t, c_char, c_uchar};
+use libc::{c_char, c_uchar, ptrdiff_t};
 use base64_crate;
 
 use lisp::LispObject;
 use strings::MIME_LINE_LENGTH;
-use multibyte::{MAX_5_BYTE_CHAR, multibyte_char_at, raw_byte_from_codepoint};
+use multibyte::{multibyte_char_at, raw_byte_from_codepoint, MAX_5_BYTE_CHAR};
 use remacs_sys::make_unibyte_string;
 use remacs_macros::lisp_fn;
 

--- a/rust_src/src/buffers.rs
+++ b/rust_src/src/buffers.rs
@@ -1,14 +1,14 @@
 //! Functions operating on buffers.
 
-use libc::{c_void, c_uchar, ptrdiff_t, c_int};
+use libc::{c_int, c_uchar, c_void, ptrdiff_t};
 
-use lisp::{LispObject, ExternalPtr};
-use remacs_sys::{Lisp_Object, EmacsInt, Lisp_Buffer, Lisp_Overlay, Lisp_Type, Vbuffer_alist,
-                 make_lisp_ptr, set_buffer_internal, nsberror};
+use lisp::{ExternalPtr, LispObject};
+use remacs_sys::{make_lisp_ptr, nsberror, set_buffer_internal, EmacsInt, Lisp_Buffer, Lisp_Object,
+                 Lisp_Overlay, Lisp_Type, Vbuffer_alist};
 use strings::string_equal;
 use lists::{car, cdr};
 use threads::ThreadState;
-use marker::{marker_position, marker_buffer};
+use marker::{marker_buffer, marker_position};
 use multibyte::string_char;
 
 use std::{mem, ptr};
@@ -60,20 +60,18 @@ impl LispBufferRef {
     #[inline]
     pub fn gap_end_addr(&self) -> *mut c_uchar {
         unsafe {
-            (*self.text).beg.offset(
-                (*self.text).gpt_byte + (*self.text).gap_size -
-                    BEG_BYTE,
-            )
+            (*self.text)
+                .beg
+                .offset((*self.text).gpt_byte + (*self.text).gap_size - BEG_BYTE)
         }
     }
 
     #[inline]
     pub fn z_addr(&self) -> *mut c_uchar {
         unsafe {
-            (*self.text).beg.offset(
-                (*self.text).gap_size + (*self.text).z_byte -
-                    BEG_BYTE,
-            )
+            (*self.text)
+                .beg
+                .offset((*self.text).gap_size + (*self.text).z_byte - BEG_BYTE)
         }
     }
 
@@ -204,9 +202,8 @@ pub fn buffer_live_p(object: LispObject) -> LispObject {
 /// Like Fassoc, but use `Fstring_equal` to compare
 /// (which ignores text properties), and don't ever quit.
 fn assoc_ignore_text_properties(key: LispObject, list: LispObject) -> LispObject {
-    let result = list.iter_tails_safe().find(|&item| {
-        string_equal(car(item.car()), key).is_not_nil()
-    });
+    let result = list.iter_tails_safe()
+        .find(|&item| string_equal(car(item.car()), key).is_not_nil());
     if let Some(elt) = result {
         elt.car()
     } else {

--- a/rust_src/src/character.rs
+++ b/rust_src/src/character.rs
@@ -1,7 +1,7 @@
 //! Operations on characters.
 
 use lisp::LispObject;
-use multibyte::{MAX_CHAR, make_char_multibyte, raw_byte_from_codepoint_safe};
+use multibyte::{make_char_multibyte, raw_byte_from_codepoint_safe, MAX_CHAR};
 use remacs_macros::lisp_fn;
 use remacs_sys::EmacsInt;
 

--- a/rust_src/src/crypto/mod.rs
+++ b/rust_src/src/crypto/mod.rs
@@ -2,25 +2,25 @@
 
 use md5;
 use sha1;
-use sha2::{Sha224, Digest, Sha256, Sha384, Sha512};
+use sha2::{Digest, Sha224, Sha256, Sha384, Sha512};
 use std;
 use std::slice;
 use libc::ptrdiff_t;
 
-use buffers::{LispBufferRef, get_buffer, buffer_file_name};
+use buffers::{buffer_file_name, get_buffer, LispBufferRef};
 use libc;
-use lisp::{LispObject, LispNumber};
+use lisp::{LispNumber, LispObject};
 use multibyte::LispStringRef;
-use remacs_sys::{nsberror, Fcurrent_buffer, EmacsInt, make_uninit_string, make_specified_string};
-use remacs_sys::{preferred_coding_system, Fcoding_system_p, code_convert_string,
-                 validate_subarray, string_char_to_byte, extract_data_from_object};
-use remacs_sys::{current_thread, record_unwind_current_buffer, set_buffer_internal,
-                 make_buffer_string};
+use remacs_sys::{make_specified_string, make_uninit_string, nsberror, EmacsInt, Fcurrent_buffer};
+use remacs_sys::{code_convert_string, extract_data_from_object, preferred_coding_system,
+                 string_char_to_byte, validate_subarray, Fcoding_system_p};
+use remacs_sys::{current_thread, make_buffer_string, record_unwind_current_buffer,
+                 set_buffer_internal};
 use remacs_sys::{globals, Ffind_operation_coding_system, Flocal_variable_p};
-use remacs_sys::{Qmd5, Qsha1, Qsha224, Qsha256, Qsha384, Qsha512, Qstringp, Qraw_text,
-                 Qcoding_system_error, Qwrite_region, Qbuffer_file_coding_system};
+use remacs_sys::{Qbuffer_file_coding_system, Qcoding_system_error, Qmd5, Qraw_text, Qsha1,
+                 Qsha224, Qsha256, Qsha384, Qsha512, Qstringp, Qwrite_region};
 use remacs_macros::lisp_fn;
-use symbols::{symbol_name, fboundp};
+use symbols::{fboundp, symbol_name};
 use threads::ThreadState;
 
 #[derive(Clone, Copy)]
@@ -104,13 +104,12 @@ fn get_coding_system_for_buffer(
     if LispObject::from(unsafe { globals.f_Vcoding_system_for_write }).is_not_nil() {
         return LispObject::from(unsafe { globals.f_Vcoding_system_for_write });
     }
-    if LispObject::from(buffer.buffer_file_coding_system).is_nil() ||
-        LispObject::from(unsafe {
-            Flocal_variable_p(
-                Qbuffer_file_coding_system,
-                LispObject::constant_nil().to_raw(),
-            )
-        }).is_nil()
+    if LispObject::from(buffer.buffer_file_coding_system).is_nil() || LispObject::from(unsafe {
+        Flocal_variable_p(
+            Qbuffer_file_coding_system,
+            LispObject::constant_nil().to_raw(),
+        )
+    }).is_nil()
     {
         if LispObject::from(buffer.enable_multibyte_characters).is_nil() {
             return LispObject::from(unsafe { Qraw_text });
@@ -518,9 +517,10 @@ fn buffer_hash(buffer_or_name: LispObject) -> LispObject {
 
     let formatted = ctx.digest().to_string();
     let digest = LispObject::from(unsafe { make_uninit_string(formatted.len() as EmacsInt) });
-    digest.as_string().unwrap().as_mut_slice().copy_from_slice(
-        formatted
-            .as_bytes(),
-    );
+    digest
+        .as_string()
+        .unwrap()
+        .as_mut_slice()
+        .copy_from_slice(formatted.as_bytes());
     digest
 }

--- a/rust_src/src/dispnew.rs
+++ b/rust_src/src/dispnew.rs
@@ -4,7 +4,7 @@ use remacs_macros::lisp_fn;
 use remacs_sys::{current_timespec, dtotimespec, timespec_add, timespec_sub,
                  wait_reading_process_output, WAIT_READING_MAX};
 use lisp::LispObject;
-use std::{ptr, cmp};
+use std::{cmp, ptr};
 use floatfns::extract_float;
 
 

--- a/rust_src/src/editfns.rs
+++ b/rust_src/src/editfns.rs
@@ -237,7 +237,7 @@ pub fn propertize(args: &mut [LispObject]) -> LispObject {
     let first = it.next().unwrap();
     let orig_string = first.as_string_or_error();
 
-    let copy = LispObject::from_raw(unsafe { Fcopy_sequence(first.to_raw()) });
+    let copy = LispObject::from(unsafe { Fcopy_sequence(first.to_raw()) });
 
     // this is a C style Lisp_Object because that is what Fcons expects and returns.
     // Once Fcons is ported to Rust this can be migrated to a LispObject.

--- a/rust_src/src/editfns.rs
+++ b/rust_src/src/editfns.rs
@@ -3,9 +3,8 @@
 use remacs_macros::lisp_fn;
 use lisp::LispObject;
 use util::clip_to_bounds;
-use remacs_sys::{buf_charpos_to_bytepos, globals, set_point_both, Fcons, Fcopy_sequence,
-                 Fadd_text_properties, Finsert_char, EmacsInt, Qinteger_or_marker_p,
-                 Qmark_inactive, Qnil};
+use remacs_sys::{buf_charpos_to_bytepos, globals, set_point_both, EmacsInt, Fadd_text_properties,
+                 Fcons, Fcopy_sequence, Finsert_char, Qinteger_or_marker_p, Qmark_inactive, Qnil};
 use threads::ThreadState;
 use buffers::get_buffer;
 use marker::{marker_position, set_point_from_marker};
@@ -80,9 +79,9 @@ pub fn eolp() -> LispObject {
 /// If there is no region active, signal an error.
 fn region_limit(beginningp: bool) -> LispObject {
     let current_buf = ThreadState::current_buffer();
-    if LispObject::from(unsafe { globals.f_Vtransient_mark_mode }).is_not_nil() &&
-        LispObject::from(unsafe { globals.f_Vmark_even_if_inactive }).is_nil() &&
-        current_buf.mark_active().is_nil()
+    if LispObject::from(unsafe { globals.f_Vtransient_mark_mode }).is_not_nil()
+        && LispObject::from(unsafe { globals.f_Vmark_even_if_inactive }).is_nil()
+        && current_buf.mark_active().is_nil()
     {
         xsignal!(Qmark_inactive);
     }
@@ -97,8 +96,8 @@ fn region_limit(beginningp: bool) -> LispObject {
     if ((current_buf.pt as EmacsInt) < num) == beginningp {
         LispObject::from_fixnum(current_buf.pt as EmacsInt)
     } else {
-        LispObject::from_fixnum(clip_to_bounds(current_buf.begv, num, current_buf.zv) as
-            EmacsInt)
+        LispObject::from_fixnum(clip_to_bounds(current_buf.begv, num, current_buf.zv)
+            as EmacsInt)
     }
 }
 

--- a/rust_src/src/floatfns.rs
+++ b/rust_src/src/floatfns.rs
@@ -4,9 +4,9 @@ use std::mem;
 use libc;
 
 use math::ArithOp;
-use lisp::{LispObject, LispNumber};
-use remacs_sys::{EmacsDouble, EmacsInt, EmacsUint, Lisp_Object, Qnumberp, Qinteger_or_marker_p,
-                 Qarith_error, Qrange_error, build_string, MOST_NEGATIVE_FIXNUM,
+use lisp::{LispNumber, LispObject};
+use remacs_sys::{build_string, EmacsDouble, EmacsInt, EmacsUint, Lisp_Object, Qarith_error,
+                 Qinteger_or_marker_p, Qnumberp, Qrange_error, MOST_NEGATIVE_FIXNUM,
                  MOST_POSITIVE_FIXNUM};
 use remacs_sys::libm;
 use remacs_macros::lisp_fn;
@@ -80,16 +80,14 @@ pub fn float_arith_driver(
                 }
             }
             ArithOp::Mult => accum *= next,
-            ArithOp::Div => {
-                if args.len() > 1 && argnum == 0 {
-                    accum = next;
-                } else {
-                    if next == 0. {
-                        xsignal!(Qarith_error);
-                    }
-                    accum /= next;
+            ArithOp::Div => if args.len() > 1 && argnum == 0 {
+                accum = next;
+            } else {
+                if next == 0. {
+                    xsignal!(Qarith_error);
                 }
-            }
+                accum /= next;
+            },
             ArithOp::Logand | ArithOp::Logior | ArithOp::Logxor => {
                 wrong_type!(Qinteger_or_marker_p, val)
             }
@@ -377,12 +375,11 @@ fn round2(i1: EmacsInt, i2: EmacsInt) -> EmacsInt {
     let r = i1 % i2;
     let abs_r = r.abs();
     let abs_r1 = i2.abs() - abs_r;
-    q +
-        if abs_r + (q & 1) <= abs_r1 {
-            0
-        } else if (i2 ^ r) < 0 {
-            -1
-        } else {
-            1
-        }
+    q + if abs_r + (q & 1) <= abs_r1 {
+        0
+    } else if (i2 ^ r) < 0 {
+        -1
+    } else {
+        1
+    }
 }

--- a/rust_src/src/fns.rs
+++ b/rust_src/src/fns.rs
@@ -3,7 +3,7 @@
 use remacs_macros::lisp_fn;
 use remacs_sys::{globals, Qsubfeatures};
 use lisp::LispObject;
-use lists::{memq, get, member};
+use lists::{get, member, memq};
 
 
 /// Return t if FEATURE is present in this Emacs.

--- a/rust_src/src/fonts.rs
+++ b/rust_src/src/fonts.rs
@@ -1,5 +1,5 @@
 use remacs_macros::lisp_fn;
-use remacs_sys::{font, EmacsInt, Qfont_spec, Qfont_entity, Qfont_object};
+use remacs_sys::{font, EmacsInt, Qfont_entity, Qfont_object, Qfont_spec};
 use lisp::LispObject;
 use lisp::intern;
 use vectors::LispVectorlikeRef;
@@ -59,8 +59,9 @@ impl FontExtraType {
 pub fn fontp(object: LispObject, extra_type: LispObject) -> LispObject {
     // For compatibility with the C version, checking that object is a font
     // takes priority over checking that extra_type is well-formed.
-    object.as_font().map_or(LispObject::constant_nil(), |f| {
-        if extra_type.is_nil() {
+    object
+        .as_font()
+        .map_or(LispObject::constant_nil(), |f| if extra_type.is_nil() {
             LispObject::constant_t()
         } else {
             match FontExtraType::from_symbol_or_error(extra_type) {
@@ -68,6 +69,5 @@ pub fn fontp(object: LispObject, extra_type: LispObject) -> LispObject {
                 FontExtraType::Entity => LispObject::from_bool(f.is_font_entity()),
                 FontExtraType::Object => LispObject::from_bool(f.is_font_object()),
             }
-        }
-    })
+        })
 }

--- a/rust_src/src/frames.rs
+++ b/rust_src/src/frames.rs
@@ -1,8 +1,8 @@
 //! Generic frame functions.
 
 use remacs_macros::lisp_fn;
-use remacs_sys::{Lisp_Frame, selected_frame as current_frame};
-use lisp::{LispObject, ExternalPtr};
+use remacs_sys::{selected_frame as current_frame, Lisp_Frame};
+use lisp::{ExternalPtr, LispObject};
 
 pub type LispFrameRef = ExternalPtr<Lisp_Frame>;
 

--- a/rust_src/src/hashtable.rs
+++ b/rust_src/src/hashtable.rs
@@ -1,10 +1,10 @@
 use remacs_macros::lisp_fn;
 use libc::c_void;
-use lisp::{LispObject, ExternalPtr};
-use lists::{put, list};
-use remacs_sys::{Lisp_Hash_Table, PseudovecType, Fcopy_sequence, Faref, hash_lookup, EmacsInt,
-                 EmacsUint, CHECK_IMPURE, hash_remove_from_table, gc_aset, hash_put, EmacsDouble,
-                 hash_clear, Qhash_table_test};
+use lisp::{ExternalPtr, LispObject};
+use lists::{list, put};
+use remacs_sys::{gc_aset, hash_clear, hash_lookup, hash_put, hash_remove_from_table, EmacsDouble,
+                 EmacsInt, EmacsUint, Faref, Fcopy_sequence, Lisp_Hash_Table, PseudovecType,
+                 Qhash_table_test, CHECK_IMPURE};
 use std::ptr;
 
 pub type LispHashTableRef = ExternalPtr<Lisp_Hash_Table>;
@@ -273,9 +273,7 @@ fn hash_table_count(table: LispObject) -> LispObject {
 /// Return the current rehash threshold of TABLE.
 #[lisp_fn]
 fn hash_table_rehash_threshold(table: LispObject) -> LispObject {
-    LispObject::from_float(
-        table.as_hash_table_or_error().rehash_threshold as EmacsDouble,
-    )
+    LispObject::from_float(table.as_hash_table_or_error().rehash_threshold as EmacsDouble)
 }
 
 /// Return the size of TABLE.

--- a/rust_src/src/hashtable.rs
+++ b/rust_src/src/hashtable.rs
@@ -288,7 +288,7 @@ fn hash_table_size(table: LispObject) -> LispObject {
 /// Return the test TABLE uses.
 #[lisp_fn]
 fn hash_table_test(table: LispObject) -> LispObject {
-    LispObject::from_raw(table.as_hash_table_or_error().test.name)
+    LispObject::from(table.as_hash_table_or_error().test.name)
 }
 
 /// Return the weakness of TABLE.
@@ -318,6 +318,6 @@ fn clrhash(table: LispObject) -> LispObject {
 /// returns nil, then (funcall TEST x1 x2) also returns nil.
 #[lisp_fn]
 fn define_hash_table_test(name: LispObject, test: LispObject, hash: LispObject) -> LispObject {
-    let sym = unsafe { LispObject::from_raw(Qhash_table_test) };
+    let sym = unsafe { LispObject::from(Qhash_table_test) };
     put(name, sym, list(&mut [test, hash]))
 }

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -17,13 +17,13 @@ extern crate remacs_sys;
 // Needed for linking.
 extern crate remacs_lib;
 
-extern crate remacs_macros;
+extern crate base64 as base64_crate;
 extern crate libc;
 extern crate md5;
 extern crate rand;
+extern crate remacs_macros;
 extern crate sha1;
 extern crate sha2;
-extern crate base64 as base64_crate;
 
 #[cfg(test)]
 extern crate mock_derive;

--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -9,12 +9,12 @@ use std::mem;
 use std::slice;
 use std::convert::From;
 use std::ops::{Deref, DerefMut};
-use std::fmt::{Debug, Formatter, Error};
+use std::fmt::{Debug, Error, Formatter};
 use libc::{c_char, c_void, intptr_t, ptrdiff_t, uintptr_t};
 
 use multibyte::{Codepoint, LispStringRef, MAX_CHAR};
 use symbols::LispSymbolRef;
-use vectors::{LispVectorlikeRef, LispVectorRef};
+use vectors::{LispVectorRef, LispVectorlikeRef};
 use buffers::{LispBufferRef, LispOverlayRef};
 use windows::LispWindowRef;
 use frames::LispFrameRef;
@@ -26,14 +26,15 @@ use chartable::LispCharTableRef;
 use obarray::LispObarrayRef;
 use threads::ThreadStateRef;
 
-use remacs_sys::{EmacsInt, EmacsUint, EmacsDouble, VALMASK, VALBITS, INTTYPEBITS, INTMASK,
-                 USE_LSB_TAG, MOST_POSITIVE_FIXNUM, MOST_NEGATIVE_FIXNUM, Lisp_Type,
-                 Lisp_Misc_Any, Lisp_Misc_Type, Lisp_Float, Lisp_Cons, Lisp_Object, lispsym,
-                 make_float, circular_list, internal_equal, Fcons, CHECK_IMPURE, Qnil, Qt,
-                 Qnumberp, Qfloatp, Qstringp, Qsymbolp, Qnumber_or_marker_p, Qinteger_or_marker_p,
-                 Qwholenump, Qvectorp, Qcharacterp, Qlistp, Qplistp, Qintegerp, Qhash_table_p,
-                 Qchar_table_p, Qconsp, Qbufferp, Qmarkerp, Qoverlayp, Qwindowp, Qwindow_live_p,
-                 Qframep, Qprocessp, Qthreadp, SYMBOL_NAME, PseudovecType, EqualKind};
+use remacs_sys::{circular_list, internal_equal, lispsym, make_float, EmacsDouble, EmacsInt,
+                 EmacsUint, EqualKind, Fcons, Lisp_Cons, Lisp_Float, Lisp_Misc_Any,
+                 Lisp_Misc_Type, Lisp_Object, Lisp_Type, PseudovecType, Qbufferp, Qchar_table_p,
+                 Qcharacterp, Qconsp, Qfloatp, Qframep, Qhash_table_p, Qinteger_or_marker_p,
+                 Qintegerp, Qlistp, Qmarkerp, Qnil, Qnumber_or_marker_p, Qnumberp, Qoverlayp,
+                 Qplistp, Qprocessp, Qstringp, Qsymbolp, Qt, Qthreadp, Qvectorp, Qwholenump,
+                 Qwindow_live_p, Qwindowp, CHECK_IMPURE, INTMASK, INTTYPEBITS,
+                 MOST_NEGATIVE_FIXNUM, MOST_POSITIVE_FIXNUM, SYMBOL_NAME, USE_LSB_TAG, VALBITS,
+                 VALMASK};
 
 #[cfg(test)]
 use functions::ExternCMocks;
@@ -103,10 +104,10 @@ impl LispObject {
     pub fn get_type(self) -> Lisp_Type {
         let raw = self.to_raw() as EmacsUint;
         let res = (if USE_LSB_TAG {
-                       raw & (!VALMASK as EmacsUint)
-                   } else {
-                       raw >> VALBITS
-                   }) as u8;
+            raw & (!VALMASK as EmacsUint)
+        } else {
+            raw >> VALBITS
+        }) as u8;
         unsafe { mem::transmute(res) }
     }
 
@@ -161,11 +162,9 @@ impl LispObject {
     #[inline]
     pub fn symbol_or_string_as_string(self) -> LispStringRef {
         match self.as_symbol() {
-            Some(sym) => {
-                sym.symbol_name().as_string().expect(
-                    "Expected a symbol name?",
-                )
-            }
+            Some(sym) => sym.symbol_name()
+                .as_string()
+                .expect("Expected a symbol name?"),
             None => self.as_string_or_error(),
         }
     }
@@ -337,8 +336,8 @@ impl LispObject {
     #[inline]
     pub fn is_fixnum(self) -> bool {
         let ty = self.get_type();
-        (ty as u8 & ((Lisp_Type::Lisp_Int0 as u8) | !(Lisp_Type::Lisp_Int1 as u8))) ==
-            Lisp_Type::Lisp_Int0 as u8
+        (ty as u8 & ((Lisp_Type::Lisp_Int0 as u8) | !(Lisp_Type::Lisp_Int1 as u8)))
+            == Lisp_Type::Lisp_Int0 as u8
     }
 
     #[inline]
@@ -435,9 +434,8 @@ impl LispObject {
 
 impl LispObject {
     pub fn is_thread(self) -> bool {
-        self.as_vectorlike().map_or(false, |v| {
-            v.is_pseudovector(PseudovecType::PVEC_THREAD)
-        })
+        self.as_vectorlike()
+            .map_or(false, |v| v.is_pseudovector(PseudovecType::PVEC_THREAD))
     }
 
     pub fn as_thread(self) -> Option<ThreadStateRef> {
@@ -445,39 +443,33 @@ impl LispObject {
     }
 
     pub fn as_thread_or_error(self) -> ThreadStateRef {
-        self.as_thread().unwrap_or_else(
-            || wrong_type!(Qthreadp, self),
-        )
+        self.as_thread()
+            .unwrap_or_else(|| wrong_type!(Qthreadp, self))
     }
 
     pub fn is_mutex(self) -> bool {
-        self.as_vectorlike().map_or(false, |v| {
-            v.is_pseudovector(PseudovecType::PVEC_MUTEX)
-        })
+        self.as_vectorlike()
+            .map_or(false, |v| v.is_pseudovector(PseudovecType::PVEC_MUTEX))
     }
 
     pub fn is_condition_variable(self) -> bool {
-        self.as_vectorlike().map_or(false, |v| {
-            v.is_pseudovector(PseudovecType::PVEC_CONDVAR)
-        })
+        self.as_vectorlike()
+            .map_or(false, |v| v.is_pseudovector(PseudovecType::PVEC_CONDVAR))
     }
 
     pub fn is_byte_code_function(self) -> bool {
-        self.as_vectorlike().map_or(false, |v| {
-            v.is_pseudovector(PseudovecType::PVEC_COMPILED)
-        })
+        self.as_vectorlike()
+            .map_or(false, |v| v.is_pseudovector(PseudovecType::PVEC_COMPILED))
     }
 
     pub fn is_subr(self) -> bool {
-        self.as_vectorlike().map_or(false, |v| {
-            v.is_pseudovector(PseudovecType::PVEC_SUBR)
-        })
+        self.as_vectorlike()
+            .map_or(false, |v| v.is_pseudovector(PseudovecType::PVEC_SUBR))
     }
 
     pub fn is_buffer(self) -> bool {
-        self.as_vectorlike().map_or(false, |v| {
-            v.is_pseudovector(PseudovecType::PVEC_BUFFER)
-        })
+        self.as_vectorlike()
+            .map_or(false, |v| v.is_pseudovector(PseudovecType::PVEC_BUFFER))
     }
 
     pub fn as_buffer(self) -> Option<LispBufferRef> {
@@ -485,15 +477,13 @@ impl LispObject {
     }
 
     pub fn as_buffer_or_error(self) -> LispBufferRef {
-        self.as_buffer().unwrap_or_else(
-            || wrong_type!(Qbufferp, self),
-        )
+        self.as_buffer()
+            .unwrap_or_else(|| wrong_type!(Qbufferp, self))
     }
 
     pub fn is_char_table(self) -> bool {
-        self.as_vectorlike().map_or(false, |v| {
-            v.is_pseudovector(PseudovecType::PVEC_CHAR_TABLE)
-        })
+        self.as_vectorlike()
+            .map_or(false, |v| v.is_pseudovector(PseudovecType::PVEC_CHAR_TABLE))
     }
 
     pub fn as_char_table(self) -> Option<LispCharTableRef> {
@@ -530,9 +520,8 @@ impl LispObject {
     }
 
     pub fn is_process(self) -> bool {
-        self.as_vectorlike().map_or(false, |v| {
-            v.is_pseudovector(PseudovecType::PVEC_PROCESS)
-        })
+        self.as_vectorlike()
+            .map_or(false, |v| v.is_pseudovector(PseudovecType::PVEC_PROCESS))
     }
 
     pub fn as_process(self) -> Option<LispProcessRef> {
@@ -540,15 +529,13 @@ impl LispObject {
     }
 
     pub fn as_process_or_error(self) -> LispProcessRef {
-        self.as_process().unwrap_or_else(
-            || wrong_type!(Qprocessp, self),
-        )
+        self.as_process()
+            .unwrap_or_else(|| wrong_type!(Qprocessp, self))
     }
 
     pub fn is_window(self) -> bool {
-        self.as_vectorlike().map_or(false, |v| {
-            v.is_pseudovector(PseudovecType::PVEC_WINDOW)
-        })
+        self.as_vectorlike()
+            .map_or(false, |v| v.is_pseudovector(PseudovecType::PVEC_WINDOW))
     }
 
     pub fn as_window(self) -> Option<LispWindowRef> {
@@ -556,15 +543,13 @@ impl LispObject {
     }
 
     pub fn as_window_or_error(self) -> LispWindowRef {
-        self.as_window().unwrap_or_else(
-            || wrong_type!(Qwindowp, self),
-        )
+        self.as_window()
+            .unwrap_or_else(|| wrong_type!(Qwindowp, self))
     }
 
     pub fn as_minibuffer_or_error(self) -> LispWindowRef {
-        let w = self.as_window().unwrap_or_else(
-            || wrong_type!(Qwindowp, self),
-        );
+        let w = self.as_window()
+            .unwrap_or_else(|| wrong_type!(Qwindowp, self));
         if !w.is_minibuffer() {
             error!("Window is not a minibuffer window");
         }
@@ -580,9 +565,8 @@ impl LispObject {
     }
 
     pub fn is_frame(self) -> bool {
-        self.as_vectorlike().map_or(false, |v| {
-            v.is_pseudovector(PseudovecType::PVEC_FRAME)
-        })
+        self.as_vectorlike()
+            .map_or(false, |v| v.is_pseudovector(PseudovecType::PVEC_FRAME))
     }
 
     pub fn as_frame(self) -> Option<LispFrameRef> {
@@ -590,38 +574,32 @@ impl LispObject {
     }
 
     pub fn as_frame_or_error(self) -> LispFrameRef {
-        self.as_frame().unwrap_or_else(
-            || wrong_type!(Qframep, self),
-        )
+        self.as_frame()
+            .unwrap_or_else(|| wrong_type!(Qframep, self))
     }
 
     pub fn is_hash_table(self) -> bool {
-        self.as_vectorlike().map_or(false, |v| {
-            v.is_pseudovector(PseudovecType::PVEC_HASH_TABLE)
-        })
+        self.as_vectorlike()
+            .map_or(false, |v| v.is_pseudovector(PseudovecType::PVEC_HASH_TABLE))
     }
 
     pub fn is_font(self) -> bool {
-        self.as_vectorlike().map_or(false, |v| {
-            v.is_pseudovector(PseudovecType::PVEC_FONT)
-        })
+        self.as_vectorlike()
+            .map_or(false, |v| v.is_pseudovector(PseudovecType::PVEC_FONT))
     }
 
     pub fn as_font(self) -> Option<LispFontRef> {
-        self.as_vectorlike().map_or(None, |v| if v.is_pseudovector(
-            PseudovecType::PVEC_FONT,
-        )
-        {
-            Some(LispFontRef::from_vectorlike(v))
-        } else {
-            None
-        })
+        self.as_vectorlike()
+            .map_or(None, |v| if v.is_pseudovector(PseudovecType::PVEC_FONT) {
+                Some(LispFontRef::from_vectorlike(v))
+            } else {
+                None
+            })
     }
 
     pub fn is_record(self) -> bool {
-        self.as_vectorlike().map_or(false, |v| {
-            v.is_pseudovector(PseudovecType::PVEC_RECORD)
-        })
+        self.as_vectorlike()
+            .map_or(false, |v| v.is_pseudovector(PseudovecType::PVEC_RECORD))
     }
 }
 
@@ -876,16 +854,14 @@ impl LispObject {
 
     /// If the LispObject is a number (of any kind), get a floating point value for it
     pub fn any_to_float(self) -> Option<EmacsDouble> {
-        self.as_float().or_else(
-            || self.as_fixnum().map(|i| i as EmacsDouble),
-        )
+        self.as_float()
+            .or_else(|| self.as_fixnum().map(|i| i as EmacsDouble))
     }
 
     pub fn any_to_float_or_error(self) -> EmacsDouble {
         self.as_float().unwrap_or_else(|| {
-            self.as_fixnum().unwrap_or_else(
-                || wrong_type!(Qnumberp, self),
-            ) as EmacsDouble
+            self.as_fixnum()
+                .unwrap_or_else(|| wrong_type!(Qnumberp, self)) as EmacsDouble
         })
     }
 }
@@ -973,35 +949,29 @@ impl LispObject {
 
     #[inline]
     pub fn is_marker(self) -> bool {
-        self.as_misc().map_or(
-            false,
-            |m| m.ty == Lisp_Misc_Type::Marker,
-        )
+        self.as_misc()
+            .map_or(false, |m| m.ty == Lisp_Misc_Type::Marker)
     }
 
     #[inline]
     pub fn as_marker(self) -> Option<LispMarkerRef> {
-        self.as_misc().and_then(
-            |m| if m.ty == Lisp_Misc_Type::Marker {
+        self.as_misc()
+            .and_then(|m| if m.ty == Lisp_Misc_Type::Marker {
                 unsafe { Some(mem::transmute(m)) }
             } else {
                 None
-            },
-        )
+            })
     }
 
     pub fn as_marker_or_error(self) -> LispMarkerRef {
-        self.as_marker().unwrap_or_else(
-            || wrong_type!(Qmarkerp, self),
-        )
+        self.as_marker()
+            .unwrap_or_else(|| wrong_type!(Qmarkerp, self))
     }
 
     /// Nonzero iff X is a character.
     pub fn is_character(self) -> bool {
-        self.as_fixnum().map_or(
-            false,
-            |i| 0 <= i && i <= MAX_CHAR as EmacsInt,
-        )
+        self.as_fixnum()
+            .map_or(false, |i| 0 <= i && i <= MAX_CHAR as EmacsInt)
     }
 
     /// Check if Lisp object is a character or not and return the codepoint
@@ -1016,26 +986,22 @@ impl LispObject {
 
     #[inline]
     pub fn is_overlay(self) -> bool {
-        self.as_misc().map_or(
-            false,
-            |m| m.ty == Lisp_Misc_Type::Overlay,
-        )
+        self.as_misc()
+            .map_or(false, |m| m.ty == Lisp_Misc_Type::Overlay)
     }
 
     pub fn as_overlay(self) -> Option<LispOverlayRef> {
-        self.as_misc().and_then(
-            |m| if m.ty == Lisp_Misc_Type::Overlay {
+        self.as_misc()
+            .and_then(|m| if m.ty == Lisp_Misc_Type::Overlay {
                 unsafe { Some(mem::transmute(m)) }
             } else {
                 None
-            },
-        )
+            })
     }
 
     pub fn as_overlay_or_error(self) -> LispOverlayRef {
-        self.as_overlay().unwrap_or_else(
-            || wrong_type!(Qoverlayp, self),
-        )
+        self.as_overlay()
+            .unwrap_or_else(|| wrong_type!(Qoverlayp, self))
     }
 
     // The three Emacs Lisp comparison functions.
@@ -1130,8 +1096,7 @@ impl Debug for LispObject {
                     )?;
                 }
             }
-            Lisp_Type::Lisp_Int0 |
-            Lisp_Type::Lisp_Int1 => {
+            Lisp_Type::Lisp_Int0 | Lisp_Type::Lisp_Int1 => {
                 write!(f, "{}", self.as_fixnum().unwrap())?;
             }
             Lisp_Type::Lisp_Misc => {
@@ -1148,11 +1113,8 @@ impl Debug for LispObject {
 /// Intern (e.g. create a symbol from) a string.
 pub fn intern<T: AsRef<str>>(string: T) -> LispObject {
     let s = string.as_ref();
-    LispObarrayRef::constant_obarray().intern_cstring(
-        s.as_ptr() as
-            *const c_char,
-        s.len() as ptrdiff_t,
-    )
+    LispObarrayRef::constant_obarray()
+        .intern_cstring(s.as_ptr() as *const c_char, s.len() as ptrdiff_t)
 }
 
 #[test]
@@ -1162,7 +1124,9 @@ fn test_basic_float() {
         .called_once()
         .return_result_of(move || {
             // Fake an allocated float by just putting it on the heap and leaking it.
-            let boxed = Box::new(Lisp_Float { data: unsafe { mem::transmute(val) } });
+            let boxed = Box::new(Lisp_Float {
+                data: unsafe { mem::transmute(val) },
+            });
             let raw = ExternalPtr::new(Box::into_raw(boxed));
             LispObject::tag_ptr(raw, Lisp_Type::Lisp_Float).to_raw()
         });

--- a/rust_src/src/lists.rs
+++ b/rust_src/src/lists.rs
@@ -1,7 +1,7 @@
 //! Operations on lists.
 
 use lisp::LispObject;
-use remacs_sys::{Qlistp, Qplistp, EmacsInt, globals};
+use remacs_sys::{globals, EmacsInt, Qlistp, Qplistp};
 use remacs_macros::lisp_fn;
 
 /// Return t if OBJECT is not a cons cell.  This includes nil.
@@ -78,19 +78,17 @@ pub fn cdr(list: LispObject) -> LispObject {
 /// Return the car of OBJECT if it is a cons cell, or else nil.
 #[lisp_fn]
 fn car_safe(object: LispObject) -> LispObject {
-    object.as_cons().map_or(
-        LispObject::constant_nil(),
-        |cons| cons.car(),
-    )
+    object
+        .as_cons()
+        .map_or(LispObject::constant_nil(), |cons| cons.car())
 }
 
 /// Return the cdr of OBJECT if it is a cons cell, or else nil.
 #[lisp_fn]
 fn cdr_safe(object: LispObject) -> LispObject {
-    object.as_cons().map_or(
-        LispObject::constant_nil(),
-        |cons| cons.cdr(),
-    )
+    object
+        .as_cons()
+        .map_or(LispObject::constant_nil(), |cons| cons.cdr())
 }
 
 /// Take cdr N times on LIST, return the result.
@@ -267,11 +265,9 @@ fn plist_get(plist: LispObject, prop: LispObject) -> LispObject {
         if prop_item {
             match tail.cdr().as_cons() {
                 None => break,
-                Some(tail_cdr_cons) => {
-                    if tail.car().eq(prop) {
-                        return tail_cdr_cons.car();
-                    }
-                }
+                Some(tail_cdr_cons) => if tail.car().eq(prop) {
+                    return tail_cdr_cons.car();
+                },
             }
         }
         prop_item = !prop_item;
@@ -297,11 +293,9 @@ fn lax_plist_get(plist: LispObject, prop: LispObject) -> LispObject {
                     }
                     break;
                 }
-                Some(tail_cdr_cons) => {
-                    if tail.car().equal(prop) {
-                        return tail_cdr_cons.car();
-                    }
-                }
+                Some(tail_cdr_cons) => if tail.car().equal(prop) {
+                    return tail_cdr_cons.car();
+                },
             }
         }
         prop_item = !prop_item;
@@ -418,10 +412,11 @@ pub fn put(symbol: LispObject, propname: LispObject, value: LispObject) -> LispO
 /// usage: (list &rest OBJECTS)
 #[lisp_fn]
 pub fn list(args: &mut [LispObject]) -> LispObject {
-    args.iter().rev().fold(
-        LispObject::constant_nil(),
-        |list, &arg| LispObject::cons(arg, list),
-    )
+    args.iter()
+        .rev()
+        .fold(LispObject::constant_nil(), |list, &arg| {
+            LispObject::cons(arg, list)
+        })
 }
 
 /// Return a newly created list of length LENGTH, with each element being INIT.

--- a/rust_src/src/marker.rs
+++ b/rust_src/src/marker.rs
@@ -2,7 +2,7 @@ use libc::{c_void, ptrdiff_t};
 use std::mem;
 
 use remacs_sys::make_lisp_ptr;
-use lisp::{LispObject, ExternalPtr};
+use lisp::{ExternalPtr, LispObject};
 use remacs_sys::{buf_charpos_to_bytepos, set_point_both, EmacsInt, Lisp_Marker, Lisp_Type};
 use remacs_macros::lisp_fn;
 use util::clip_to_bounds;
@@ -45,7 +45,6 @@ impl LispMarkerRef {
         } else {
             Some(unsafe { mem::transmute(buf) })
         }
-
     }
 }
 

--- a/rust_src/src/math.rs
+++ b/rust_src/src/math.rs
@@ -1,7 +1,7 @@
 //! Functions doing math on numbers.
 
 use floatfns;
-use lisp::{LispObject, LispNumber};
+use lisp::{LispNumber, LispObject};
 use remacs_sys::{EmacsInt, Qarith_error, Qnumberp};
 use remacs_macros::lisp_fn;
 
@@ -300,19 +300,36 @@ pub extern "C" fn arithcompare(
     let result = match comparison {
         ArithComparison::Equal => !fneq && i1 == i2,
         ArithComparison::Notequal => fneq || i1 != i2,
-        ArithComparison::Less => if fneq { f1 < f2 } else { i1 < i2 },
-        ArithComparison::LessOrEqual => if fneq { f1 <= f2 } else { i1 <= i2 },
-        ArithComparison::Grtr => if fneq { f1 > f2 } else { i1 > i2 },
-        ArithComparison::GrtrOrEqual => if fneq { f1 >= f2 } else { i1 >= i2 },
+        ArithComparison::Less => if fneq {
+            f1 < f2
+        } else {
+            i1 < i2
+        },
+        ArithComparison::LessOrEqual => if fneq {
+            f1 <= f2
+        } else {
+            i1 <= i2
+        },
+        ArithComparison::Grtr => if fneq {
+            f1 > f2
+        } else {
+            i1 > i2
+        },
+        ArithComparison::GrtrOrEqual => if fneq {
+            f1 >= f2
+        } else {
+            i1 >= i2
+        },
     };
 
     LispObject::from_bool(result)
 }
 
 fn arithcompare_driver(args: &[LispObject], comparison: ArithComparison) -> LispObject {
-    LispObject::from_bool(args.windows(2).all(|i| {
-        arithcompare(i[0], i[1], comparison).is_not_nil()
-    }))
+    LispObject::from_bool(
+        args.windows(2)
+            .all(|i| arithcompare(i[0], i[1], comparison).is_not_nil()),
+    )
 }
 
 /// Return t if args, all numbers or markers, are equal.

--- a/rust_src/src/minibuf.rs
+++ b/rust_src/src/minibuf.rs
@@ -2,7 +2,7 @@
 
 use remacs_macros::lisp_fn;
 use lisp::LispObject;
-use remacs_sys::{Vminibuffer_list, minibuf_level, minibuf_window};
+use remacs_sys::{minibuf_level, minibuf_window, Vminibuffer_list};
 use buffers::{current_buffer, get_buffer};
 use lists::memq;
 
@@ -20,9 +20,7 @@ pub fn minibufferp(object: LispObject) -> LispObject {
         object.as_buffer_or_error();
         object
     };
-    LispObject::from_bool(
-        memq(buffer, LispObject::from(unsafe { Vminibuffer_list })).is_not_nil(),
-    )
+    LispObject::from_bool(memq(buffer, LispObject::from(unsafe { Vminibuffer_list })).is_not_nil())
 }
 
 /// Return the currently active minibuffer window, or nil if none.

--- a/rust_src/src/multibyte.rs
+++ b/rust_src/src/multibyte.rs
@@ -34,11 +34,11 @@
 
 use std::ptr;
 use std::slice;
-use libc::{ptrdiff_t, c_char, c_uchar, c_uint, c_int};
+use libc::{c_char, c_int, c_uchar, c_uint, ptrdiff_t};
 
 use lisp::ExternalPtr;
-use remacs_sys::{CHAR_MODIFIER_MASK, CHAR_SHIFT, CHAR_CTL, emacs_abort, CHARACTERBITS, EmacsInt,
-                 Lisp_String};
+use remacs_sys::{emacs_abort, EmacsInt, Lisp_String, CHARACTERBITS, CHAR_CTL, CHAR_MODIFIER_MASK,
+                 CHAR_SHIFT};
 
 pub type LispStringRef = ExternalPtr<Lisp_String>;
 
@@ -404,21 +404,23 @@ pub fn multibyte_char_at(slice: &[c_uchar]) -> (Codepoint, usize) {
         }
     } else if head & 0x10 == 0 {
         (
-            ((head & 0x0F) << 12) | ((slice[1] as Codepoint & 0x3F) << 6) |
-                (slice[2] as Codepoint & 0x3F),
+            ((head & 0x0F) << 12) | ((slice[1] as Codepoint & 0x3F) << 6)
+                | (slice[2] as Codepoint & 0x3F),
             3,
         )
     } else if head & 0x08 == 0 {
         (
-            ((head & 0x07) << 18) | ((slice[1] as Codepoint & 0x3F) << 12) |
-                ((slice[2] as Codepoint & 0x3F) << 6) | (slice[3] as Codepoint & 0x3F),
+            ((head & 0x07) << 18) | ((slice[1] as Codepoint & 0x3F) << 12)
+                | ((slice[2] as Codepoint & 0x3F) << 6)
+                | (slice[3] as Codepoint & 0x3F),
             4,
         )
     } else {
         // the relevant bytes of "head" are always zero
         (
-            ((slice[1] as Codepoint & 0x3F) << 18) | ((slice[2] as Codepoint & 0x3F) << 12) |
-                ((slice[3] as Codepoint & 0x3F) << 6) | (slice[4] as Codepoint & 0x3F),
+            ((slice[1] as Codepoint & 0x3F) << 18) | ((slice[2] as Codepoint & 0x3F) << 12)
+                | ((slice[3] as Codepoint & 0x3F) << 6)
+                | (slice[4] as Codepoint & 0x3F),
             5,
         )
     }
@@ -548,13 +550,11 @@ pub fn str_as_multibyte(
         while from < slice.len() {
             chars += 1;
             match multibyte_length(&slice[from..], false) {
-                Some(n) => {
-                    for _ in 0..n {
-                        slice[to] = slice[from];
-                        from += 1;
-                        to += 1;
-                    }
-                }
+                Some(n) => for _ in 0..n {
+                    slice[to] = slice[from];
+                    from += 1;
+                    to += 1;
+                },
                 None => {
                     let byte = slice[from];
                     to += write_codepoint(&mut slice[to..], raw_byte_codepoint(byte));
@@ -595,13 +595,11 @@ pub fn str_as_unibyte(ptr: *mut c_uchar, bytes: ptrdiff_t) -> ptrdiff_t {
                 from += 2;
                 to += 1;
             }
-            n => {
-                for _ in 0..n {
-                    slice[to] = slice[from];
-                    from += 1;
-                    to += 1;
-                }
-            }
+            n => for _ in 0..n {
+                slice[to] = slice[from];
+                from += 1;
+                to += 1;
+            },
         }
     }
     to as ptrdiff_t

--- a/rust_src/src/numbers.rs
+++ b/rust_src/src/numbers.rs
@@ -1,7 +1,7 @@
 //! Functions operating on numbers.
 
 use std::sync::Mutex;
-use rand::{StdRng, Rng, SeedableRng};
+use rand::{Rng, SeedableRng, StdRng};
 
 use lisp::LispObject;
 use remacs_sys::{EmacsInt, INTMASK};

--- a/rust_src/src/obarray.rs
+++ b/rust_src/src/obarray.rs
@@ -1,8 +1,8 @@
 use libc;
 use remacs_macros::lisp_fn;
 use lisp::LispObject;
-use remacs_sys::{Lisp_Object, check_obarray, check_vobarray, Fpurecopy, globals, intern_driver,
-                 make_unibyte_string, oblookup};
+use remacs_sys::{check_obarray, check_vobarray, globals, intern_driver, make_unibyte_string,
+                 oblookup, Fpurecopy, Lisp_Object};
 
 /// A lisp object containing an `obarray`.
 pub struct LispObarrayRef(LispObject);

--- a/rust_src/src/process.rs
+++ b/rust_src/src/process.rs
@@ -81,5 +81,5 @@ pub fn get_buffer_process(buffer: LispObject) -> LispObject {
 /// Return a list of all processes that are Emacs sub-processes.
 #[lisp_fn]
 pub fn process_list() -> LispObject {
-    LispObject::from_raw(unsafe { Fmapcar(Qcdr, Vprocess_alist) })
+    LispObject::from(unsafe { Fmapcar(Qcdr, Vprocess_alist) })
 }

--- a/rust_src/src/str2sig.rs
+++ b/rust_src/src/str2sig.rs
@@ -82,14 +82,12 @@ pub unsafe extern "C" fn str2sig(signame: *const c_char, signum: *mut c_int) -> 
             *signum = i;
             return 0;
         }
-        Err(_) => {
-            for &(name, num) in numname.iter() {
-                if name == s {
-                    *signum = num;
-                    return 0;
-                }
+        Err(_) => for &(name, num) in numname.iter() {
+            if name == s {
+                *signum = num;
+                return 0;
             }
-        }
+        },
     }
     -1
 }

--- a/rust_src/src/strings.rs
+++ b/rust_src/src/strings.rs
@@ -6,8 +6,8 @@ use libc::{self, c_void};
 
 use lisp::LispObject;
 use multibyte;
-use remacs_sys::{SYMBOL_NAME, EmacsInt, make_unibyte_string, make_uninit_multibyte_string,
-                 string_to_multibyte as c_string_to_multibyte};
+use remacs_sys::{make_unibyte_string, make_uninit_multibyte_string,
+                 string_to_multibyte as c_string_to_multibyte, EmacsInt, SYMBOL_NAME};
 use remacs_macros::lisp_fn;
 
 pub static MIME_LINE_LENGTH: isize = 76;
@@ -41,14 +41,13 @@ pub fn string_equal(mut s1: LispObject, mut s2: LispObject) -> LispObject {
     let mut s2 = s2.as_string_or_error();
 
     LispObject::from_bool(
-        s1.len_chars() == s2.len_chars() && s1.len_bytes() == s2.len_bytes() &&
-            unsafe {
-                libc::memcmp(
-                    s1.data_ptr() as *mut c_void,
-                    s2.data_ptr() as *mut c_void,
-                    s1.len_bytes() as usize,
-                ) == 0
-            },
+        s1.len_chars() == s2.len_chars() && s1.len_bytes() == s2.len_bytes() && unsafe {
+            libc::memcmp(
+                s1.data_ptr() as *mut c_void,
+                s2.data_ptr() as *mut c_void,
+                s1.len_bytes() as usize,
+            ) == 0
+        },
     )
 }
 

--- a/rust_src/src/symbols.rs
+++ b/rust_src/src/symbols.rs
@@ -1,8 +1,8 @@
 use remacs_macros::lisp_fn;
 use std::mem;
-use lisp::{LispObject, ExternalPtr};
-use remacs_sys::{make_lisp_symbol, Lisp_Symbol, Symbol_Interned, Symbol_Redirect,
-                 Qsetting_constant, Qcyclic_variable_indirection};
+use lisp::{ExternalPtr, LispObject};
+use remacs_sys::{make_lisp_symbol, Lisp_Symbol, Qcyclic_variable_indirection, Qsetting_constant,
+                 Symbol_Interned, Symbol_Redirect};
 
 pub type LispSymbolRef = ExternalPtr<Lisp_Symbol>;
 
@@ -31,8 +31,8 @@ impl LispSymbolRef {
     }
 
     pub fn is_interned_in_initial_obarray(&self) -> bool {
-        self.symbol_bitfield & FLAG_INTERNED ==
-            (Symbol_Interned::InternedInInitialObarray as u32) << 6
+        self.symbol_bitfield & FLAG_INTERNED
+            == (Symbol_Interned::InternedInInitialObarray as u32) << 6
     }
 
     pub fn is_alias(&self) -> bool {
@@ -146,9 +146,7 @@ fn fmakunbound(symbol: LispObject) -> LispObject {
 fn keywordp(object: LispObject) -> LispObject {
     if let Some(sym) = object.as_symbol() {
         let name = sym.symbol_name().as_string_or_error();
-        LispObject::from_bool(
-            name.byte_at(0) == b':' && sym.is_interned_in_initial_obarray(),
-        )
+        LispObject::from_bool(name.byte_at(0) == b':' && sym.is_interned_in_initial_obarray())
     } else {
         LispObject::constant_nil()
     }

--- a/rust_src/src/threads.rs
+++ b/rust_src/src/threads.rs
@@ -1,7 +1,7 @@
 //! Threading code.
 
 use std::mem;
-use remacs_sys::{thread_state, current_thread};
+use remacs_sys::{current_thread, thread_state};
 use remacs_macros::lisp_fn;
 use lisp::{ExternalPtr, LispObject};
 use buffers::LispBufferRef;

--- a/rust_src/src/vectors.rs
+++ b/rust_src/src/vectors.rs
@@ -9,16 +9,16 @@ use libc::ptrdiff_t;
 
 use lisp::{ExternalPtr, LispObject};
 use multibyte::MAX_CHAR;
-use lists::{sort_list, inorder, nthcdr, car};
+use lists::{car, inorder, nthcdr, sort_list};
 use buffers::LispBufferRef;
 use windows::LispWindowRef;
 use frames::LispFrameRef;
 use process::LispProcessRef;
 use chartable::LispCharTableRef;
 use threads::ThreadStateRef;
-use remacs_sys::{Qsequencep, EmacsInt, PSEUDOVECTOR_FLAG, PVEC_TYPE_MASK, PSEUDOVECTOR_AREA_BITS,
-                 PSEUDOVECTOR_SIZE_MASK, PseudovecType, Lisp_Vectorlike, Lisp_Vector,
-                 Lisp_Bool_Vector, MOST_POSITIVE_FIXNUM, Faref};
+use remacs_sys::{EmacsInt, Faref, Lisp_Bool_Vector, Lisp_Vector, Lisp_Vectorlike, PseudovecType,
+                 Qsequencep, MOST_POSITIVE_FIXNUM, PSEUDOVECTOR_AREA_BITS, PSEUDOVECTOR_FLAG,
+                 PSEUDOVECTOR_SIZE_MASK, PVEC_TYPE_MASK};
 use remacs_macros::lisp_fn;
 
 pub type LispVectorlikeRef = ExternalPtr<Lisp_Vectorlike>;
@@ -47,8 +47,8 @@ impl LispVectorlikeRef {
 
     #[inline]
     pub fn is_pseudovector(&self, tp: PseudovecType) -> bool {
-        self.header.size & (PSEUDOVECTOR_FLAG | PVEC_TYPE_MASK) ==
-            (PSEUDOVECTOR_FLAG | ((tp as isize) << PSEUDOVECTOR_AREA_BITS))
+        self.header.size & (PSEUDOVECTOR_FLAG | PVEC_TYPE_MASK)
+            == (PSEUDOVECTOR_FLAG | ((tp as isize) << PSEUDOVECTOR_AREA_BITS))
     }
 
     #[inline]
@@ -148,9 +148,7 @@ impl LispVectorRef {
 
     #[inline]
     pub unsafe fn get_unchecked(&self, idx: ptrdiff_t) -> LispObject {
-        ptr::read(
-            mem::transmute::<_, *const LispObject>(&self.contents).offset(idx),
-        )
+        ptr::read(mem::transmute::<_, *const LispObject>(&self.contents).offset(idx))
     }
 
     #[inline]
@@ -182,8 +180,8 @@ pub fn length(sequence: LispObject) -> LispObject {
             return LispObject::from_natnum(bv.len() as EmacsInt);
         } else if vl.is_pseudovector(PseudovecType::PVEC_CHAR_TABLE) {
             return LispObject::from_natnum(MAX_CHAR as EmacsInt);
-        } else if vl.is_pseudovector(PseudovecType::PVEC_COMPILED) ||
-                   vl.is_pseudovector(PseudovecType::PVEC_RECORD)
+        } else if vl.is_pseudovector(PseudovecType::PVEC_COMPILED)
+            || vl.is_pseudovector(PseudovecType::PVEC_RECORD)
         {
             return LispObject::from_natnum(vl.pseudovector_size());
         }

--- a/rust_src/src/windows.rs
+++ b/rust_src/src/windows.rs
@@ -1,9 +1,9 @@
 //! Functions operating on windows.
 
-use lisp::{LispObject, ExternalPtr};
+use lisp::{ExternalPtr, LispObject};
 use remacs_macros::lisp_fn;
-use remacs_sys::{EmacsInt, Lisp_Window, selected_window as current_window,
-                 minibuf_selected_window as current_minibuf_window, minibuf_level};
+use remacs_sys::{minibuf_level, minibuf_selected_window as current_minibuf_window,
+                 selected_window as current_window, EmacsInt, Lisp_Window};
 use marker::marker_position;
 use editfns::point;
 use libc::c_int;
@@ -107,10 +107,11 @@ pub fn window_buffer(window: LispObject) -> LispObject {
 /// window.  Windows that have been deleted are not valid.
 #[lisp_fn]
 pub fn window_valid_p(object: LispObject) -> LispObject {
-    LispObject::from_bool(object.as_window().map_or(
-        false,
-        |win| win.contents().is_not_nil(),
-    ))
+    LispObject::from_bool(
+        object
+            .as_window()
+            .map_or(false, |win| win.contents().is_not_nil()),
+    )
 }
 
 /// Return position at which display currently starts in WINDOW.
@@ -171,8 +172,8 @@ pub fn window_margins(window: LispObject) -> LispObject {
 pub fn minibuffer_selected_window() -> LispObject {
     let level = unsafe { minibuf_level };
     let current_minibuf = unsafe { LispObject::from(current_minibuf_window) };
-    if level > 0 && selected_window().as_window_or_error().is_minibuffer() &&
-        current_minibuf.as_window().unwrap().is_live()
+    if level > 0 && selected_window().as_window_or_error().is_minibuffer()
+        && current_minibuf.as_window().unwrap().is_live()
     {
         current_minibuf
     } else {


### PR DESCRIPTION
The `rustfmt` crate is no longer updated however, it is only kept around for compatibility with stable Rust. See https://users.rust-lang.org/t/rustfmt-releases/11357 and the linked blog post: New development is happening on a new crate which is recommended.

Of course, this requires a one-time reformat of all the Remacs code and an update to developers' configurations, which might outweigh the benefit of getting the new lints.

If one follows the `rustfmt` team's recommendation and uses the `rustfmt-nightly` crate it creates a lot of inconvenient diffs when developing. I believe the one-time pain is worth being on the latest and maintained formatter.