### PR TITLE
Port window-frame

### DIFF
--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -257,6 +257,7 @@ pub extern "C" fn rust_init_syms() {
         defsubr(&*windows::Swindow_start);
         defsubr(&*windows::Swindow_margins);
         defsubr(&*windows::Sminibuffer_selected_window);
+        defsubr(&*windows::Swindow_frame);
         defsubr(&*process::Sget_process);
         defsubr(&*process::Sprocessp);
         defsubr(&*process::Sprocess_name);

--- a/rust_src/src/windows.rs
+++ b/rust_src/src/windows.rs
@@ -32,7 +32,7 @@ impl LispWindowRef {
 
     #[inline]
     pub fn frame(&self) -> LispObject {
-        LispObject::from_raw(self.frame)
+        LispObject::from(self.frame)
     }
 
     #[inline]

--- a/rust_src/src/windows.rs
+++ b/rust_src/src/windows.rs
@@ -31,6 +31,11 @@ impl LispWindowRef {
     }
 
     #[inline]
+    pub fn frame(&self) -> LispObject {
+        LispObject::from_raw(self.frame)
+    }
+
+    #[inline]
     pub fn start_marker(self) -> LispObject {
         LispObject::from_raw(self.start)
     }
@@ -178,4 +183,18 @@ pub fn minibuffer_selected_window() -> LispObject {
     } else {
         LispObject::constant_nil()
     }
+}
+
+/// Return the frame that window WINDOW is on.
+/// WINDOW is optional and defaults to the selected window. If provided it must
+/// be a valid window.
+#[lisp_fn(min = "0")]
+pub fn window_frame(window: LispObject) -> LispObject {
+    let win = if window.is_nil() {
+        selected_window()
+    } else {
+        window
+    };
+
+    win.as_window_or_error().frame()
 }

--- a/src/window.c
+++ b/src/window.c
@@ -301,15 +301,6 @@ wset_buffer (struct window *w, Lisp_Object val)
   adjust_window_count (w, 1);
 }
 
-/* Frames and windows.  */
-DEFUN ("window-frame", Fwindow_frame, Swindow_frame, 0, 1, 0,
-       doc: /* Return the frame that window WINDOW is on.
-WINDOW must be a valid window and defaults to the selected one.  */)
-  (Lisp_Object window)
-{
-  return decode_valid_window (window)->frame;
-}
-
 DEFUN ("frame-root-window", Fframe_root_window, Sframe_root_window, 0, 1, 0,
        doc: /* Return the root window of FRAME-OR-WINDOW.
 If omitted, FRAME-OR-WINDOW defaults to the currently selected frame.
@@ -7626,7 +7617,6 @@ displayed after a scrolling operation to be somewhat inaccurate.  */);
   Vfast_but_imprecise_scrolling = false;
 
   defsubr (&Sminibuffer_window);
-  defsubr (&Swindow_frame);
   defsubr (&Sframe_root_window);
   defsubr (&Sframe_first_window);
   defsubr (&Sframe_selected_window);


### PR DESCRIPTION
Add a `frame` method to `LispWindowRef` to get the window's frame.