### PR TITLE
Add rustfmt helper example.

### DIFF
--- a/rust_src/rustfmt.helper.sh
+++ b/rust_src/rustfmt.helper.sh
@@ -4,6 +4,6 @@
 #
 #     (setq rust-format-on-save t)
 #
-# Then make sure this script is in your path before ~/.cargo/bin
+# Then make sure this script is named `rustfmt` and in your path before ~/.cargo/bin.
 
 LD_LIBRARY_PATH=$(rustc --print sysroot)/lib:$LD_LIBRARY_PATH ~/.cargo/bin/rustfmt "$@"

--- a/rust_src/rustfmt.helper.sh
+++ b/rust_src/rustfmt.helper.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+LD_LIBRARY_PATH=$(rustc --print sysroot)/lib:$LD_LIBRARY_PATH ~/.cargo/bin/rustfmt "$@"

--- a/rust_src/rustfmt.helper.sh
+++ b/rust_src/rustfmt.helper.sh
@@ -1,3 +1,9 @@
 #!/bin/bash
 
+# Add this to your Emacs config and it will format the file whenever you save.
+#
+#     (setq rust-format-on-save t)
+#
+# Then make sure this script is in your path before ~/.cargo/bin
+
 LD_LIBRARY_PATH=$(rustc --print sysroot)/lib:$LD_LIBRARY_PATH ~/.cargo/bin/rustfmt "$@"


### PR DESCRIPTION
This works around the issue on Linux where rustfmt-nightly cannot find the
Rust compiler's shared libraries.