### PR TITLE
port logcount

### DIFF
--- a/rust_src/src/data.rs
+++ b/rust_src/src/data.rs
@@ -18,8 +18,8 @@ use crate::{
     remacs_sys,
     remacs_sys::{
         aset_multibyte_string, bool_vector_binop_driver, buffer_defaults, build_string,
-        emacs_abort, globals, set_default_internal, set_internal, symbol_trapped_write,
-        wrong_choice, wrong_range, CHAR_TABLE_SET, CHECK_IMPURE,
+        emacs_abort, globals, rust_count_one_bits, set_default_internal, set_internal,
+        symbol_trapped_write, wrong_choice, wrong_range, CHAR_TABLE_SET, CHECK_IMPURE,
     },
     remacs_sys::{buffer_local_flags, per_buffer_default, symbol_redirect},
     remacs_sys::{pvec_type, BoolVectorOp, EmacsInt, Lisp_Misc_Type, Lisp_Type, Set_Internal_Bind},
@@ -777,6 +777,16 @@ pub fn get_variable_watchers(symbol: LispSymbolRef) -> LispObject {
         },
         _ => Qnil,
     }
+}
+
+/// Return population count of VALUE.
+/// This is the number of one bits in the two's complement representation
+/// of VALUE.  If VALUE is negative, return the number of zero bits in the
+/// representation.
+#[lisp_fn]
+pub fn logcount(value: EmacsInt) -> i32 {
+    let value = if value < 0 { -1 - value } else { value };
+    unsafe { rust_count_one_bits(value as usize) }
 }
 
 include!(concat!(env!("OUT_DIR"), "/data_exports.rs"));

--- a/src/data.c
+++ b/src/data.c
@@ -1674,18 +1674,6 @@ If the base used is not 10, STRING is always parsed as an integer.  */)
 }
 
 
-DEFUN ("logcount", Flogcount, Slogcount, 1, 1, 0,
-       doc: /* Return population count of VALUE.
-This is the number of one bits in the two's complement representation
-of VALUE.  If VALUE is negative, return the number of zero bits in the
-representation.  */)
-  (Lisp_Object value)
-{
-  CHECK_NUMBER (value);
-  EMACS_INT v = XINT (value) < 0 ? -1 - XINT (value) : XINT (value);
-  return make_number (rust_count_one_bits(v));
-}
-
 static Lisp_Object
 ash_lsh_impl (Lisp_Object value, Lisp_Object count, bool lsh)
 {
@@ -2210,7 +2198,6 @@ syms_of_data (void)
 #endif
   defsubr (&Snumber_to_string);
   defsubr (&Sstring_to_number);
-  defsubr (&Slogcount);
   defsubr (&Slsh);
   defsubr (&Sash);
 #ifdef HAVE_MODULES


### PR DESCRIPTION
This is a new function, that we haven't merged yet. I want to make the rollup easier.

```c
DEFUN ("logcount", Flogcount, Slogcount, 1, 1, 0,
       doc: /* Return population count of VALUE.
This is the number of one bits in the two's complement representation
of VALUE.  If VALUE is negative, return the number of zero bits in the
representation.  */)
  (Lisp_Object value)
{
  CHECK_NUMBER (value);
  EMACS_INT v = XINT (value) < 0 ? -1 - XINT (value) : XINT (value);
  return make_number (EMACS_UINT_WIDTH <= UINT_WIDTH
		      ? count_one_bits (v)
		      : EMACS_UINT_WIDTH <= ULONG_WIDTH
		      ? count_one_bits_l (v)
		      : count_one_bits_ll (v));
}
```