### PR TITLE
Port total-window-width and total-window-height

### DIFF
--- a/rust_src/remacs-sys/lib.rs
+++ b/rust_src/remacs-sys/lib.rs
@@ -918,7 +918,7 @@ pub struct Lisp_Frame {
     // This struct is incomplete.
     // It is difficult, if not impossible, to import the rest of this struct.
     // 1. #IFDEF logic means the proper number of fields is hard to determine.
-    // 2. Bitfields are compiler dependent. How much padiing, where?
+    // 2. Bitfields are compiler dependent. How much padding, where?
     //    The current count is roughly 50 bits.
     //
     // Because of this, access functions are written in src/frame.c and

--- a/rust_src/remacs-sys/lib.rs
+++ b/rust_src/remacs-sys/lib.rs
@@ -915,7 +915,21 @@ pub struct Lisp_Frame {
     /// most recently buried buffer is first.  For last-buffer.
     pub buried_buffer_list: Lisp_Object,
 
-    // TODO: this struct is incomplete.
+    // This struct is incomplete.
+    // It is difficult, if not impossible, to import the rest of this struct.
+    // 1. #IFDEF logic means the proper number of fields is hard to determine.
+    // 2. Bitfields are compiler dependent. How much padiing, where?
+    //    The current count is roughly 50 bits.
+    //
+    // Because of this, access functions are written in src/frame.c and
+    // exported here for use in Rust. This means that instead of
+    // frame.foo the proper method is fget_foo(frame).
+}
+
+/// Functions to access members of `struct frame`.
+extern "C" {
+    pub fn fget_column_width(f: *const Lisp_Frame) -> c_int;
+    pub fn fget_line_height(f: *const Lisp_Frame) -> c_int;
 }
 
 #[repr(C)]
@@ -959,6 +973,8 @@ extern "C" {
     pub static Qnumberp: Lisp_Object;
     pub static Qintegerp: Lisp_Object;
     pub static Qfloatp: Lisp_Object;
+    pub static Qceiling: Lisp_Object;
+    pub static Qfloor: Lisp_Object;
     pub static Qstringp: Lisp_Object;
     pub static Qsymbolp: Lisp_Object;
     pub static Qlistp: Lisp_Object;

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -257,6 +257,8 @@ pub extern "C" fn rust_init_syms() {
         defsubr(&*windows::Swindow_start);
         defsubr(&*windows::Swindow_margins);
         defsubr(&*windows::Sminibuffer_selected_window);
+        defsubr(&*windows::Swindow_total_height);
+        defsubr(&*windows::Swindow_total_width);
         defsubr(&*process::Sget_process);
         defsubr(&*process::Sprocessp);
         defsubr(&*process::Sprocess_name);

--- a/rust_src/src/windows.rs
+++ b/rust_src/src/windows.rs
@@ -52,11 +52,6 @@ impl LispWindowRef {
         self.flags & FLAG_MINI != 0
     }
 
-    #[inline]
-    pub fn frame(&self) -> LispObject {
-        LispObject::from(self.frame)
-    }
-
     pub fn total_width(&self, round: LispObject) -> i32 {
         let qfloor = LispObject::from(unsafe { Qfloor });
         let qceiling = LispObject::from(unsafe { Qceiling });

--- a/rust_src/src/windows.rs
+++ b/rust_src/src/windows.rs
@@ -4,8 +4,7 @@ use lisp::{ExternalPtr, LispObject};
 use remacs_macros::lisp_fn;
 use remacs_sys::{fget_column_width, fget_line_height, minibuf_level,
                  minibuf_selected_window as current_minibuf_window,
-                 selected_window as current_window, EmacsInt, Lisp_Window, Qceiling, Qfloor,
-                 Qwindowp};
+                 selected_window as current_window, EmacsInt, Lisp_Window, Qceiling, Qfloor};
 use marker::marker_position;
 use editfns::point;
 use libc::c_int;
@@ -298,18 +297,7 @@ pub fn minibuffer_selected_window() -> LispObject {
 /// total width of WINDOW.
 #[lisp_fn(min = "0")]
 pub fn window_total_width(window: LispObject, round: LispObject) -> LispObject {
-    let win = if window.is_nil() {
-        selected_window().as_window_or_error()
-    } else {
-        window
-            .as_window()
-            .and_then(|w| if w.contents().is_not_nil() {
-                Some(w)
-            } else {
-                None
-            })
-            .unwrap_or_else(|| wrong_type!(Qwindowp, window))
-    };
+    let win = window_valid_or_selected(window);
 
     LispObject::from_natnum(win.total_width(round) as EmacsInt)
 }
@@ -336,18 +324,7 @@ pub fn window_total_width(window: LispObject, round: LispObject) -> LispObject {
 /// total height of WINDOW.
 #[lisp_fn(min = "0")]
 pub fn window_total_height(window: LispObject, round: LispObject) -> LispObject {
-    let win = if window.is_nil() {
-        selected_window().as_window_or_error()
-    } else {
-        window
-            .as_window()
-            .and_then(|w| if w.contents().is_not_nil() {
-                Some(w)
-            } else {
-                None
-            })
-            .unwrap_or_else(|| wrong_type!(Qwindowp, window))
-    };
+    let win = window_valid_or_selected(window);
 
     LispObject::from_natnum(win.total_height(round) as EmacsInt)
 }

--- a/src/frame.c
+++ b/src/frame.c
@@ -5469,6 +5469,17 @@ make_monitor_attribute_list (struct MonitorInfo *monitors,
 
 #endif /* HAVE_WINDOW_SYSTEM */
 
+/* Accessors to enable Rust code to get data from the Frame struct */
+int fget_column_width(const struct frame *f)
+{
+  return f->column_width;
+}
+
+int fget_line_height(const struct frame *f)
+{
+  return f->line_height;
+}
+
 
 /***********************************************************************
 				Initialization

--- a/src/frame.h
+++ b/src/frame.h
@@ -695,6 +695,10 @@ fset_desired_tool_bar_string (struct frame *f, Lisp_Object val)
 }
 #endif /* HAVE_WINDOW_SYSTEM && !USE_GTK && !HAVE_NS */
 
+/* Accessors for Rust */
+int fget_column_width(const struct frame *f);
+int fget_line_height(const struct frame *f);
+
 INLINE double
 NUMVAL (Lisp_Object x)
 {

--- a/src/window.c
+++ b/src/window.c
@@ -697,79 +697,6 @@ after that.  */)
 	  (decode_valid_window (window)->pixel_height_before_size_change));
 }
 
-DEFUN ("window-total-height", Fwindow_total_height, Swindow_total_height, 0, 2, 0,
-       doc: /* Return the height of window WINDOW in lines.
-WINDOW must be a valid window and defaults to the selected one.
-
-The return value includes the heights of WINDOW's mode and header line
-and its bottom divider, if any.  If WINDOW is an internal window, the
-total height is the height of the screen areas spanned by its children.
-
-If WINDOW's pixel height is not an integral multiple of its frame's
-character height, the number of lines occupied by WINDOW is rounded
-internally.  This is done in a way such that, if WINDOW is a parent
-window, the sum of the total heights of all its children internally
-equals the total height of WINDOW.
-
-If the optional argument ROUND is `ceiling', return the smallest integer
-larger than WINDOW's pixel height divided by the character height of
-WINDOW's frame.  ROUND `floor' means to return the largest integer
-smaller than WINDOW's pixel height divided by the character height of
-WINDOW's frame.  Any other value of ROUND means to return the internal
-total height of WINDOW.  */)
-  (Lisp_Object window, Lisp_Object round)
-{
-  struct window *w = decode_valid_window (window);
-
-  if (! EQ (round, Qfloor) && ! EQ (round, Qceiling))
-    return make_number (w->total_lines);
-  else
-    {
-      int unit = FRAME_LINE_HEIGHT (WINDOW_XFRAME (w));
-
-      return make_number (EQ (round, Qceiling)
-			  ? ((w->pixel_height + unit - 1) /unit)
-			  : (w->pixel_height / unit));
-    }
-}
-
-DEFUN ("window-total-width", Fwindow_total_width, Swindow_total_width, 0, 2, 0,
-       doc: /* Return the total width of window WINDOW in columns.
-WINDOW must be a valid window and defaults to the selected one.
-
-The return value includes the widths of WINDOW's fringes, margins,
-scroll bars and its right divider, if any.  If WINDOW is an internal
-window, the total width is the width of the screen areas spanned by its
-children.
-
-If WINDOW's pixel width is not an integral multiple of its frame's
-character width, the number of lines occupied by WINDOW is rounded
-internally.  This is done in a way such that, if WINDOW is a parent
-window, the sum of the total widths of all its children internally
-equals the total width of WINDOW.
-
-If the optional argument ROUND is `ceiling', return the smallest integer
-larger than WINDOW's pixel width divided by the character width of
-WINDOW's frame.  ROUND `floor' means to return the largest integer
-smaller than WINDOW's pixel width divided by the character width of
-WINDOW's frame.  Any other value of ROUND means to return the internal
-total width of WINDOW.  */)
-  (Lisp_Object window, Lisp_Object round)
-{
-  struct window *w = decode_valid_window (window);
-
-  if (! EQ (round, Qfloor) && ! EQ (round, Qceiling))
-    return make_number (w->total_cols);
-  else
-    {
-      int unit = FRAME_COLUMN_WIDTH (WINDOW_XFRAME (w));
-
-      return make_number (EQ (round, Qceiling)
-			  ? ((w->pixel_width + unit - 1) /unit)
-			  : (w->pixel_width / unit));
-    }
-}
-
 DEFUN ("window-new-total", Fwindow_new_total, Swindow_new_total, 0, 1, 0,
        doc: /* Return the new total size of window WINDOW.
 WINDOW must be a valid window and defaults to the selected one.
@@ -7645,8 +7572,6 @@ displayed after a scrolling operation to be somewhat inaccurate.  */);
   defsubr (&Swindow_pixel_height);
   defsubr (&Swindow_pixel_width_before_size_change);
   defsubr (&Swindow_pixel_height_before_size_change);
-  defsubr (&Swindow_total_width);
-  defsubr (&Swindow_total_height);
   defsubr (&Swindow_normal_size);
   defsubr (&Swindow_new_pixel);
   defsubr (&Swindow_new_total);


### PR DESCRIPTION
Document why `Lisp_Frame` cannot be filled in easily.
Add the needed access functions in src/frame.c.
Create `frame()`, `total_width()`, and `total_height()` methods
on `LispWindowRef`.

Closes #355