### PR TITLE
Apply clippy for doc identifier markdown

### DIFF
--- a/rust_src/src/base64.rs
+++ b/rust_src/src/base64.rs
@@ -55,8 +55,8 @@ pub extern "C" fn base64_encode_1(
 }
 
 /// Base64-decode the data at FROM of LENGTH bytes into TO.  If MULTIBYTE, the
-/// decoded result should be in multibyte form.  If NCHARS_RETURN is not NULL,
-/// store the number of produced characters in *NCHARS_RETURN.
+/// decoded result should be in multibyte form.  If `NCHARS_RETURN` is not NULL,
+/// store the number of produced characters in `*NCHARS_RETURN`.
 #[no_mangle]
 pub extern "C" fn base64_decode_1(
     from: *const c_char,

--- a/rust_src/src/data.rs
+++ b/rust_src/src/data.rs
@@ -9,7 +9,7 @@ use lisp::LispObject;
 /// return it.  If there is a cycle in the function chain, signal a
 /// cyclic-function-indirection error.
 ///
-/// This is like Findirect_function, except that it doesn't signal an
+/// This is like `Findirect_function`, except that it doesn't signal an
 /// error if the chain ends up unbound.
 #[no_mangle]
 pub extern "C" fn indirect_function(object: LispObject) -> LispObject {

--- a/rust_src/src/hashtable.rs
+++ b/rust_src/src/hashtable.rs
@@ -112,8 +112,8 @@ impl LispHashTableRef {
 }
 
 /// An iterator used for iterating over the indices
-/// of the 'key_and_value' vector of a Lisp_Hash_Table.
-/// Equivalent to a 'for (i = 0; i < HASH_TABLE_SIZE(h); ++i)'
+/// of the `key_and_value` vector of a `Lisp_Hash_Table`.
+/// Equivalent to a `for (i = 0; i < HASH_TABLE_SIZE(h); ++i)`
 /// loop in the C layer.
 pub struct HashTableIter<'a> {
     table: &'a LispHashTableRef,
@@ -124,7 +124,7 @@ impl<'a> Iterator for HashTableIter<'a> {
     type Item = isize;
 
     fn next(&mut self) -> Option<isize> {
-        // This is duplicating 'LispHashTableRef::size' to keep inline with the old C code,
+        // This is duplicating `LispHashTableRef::size` to keep inline with the old C code,
         // in which the len of the vector could technically change while iterating. While
         // I don't know if any code actually uses that behavior, I'm going to avoid making
         // this use size to keep it consistent.
@@ -140,7 +140,7 @@ impl<'a> Iterator for HashTableIter<'a> {
 }
 
 /// An iterator used for looping over the keys and values
-/// contained in a Lisp_Hash_Table.
+/// contained in a `Lisp_Hash_Table`.
 pub struct KeyAndValueIter<'a>(HashTableIter<'a>);
 
 impl<'a> Iterator for KeyAndValueIter<'a> {


### PR DESCRIPTION
Trivial docstring change to add backticks for identifiers and code sections