### PR TITLE
port process_query_on_exit_flag and set_process_query_on_exit_flag

### DIFF
--- a/rust_src/remacs-sys/lib.rs
+++ b/rust_src/remacs-sys/lib.rs
@@ -14,6 +14,7 @@
 //! - `EMACS_FLOAT_SIZE`
 //! - `GCTYPEBITS`
 //! - `USE_LSB_TAG`
+//! - `BoolBF`
 
 extern crate libc;
 
@@ -834,6 +835,12 @@ pub struct Lisp_Process {
 /// Functions to access members of `struct Lisp_Process`.
 extern "C" {
     pub fn pget_pid(p: *const Lisp_Process) -> libc::pid_t;
+    pub fn pget_kill_without_query(p: *const Lisp_Process) -> BoolBF;
+}
+
+/// Functions to set members of `struct Lisp_Process`.
+extern "C" {
+    pub fn pset_kill_without_query(p: *mut Lisp_Process, b: BoolBF);
 }
 
 #[repr(C)]

--- a/src/process.c
+++ b/src/process.c
@@ -397,7 +397,20 @@ pid_t pget_pid(const struct Lisp_Process *p)
 {
   return p->pid;
 }
+
+bool_bf pget_kill_without_query(const struct Lisp_Process *p)
+{
+  return p->kill_without_query;
+}
 /* End Rust Accessors */
+
+/* Setters to enable Rust code to set data in the Lisp_Process struct */
+void
+pset_kill_without_query (struct Lisp_Process *p, bool_bf val)
+{
+  p->kill_without_query = val;
+}
+/* End Rust Setters */
 
 
 static Lisp_Object
@@ -1352,30 +1365,6 @@ This function returns FLAG.  */)
   CHECK_PROCESS (process);
   XPROCESS (process)->inherit_coding_system_flag = !NILP (flag);
   return flag;
-}
-
-DEFUN ("set-process-query-on-exit-flag",
-       Fset_process_query_on_exit_flag, Sset_process_query_on_exit_flag,
-       2, 2, 0,
-       doc: /* Specify if query is needed for PROCESS when Emacs is exited.
-If the second argument FLAG is non-nil, Emacs will query the user before
-exiting or killing a buffer if PROCESS is running.  This function
-returns FLAG.  */)
-  (register Lisp_Object process, Lisp_Object flag)
-{
-  CHECK_PROCESS (process);
-  XPROCESS (process)->kill_without_query = NILP (flag);
-  return flag;
-}
-
-DEFUN ("process-query-on-exit-flag",
-       Fprocess_query_on_exit_flag, Sprocess_query_on_exit_flag,
-       1, 1, 0,
-       doc: /* Return the current value of query-on-exit flag for PROCESS.  */)
-  (register Lisp_Object process)
-{
-  CHECK_PROCESS (process);
-  return (XPROCESS (process)->kill_without_query ? Qnil : Qt);
 }
 
 DEFUN ("process-contact", Fprocess_contact, Sprocess_contact,
@@ -7882,8 +7871,6 @@ returns non-`nil'.  */);
   defsubr (&Sprocess_thread);
   defsubr (&Sset_process_window_size);
   defsubr (&Sset_process_inherit_coding_system_flag);
-  defsubr (&Sset_process_query_on_exit_flag);
-  defsubr (&Sprocess_query_on_exit_flag);
   defsubr (&Sprocess_contact);
   defsubr (&Sprocess_plist);
   defsubr (&Smake_process);

--- a/src/process.h
+++ b/src/process.h
@@ -205,6 +205,9 @@ struct Lisp_Process
 pid_t
 pget_pid(const struct Lisp_Process *p);
 
+bool_bf
+pget_kill_without_query(const struct Lisp_Process *p);
+
 INLINE bool
 PROCESSP (Lisp_Object a)
 {
@@ -300,6 +303,8 @@ extern Lisp_Object network_interface_info (Lisp_Object);
 extern Lisp_Object remove_slash_colon (Lisp_Object);
 
 extern void update_processes_for_thread_death (Lisp_Object);
+
+void pset_kill_without_query (struct Lisp_Process *p, bool_bf val);
 
 INLINE_HEADER_END
 


### PR DESCRIPTION
#419 

The type of kill_without_query is actually a bool_bf rather than a bool.  See conf_post.h

```
/* The type of bool bitfields.  Needed to compile Objective-C with
   standard GCC.  It was also needed to port to pre-C99 compilers,
   although we don't care about that any more.  */
#if NS_IMPL_GNUSTEP
typedef unsigned int bool_bf;
#else
typedef bool bool_bf;
#endif
```

Both my c-fu and rust-fu are insufficient to work out what to do about that.  Everything compiles but I get a segfault - I think whenever remacs attempts to access kill_without_query.

The switch from 'query-on-exit' at the lisp level to the boolean opposite 'kill-without-query' at the c level was annoying, but I guessed this is not the time or place to try and fix that.

I originally went looking for an `as_bool_or_error`, just pattern matching on other PRs, and it took me a while to work out that the emacs-lisp convention that nil means false and non-nil (not just t!) means true is the dominant boolean.  So `is_not_nil` is the closest thing there is to an `as_bool`, and that it will never error.  Could we switch `is_not_nil` to `as_bool`?  


 
