### PR TITLE
add intspec to goto-char

### DIFF
--- a/rust_src/src/editfns.rs
+++ b/rust_src/src/editfns.rs
@@ -141,7 +141,7 @@ pub fn point_max() -> LispObject {
 /// Beginning of buffer is position (point-min), end is (point-max).
 ///
 /// The return value is POSITION.
-#[lisp_fn]
+#[lisp_fn(intspec = "NGoto char: ")]
 pub fn goto_char(position: LispObject) -> LispObject {
     if let Some(marker) = position.as_marker() {
         set_point_from_marker(marker);


### PR DESCRIPTION
@DavidDeSimone your code from #386 doesn't work correctly. It seems `goto-char` is the only interactive function we have ported so far.