### PR TITLE
Port the preceding-char function

### DIFF
--- a/rust_src/src/character.rs
+++ b/rust_src/src/character.rs
@@ -4,6 +4,7 @@ use libc::{c_uchar, ptrdiff_t};
 
 use remacs_macros::lisp_fn;
 use remacs_sys::EmacsInt;
+
 use threads::ThreadState;
 
 /// True iff byte starts a character in a multibyte form.
@@ -18,13 +19,11 @@ pub fn char_read_p(byte: c_uchar) -> bool {
 /// to the previous character boundary. No range checking of POS.
 ///
 /// Can be used instead of the `DEC_POS` macro.
-// XXX: Pointer arithmetic is wild. Please modify this if you know a
-//      more idiomatic way to move a pointer.
 #[inline]
-pub unsafe fn dec_pos(pos_byte: &ptrdiff_t) -> ptrdiff_t {
+pub unsafe fn dec_pos(pos_byte: ptrdiff_t) -> ptrdiff_t {
     let buffer_ref = ThreadState::current_buffer();
-    let mut new_pos = pos_byte - 1;
 
+    let mut new_pos = pos_byte - 1;
     let mut offset = new_pos - buffer_ref.beg_byte();
     if new_pos >= buffer_ref.gpt_byte() {
         offset += buffer_ref.gap_size();

--- a/rust_src/src/character.rs
+++ b/rust_src/src/character.rs
@@ -1,7 +1,43 @@
 //! Operations on characters.
 
+use libc::{c_uchar, ptrdiff_t};
+
 use remacs_macros::lisp_fn;
 use remacs_sys::EmacsInt;
+use threads::ThreadState;
+
+/// True iff byte starts a character in a multibyte form.
+///
+/// Same as the `CHAR_READ_P` macro.
+#[inline]
+pub fn char_read_p(byte: c_uchar) -> bool {
+    (byte & 0xC0) != 0x80
+}
+
+/// Decrement the buffer byte position POS_BYTE of the current buffer
+/// to the previous character boundary. No range checking of POS.
+///
+/// Can be used instead of the `DEC_POS` macro.
+// XXX: Pointer arithmetic is wild. Please modify this if you know a
+//      more idiomatic way to move a pointer.
+#[inline]
+pub unsafe fn dec_pos(pos_byte: &ptrdiff_t) -> ptrdiff_t {
+    let buffer_ref = ThreadState::current_buffer();
+    let mut new_pos = pos_byte - 1;
+
+    let mut offset = new_pos - buffer_ref.beg_byte();
+    if new_pos >= buffer_ref.gpt_byte() {
+        offset += buffer_ref.gap_size();
+    }
+    let mut chp = buffer_ref.beg_addr().offset(offset);
+
+    while !char_read_p(*chp) {
+        chp = chp.offset(-1);
+        new_pos -= 1;
+    }
+
+    new_pos
+}
 
 use lisp::LispObject;
 use lisp::defsubr;

--- a/src/editfns.c
+++ b/src/editfns.c
@@ -766,25 +766,6 @@ If BYTEPOS is out of range, the value is nil.  */)
   return make_number (BYTE_TO_CHAR (pos_byte));
 }
 
-DEFUN ("preceding-char", Fprevious_char, Sprevious_char, 0, 0, 0,
-       doc: /* Return the character preceding point, as a number.
-At the beginning of the buffer or accessible region, return 0.  */)
-  (void)
-{
-  Lisp_Object temp;
-  if (PT <= BEGV)
-    XSETFASTINT (temp, 0);
-  else if (!NILP (BVAR (current_buffer, enable_multibyte_characters)))
-    {
-      ptrdiff_t pos = PT_BYTE;
-      DEC_POS (pos);
-      XSETFASTINT (temp, FETCH_CHAR (pos));
-    }
-  else
-    XSETFASTINT (temp, FETCH_BYTE (PT_BYTE - 1));
-  return temp;
-}
-
 DEFUN ("char-before", Fchar_before, Schar_before, 0, 1, 0,
        doc: /* Return character in current buffer preceding position POS.
 POS is an integer or a marker and defaults to point.
@@ -4604,7 +4585,6 @@ functions if all the text being accessed has this property.  */);
   defsubr (&Spoint_max_marker);
   defsubr (&Sbyte_to_position);
 
-  defsubr (&Sprevious_char);
   defsubr (&Schar_before);
   defsubr (&Sinsert);
   defsubr (&Sinsert_before_markers);


### PR DESCRIPTION
As referenced in issue #407. I've never had to do pointer arithmetic in Rust before, so there might be a cleaner way to implement the `DEC_POS` macro.