### PR TITLE
Lock versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,12 +34,14 @@ jobs:
   include:
     - stage: rustfmt
       before_script:
+        - travis_wait rustup install nightly-2017-10-22
+        - rustup default nightly-2017-10-22
         # rustfmt doesn't know where to look for libraries yet.
         # See https://github.com/rust-lang-nursery/rustfmt/issues/1707#issuecomment-310005652
         - export LD_LIBRARY_PATH=$(rustc --print sysroot)/lib:$LD_LIBRARY_PATH
         # Install rustfmt-nightly 0.2.12 if it isn't already installed on
         # Travis. This can be slow to install, so raise the Travis timeout.
-        - (which rustfmt && rustfmt --version && [[ "$(rustfmt --version)" =~ "0.2.12" ]]) || travis_wait cargo install --force rustfmt-nightly --vers 0.2.12
+        - (which rustfmt && rustfmt --version && [[ "$(rustfmt --version)" =~ "0.2.9" ]]) || travis_wait cargo install --force rustfmt-nightly --vers 0.2.9
       script: ./.travis-format.sh
       os: linux
 

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ to be exported with the correct ABI.
 ### Source code style guide
 
 In order to pass Travis checks on pull requests, the source has to
-be formatted according to the default style of `rustfmt-nightly`, version 0.2.12.
+be formatted according to the default style of `rustfmt-nightly`, version 0.2.9.
 To do that, install `rustfmt`:
 
 ```

--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -519,10 +519,9 @@ impl LispObject {
     }
 
     pub fn is_window_configuration(self) -> bool {
-        self.as_vectorlike().map_or(
-            false,
-            |v| v.is_pseudovector(PseudovecType::PVEC_WINDOW_CONFIGURATION),
-        )
+        self.as_vectorlike().map_or(false, |v| {
+            v.is_pseudovector(PseudovecType::PVEC_WINDOW_CONFIGURATION)
+        })
     }
 
     pub fn is_process(self) -> bool {


### PR DESCRIPTION
Rust 1.22 aka 2017-10-22
rustfmt 0.2.9

We can bump back to current when the upstream churn settles.