### PR TITLE
Port process-id to Rust Closes #431

### DIFF
--- a/rust_src/remacs-sys/lib.rs
+++ b/rust_src/remacs-sys/lib.rs
@@ -821,7 +821,14 @@ pub struct Lisp_Process {
     /// Queue for storing waiting writes.
     pub write_queue: Lisp_Object,
 
-    // TODO: this struct is incomplete.
+    // This struct is incomplete.
+    // To access remaining fields use access functions written in
+    // src/process.c and export them here for use in Rust.
+}
+
+/// Functions to access members of `struct Lisp_Process`.
+extern "C" {
+    pub fn pget_pid(p: *const Lisp_Process) -> libc::pid_t;
 }
 
 #[repr(C)]

--- a/rust_src/src/process.rs
+++ b/rust_src/src/process.rs
@@ -1,12 +1,12 @@
 //! Functions operating on process.
 
-use remacs_macros::lisp_fn;
-use remacs_sys::{Fmapcar, Lisp_Process, Qcdr, Qlistp, Vprocess_alist};
-
 use buffers::get_buffer;
 use lisp::{ExternalPtr, LispObject};
 use lisp::defsubr;
 use lists::{assoc, cdr};
+use remacs_macros::lisp_fn;
+use remacs_sys::{EmacsInt, Fmapcar, Lisp_Process, Qcdr, Qlistp, Vprocess_alist};
+use remacs_sys::pget_pid;
 
 pub type LispProcessRef = ExternalPtr<Lisp_Process>;
 
@@ -63,6 +63,19 @@ fn process_buffer(process: LispObject) -> LispObject {
     process.as_process_or_error().buffer()
 }
 
+/// Return the process id of PROCESS.
+/// This is the pid of the external process which PROCESS uses or talks to.
+/// For a network, serial, and pipe connections, this value is nil.
+#[lisp_fn]
+fn process_id(process: LispObject) -> LispObject {
+    let pid = unsafe { pget_pid(process.as_process_or_error().as_ptr()) };
+    if pid != 0 {
+        LispObject::from_fixnum(pid as EmacsInt)
+    } else {
+        LispObject::constant_nil()
+    }
+}
+
 /// Return the (or a) live process associated with BUFFER.
 /// BUFFER may be a buffer or the name of one.
 /// Return nil if all processes associated with BUFFER have been
@@ -110,6 +123,7 @@ pub fn rust_init_syms() {
         defsubr(&*Sprocess_buffer);
         defsubr(&*Sprocess_list);
         defsubr(&*Sprocess_name);
+        defsubr(&*Sprocess_id);
         defsubr(&*Sprocessp);
         defsubr(&*Sset_process_plist);
     }

--- a/src/process.c
+++ b/src/process.c
@@ -392,6 +392,13 @@ pset_stderrproc (struct Lisp_Process *p, Lisp_Object val)
   p->stderrproc = val;
 }
 
+/* Accessors to enable Rust code to get data from the Lisp_Process struct */
+pid_t pget_pid(const struct Lisp_Process *p)
+{
+  return p->pid;
+}
+/* End Rust Accessors */
+
 
 static Lisp_Object
 make_lisp_proc (struct Lisp_Process *p)
@@ -1112,19 +1119,6 @@ If PROCESS has not yet exited or died, return 0.  */)
   if (CONSP (XPROCESS (process)->status))
     return XCAR (XCDR (XPROCESS (process)->status));
   return make_number (0);
-}
-
-DEFUN ("process-id", Fprocess_id, Sprocess_id, 1, 1, 0,
-       doc: /* Return the process id of PROCESS.
-This is the pid of the external process which PROCESS uses or talks to.
-For a network, serial, and pipe connections, this value is nil.  */)
-  (register Lisp_Object process)
-{
-  pid_t pid;
-
-  CHECK_PROCESS (process);
-  pid = XPROCESS (process)->pid;
-  return (pid ? make_fixnum_or_float (pid) : Qnil);
 }
 
 DEFUN ("process-command", Fprocess_command, Sprocess_command, 1, 1, 0,
@@ -7876,7 +7870,6 @@ returns non-`nil'.  */);
   defsubr (&Sdelete_process);
   defsubr (&Sprocess_status);
   defsubr (&Sprocess_exit_status);
-  defsubr (&Sprocess_id);
   defsubr (&Sprocess_tty_name);
   defsubr (&Sprocess_command);
   defsubr (&Sset_process_buffer);

--- a/src/process.h
+++ b/src/process.h
@@ -201,6 +201,9 @@ struct Lisp_Process
     bool_bf gnutls_complete_negotiation_p : 1;
 #endif
 };
+/* Accessors for Rust */
+pid_t
+pget_pid(const struct Lisp_Process *p);
 
 INLINE bool
 PROCESSP (Lisp_Object a)


### PR DESCRIPTION
I gave a try to this, but I got stuck.
I added the `pid` attribute to the `Lisp_Process` structure, but where do I assign the value for it when the struct is instantiated?

I was also wondering about the `make_fixnum_or_float`, does it make sense to use it here in remacs? When would the process_id overflow to be transformed as an int. Maybe is there for some legacy reasons but the type `libc::pid_t=i32` that should be enough for all process_id?