### PR TITLE
Use a macro to wrap `defsubr`

### DIFF
--- a/rust_src/src/base64.rs
+++ b/rust_src/src/base64.rs
@@ -194,9 +194,7 @@ fn base64_decode_string(string: LispObject) -> LispObject {
     unsafe { LispObject::from(make_unibyte_string(decoded, decoded_length)) }
 }
 
-pub fn rust_init_syms() {
-    unsafe {
-        defsubr(&*Sbase64_decode_string);
-        defsubr(&*Sbase64_encode_string);
-    }
+export_lisp_fns! {
+    base64_decode_string,
+    base64_encode_string
 }

--- a/rust_src/src/buffers.rs
+++ b/rust_src/src/buffers.rs
@@ -360,20 +360,18 @@ fn set_buffer(buffer_or_name: LispObject) -> LispObject {
     buffer
 }
 
-pub fn rust_init_syms() {
-    unsafe {
-        defsubr(&*Sbuffer_chars_modified_tick);
-        defsubr(&*Sbuffer_file_name);
-        defsubr(&*Sbuffer_live_p);
-        defsubr(&*Sbuffer_modified_p);
-        defsubr(&*Sbuffer_modified_tick);
-        defsubr(&*Sbuffer_name);
-        defsubr(&*Scurrent_buffer);
-        defsubr(&*Sget_buffer);
-        defsubr(&*Soverlay_buffer);
-        defsubr(&*Soverlay_end);
-        defsubr(&*Soverlay_start);
-        defsubr(&*Soverlayp);
-        defsubr(&*Sset_buffer);
-    }
+export_lisp_fns! {
+    buffer_chars_modified_tick,
+    buffer_file_name,
+    buffer_live_p,
+    buffer_modified_p,
+    buffer_modified_tick,
+    buffer_name,
+    current_buffer,
+    get_buffer,
+    overlay_buffer,
+    overlay_end,
+    overlay_start,
+    overlayp,
+    set_buffer
 }

--- a/rust_src/src/category.rs
+++ b/rust_src/src/category.rs
@@ -23,9 +23,7 @@ fn category_table() -> LispObject {
     LispObject::from(buffer_ref.category_table)
 }
 
-pub fn rust_init_syms() {
-    unsafe {
-        defsubr(&*Scategory_table);
-        defsubr(&*Scategory_table_p);
-    }
+export_lisp_fns! {
+    category_table,
+    category_table_p
 }

--- a/rust_src/src/character.rs
+++ b/rust_src/src/character.rs
@@ -54,12 +54,10 @@ fn multibyte_char_to_unibyte(ch: LispObject) -> LispObject {
     }
 }
 
-pub fn rust_init_syms() {
-    unsafe {
-        defsubr(&*Scharacterp);
-        defsubr(&*Schar_or_string_p);
-        defsubr(&*Smax_char);
-        defsubr(&*Smultibyte_char_to_unibyte);
-        defsubr(&*Sunibyte_char_to_multibyte);
-    }
+export_lisp_fns! {
+    characterp,
+    char_or_string_p,
+    max_char,
+    multibyte_char_to_unibyte,
+    unibyte_char_to_multibyte
 }

--- a/rust_src/src/chartable.rs
+++ b/rust_src/src/chartable.rs
@@ -46,10 +46,8 @@ fn set_char_table_parent(chartable: LispObject, parent: LispObject) -> LispObjec
     parent
 }
 
-pub fn rust_init_syms() {
-    unsafe {
-        defsubr(&*Schar_table_parent);
-        defsubr(&*Schar_table_subtype);
-        defsubr(&*Sset_char_table_parent);
-    }
+export_lisp_fns! {
+    char_table_parent,
+    char_table_subtype,
+    set_char_table_parent
 }

--- a/rust_src/src/cmds.rs
+++ b/rust_src/src/cmds.rs
@@ -15,8 +15,6 @@ pub fn forward_point(n: LispObject) -> LispObject {
     LispObject::from_fixnum(n.as_fixnum_or_error() + pt as EmacsInt)
 }
 
-pub fn rust_init_syms() {
-    unsafe {
-        defsubr(&*Sforward_point);
-    }
+export_lisp_fns! {
+    forward_point
 }

--- a/rust_src/src/data.rs
+++ b/rust_src/src/data.rs
@@ -54,8 +54,6 @@ pub fn indirect_function_lisp(object: LispObject, _noerror: LispObject) -> LispO
     return result;
 }
 
-pub fn rust_init_syms() {
-    unsafe {
-        defsubr(&*Sindirect_function);
-    }
+export_lisp_fns! {
+    indirect_function
 }

--- a/rust_src/src/dispnew.rs
+++ b/rust_src/src/dispnew.rs
@@ -44,8 +44,6 @@ fn sleep_for(seconds: LispObject, milliseconds: LispObject) -> LispObject {
     LispObject::constant_nil()
 }
 
-pub fn rust_init_syms() {
-    unsafe {
-        defsubr(&*Ssleep_for);
-    }
+export_lisp_fns! {
+    sleep_for
 }

--- a/rust_src/src/editfns.rs
+++ b/rust_src/src/editfns.rs
@@ -291,24 +291,22 @@ pub fn propertize(args: &mut [LispObject]) -> LispObject {
     copy
 }
 
-pub fn rust_init_syms() {
-    unsafe {
-        defsubr(&*Sbobp);
-        defsubr(&*Sbolp);
-        defsubr(&*Sbuffer_size);
-        defsubr(&*Schar_after);
-        defsubr(&*Seobp);
-        defsubr(&*Seolp);
-        defsubr(&*Sfollowing_char);
-        defsubr(&*Sgoto_char);
-        defsubr(&*Sinsert_byte);
-        defsubr(&*Smark_marker);
-        defsubr(&*Spoint);
-        defsubr(&*Spoint_max);
-        defsubr(&*Spoint_min);
-        defsubr(&*Sposition_bytes);
-        defsubr(&*Spropertize);
-        defsubr(&*Sregion_beginning);
-        defsubr(&*Sregion_end);
-    }
+export_lisp_fns! {
+    bobp,
+    bolp,
+    buffer_size,
+    char_after,
+    eobp,
+    eolp,
+    following_char,
+    goto_char,
+    insert_byte,
+    mark_marker,
+    point,
+    point_max,
+    point_min,
+    position_bytes,
+    propertize,
+    region_beginning,
+    region_end
 }

--- a/rust_src/src/floatfns.rs
+++ b/rust_src/src/floatfns.rs
@@ -387,31 +387,29 @@ fn round2(i1: EmacsInt, i2: EmacsInt) -> EmacsInt {
     }
 }
 
-pub fn rust_init_syms() {
-    unsafe {
-        defsubr(&*Sacos);
-        defsubr(&*Sasin);
-        defsubr(&*Satan);
-        defsubr(&*Sceiling);
-        defsubr(&*Scopysign);
-        defsubr(&*Scos);
-        defsubr(&*Sexp);
-        defsubr(&*Sexpt);
-        defsubr(&*Sfceiling);
-        defsubr(&*Sffloor);
-        defsubr(&*Sfloat);
-        defsubr(&*Sfloor);
-        defsubr(&*Sfrexp);
-        defsubr(&*Sfround);
-        defsubr(&*Sftruncate);
-        defsubr(&*Sisnan);
-        defsubr(&*Sldexp);
-        defsubr(&*Slog);
-        defsubr(&*Slogb);
-        defsubr(&*Sround);
-        defsubr(&*Ssin);
-        defsubr(&*Ssqrt);
-        defsubr(&*Stan);
-        defsubr(&*Struncate);
-    }
+export_lisp_fns! {
+    acos,
+    asin,
+    atan,
+    ceiling,
+    copysign,
+    cos,
+    exp,
+    expt,
+    fceiling,
+    ffloor,
+    float,
+    floor,
+    frexp,
+    fround,
+    ftruncate,
+    isnan,
+    ldexp,
+    log,
+    logb,
+    round,
+    sin,
+    sqrt,
+    tan,
+    truncate
 }

--- a/rust_src/src/fns.rs
+++ b/rust_src/src/fns.rs
@@ -30,8 +30,6 @@ fn featurep(feature: LispObject, subfeature: LispObject) -> LispObject {
     }
 }
 
-pub fn rust_init_syms() {
-    unsafe {
-        defsubr(&*Sfeaturep);
-    }
+export_lisp_fns! {
+    featurep
 }

--- a/rust_src/src/fonts.rs
+++ b/rust_src/src/fonts.rs
@@ -76,8 +76,6 @@ pub fn fontp(object: LispObject, extra_type: LispObject) -> LispObject {
         })
 }
 
-pub fn rust_init_syms() {
-    unsafe {
-        defsubr(&*Sfontp);
-    }
+export_lisp_fns! {
+    fontp
 }

--- a/rust_src/src/frames.rs
+++ b/rust_src/src/frames.rs
@@ -15,8 +15,6 @@ pub fn selected_frame() -> LispObject {
     unsafe { LispObject::from(current_frame) }
 }
 
-pub extern "C" fn rust_init_syms() {
-    unsafe {
-        defsubr(&*Sselected_frame);
-    }
+export_lisp_fns! {
+    selected_frame
 }

--- a/rust_src/src/hashtable.rs
+++ b/rust_src/src/hashtable.rs
@@ -327,20 +327,18 @@ fn define_hash_table_test(name: LispObject, test: LispObject, hash: LispObject) 
     put(name, sym, list(&mut [test, hash]))
 }
 
-pub fn rust_init_syms() {
-    unsafe {
-        defsubr(&*Sclrhash);
-        defsubr(&*Scopy_hash_table);
-        defsubr(&*Sdefine_hash_table_test);
-        defsubr(&*Sgethash);
-        defsubr(&*Shash_table_p);
-        defsubr(&*Shash_table_count);
-        defsubr(&*Shash_table_rehash_threshold);
-        defsubr(&*Shash_table_size);
-        defsubr(&*Shash_table_test);
-        defsubr(&*Shash_table_weakness);
-        defsubr(&*Smaphash);
-        defsubr(&*Sputhash);
-        defsubr(&*Sremhash);
-    }
+export_lisp_fns! {
+    clrhash,
+    copy_hash_table,
+    define_hash_table_test,
+    gethash,
+    hash_table_p,
+    hash_table_count,
+    hash_table_rehash_threshold,
+    hash_table_size,
+    hash_table_test,
+    hash_table_weakness,
+    maphash,
+    puthash,
+    remhash
 }

--- a/rust_src/src/indent.rs
+++ b/rust_src/src/indent.rs
@@ -24,8 +24,6 @@ pub fn current_column() -> LispObject {
     LispObject::from_natnum(unsafe { remacs_sys::current_column() })
 }
 
-pub fn rust_init_syms() {
-    unsafe {
-        defsubr(&*Scurrent_column);
-    }
+export_lisp_fns! {
+    current_column
 }

--- a/rust_src/src/interactive.rs
+++ b/rust_src/src/interactive.rs
@@ -24,8 +24,6 @@ fn prefix_numeric_value(raw: LispObject) -> LispObject {
     }
 }
 
-pub fn rust_init_syms() {
-    unsafe {
-        defsubr(&*Sprefix_numeric_value);
-    }
+export_lisp_fns! {
+    prefix_numeric_value
 }

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -4,6 +4,7 @@
 #![feature(proc_macro)]
 #![cfg_attr(feature = "strict", deny(warnings))]
 #![feature(global_allocator)]
+#![feature(concat_idents)]
 
 #[macro_use]
 extern crate lazy_static;
@@ -32,6 +33,7 @@ mod functions;
 
 #[macro_use]
 mod eval;
+#[macro_use]
 mod lisp;
 mod lists;
 mod marker;

--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -1139,6 +1139,18 @@ extern "C" {
     pub fn defsubr(sname: *const Lisp_Subr);
 }
 
+macro_rules! export_lisp_fns {
+    ($($f:ident),+) => {
+        pub fn rust_init_syms() {
+            unsafe {
+                $(
+                    defsubr(&*concat_idents!(S, $f));
+                )+
+            }
+        }
+    }
+}
+
 #[test]
 fn test_basic_float() {
     let val = 8.0;

--- a/rust_src/src/lists.rs
+++ b/rust_src/src/lists.rs
@@ -501,37 +501,35 @@ pub fn merge(mut l1: LispObject, mut l2: LispObject, pred: LispObject) -> LispOb
     }
 }
 
-pub fn rust_init_syms() {
-    unsafe {
-        defsubr(&*Sassoc);
-        defsubr(&*Sassq);
-        defsubr(&*Satom);
-        defsubr(&*Scar);
-        defsubr(&*Scar_safe);
-        defsubr(&*Scdr);
-        defsubr(&*Scdr_safe);
-        defsubr(&*Sconsp);
-        defsubr(&*Sdelq);
-        defsubr(&*Sget);
-        defsubr(&*Slax_plist_get);
-        defsubr(&*Slax_plist_put);
-        defsubr(&*Slist);
-        defsubr(&*Slistp);
-        defsubr(&*Smake_list);
-        defsubr(&*Smember);
-        defsubr(&*Smemq);
-        defsubr(&*Smemql);
-        defsubr(&*Snlistp);
-        defsubr(&*Snth);
-        defsubr(&*Snthcdr);
-        defsubr(&*Splist_get);
-        defsubr(&*Splist_member);
-        defsubr(&*Splist_put);
-        defsubr(&*Sput);
-        defsubr(&*Srassoc);
-        defsubr(&*Srassq);
-        defsubr(&*Ssafe_length);
-        defsubr(&*Ssetcar);
-        defsubr(&*Ssetcdr);
-    }
+export_lisp_fns! {
+    assoc,
+    assq,
+    atom,
+    car,
+    car_safe,
+    cdr,
+    cdr_safe,
+    consp,
+    delq,
+    get,
+    lax_plist_get,
+    lax_plist_put,
+    list,
+    listp,
+    make_list,
+    member,
+    memq,
+    memql,
+    nlistp,
+    nth,
+    nthcdr,
+    plist_get,
+    plist_member,
+    plist_put,
+    put,
+    rassoc,
+    rassq,
+    safe_length,
+    setcar,
+    setcdr
 }

--- a/rust_src/src/marker.rs
+++ b/rust_src/src/marker.rs
@@ -102,10 +102,8 @@ pub fn set_point_from_marker(marker: LispMarkerRef) {
     unsafe { set_point_both(charpos, bytepos) };
 }
 
-pub fn rust_init_syms() {
-    unsafe {
-        defsubr(&*Smarker_buffer);
-        defsubr(&*Smarker_position);
-        defsubr(&*Smarkerp);
-    }
+export_lisp_fns! {
+    marker_buffer,
+    marker_position,
+    markerp
 }

--- a/rust_src/src/math.rs
+++ b/rust_src/src/math.rs
@@ -415,28 +415,26 @@ fn lognot(number: LispObject) -> LispObject {
     LispObject::from_fixnum(!number.as_fixnum_or_error())
 }
 
-pub fn rust_init_syms() {
-    unsafe {
-        defsubr(&*Sabs);
-        defsubr(&*Sadd1);
-        defsubr(&*Seqlsign);
-        defsubr(&*Sgeq);
-        defsubr(&*Sgtr);
-        defsubr(&*Sleq);
-        defsubr(&*Slogand);
-        defsubr(&*Slogior);
-        defsubr(&*Slognot);
-        defsubr(&*Slogxor);
-        defsubr(&*Slss);
-        defsubr(&*Smax);
-        defsubr(&*Smin);
-        defsubr(&*Sminus);
-        defsubr(&*Smod);
-        defsubr(&*Sneq);
-        defsubr(&*Splus);
-        defsubr(&*Squo);
-        defsubr(&*Srem);
-        defsubr(&*Ssub1);
-        defsubr(&*Stimes);
-    }
+export_lisp_fns! {
+    abs,
+    add1,
+    eqlsign,
+    geq,
+    gtr,
+    leq,
+    logand,
+    logior,
+    lognot,
+    logxor,
+    lss,
+    max,
+    min,
+    minus,
+    mod,
+    neq,
+    plus,
+    quo,
+    rem,
+    sub1,
+    times
 }

--- a/rust_src/src/minibuf.rs
+++ b/rust_src/src/minibuf.rs
@@ -50,10 +50,8 @@ pub fn set_minibuffer_window(window: LispObject) -> LispObject {
     window
 }
 
-pub fn rust_init_syms() {
-    unsafe {
-        defsubr(&*Sactive_minibuffer_window);
-        defsubr(&*Sminibufferp);
-        defsubr(&*Sset_minibuffer_window);
-    }
+export_lisp_fns! {
+    active_minibuffer_window,
+    minibufferp,
+    set_minibuffer_window
 }

--- a/rust_src/src/numbers.rs
+++ b/rust_src/src/numbers.rs
@@ -87,14 +87,12 @@ fn random(limit: LispObject) -> LispObject {
     }
 }
 
-pub fn rust_init_syms() {
-    unsafe {
-        defsubr(&*Sfloatp);
-        defsubr(&*Sinteger_or_marker_p);
-        defsubr(&*Sintegerp);
-        defsubr(&*Snatnump);
-        defsubr(&*Snumber_or_marker_p);
-        defsubr(&*Snumberp);
-        defsubr(&*Srandom);
-    }
+export_lisp_fns! {
+    floatp,
+    integer_or_marker_p,
+    integerp,
+    natnump,
+    number_or_marker_p,
+    numberp,
+    random
 }

--- a/rust_src/src/obarray.rs
+++ b/rust_src/src/obarray.rs
@@ -150,9 +150,7 @@ fn intern(string: LispObject, obarray: LispObject) -> LispObject {
     }
 }
 
-pub fn rust_init_syms() {
-    unsafe {
-        defsubr(&*Sintern);
-        defsubr(&*Sintern_soft);
-    }
+export_lisp_fns! {
+    intern,
+    intern_soft
 }

--- a/rust_src/src/objects.rs
+++ b/rust_src/src/objects.rs
@@ -61,13 +61,11 @@ fn identity(arg: LispObject) -> LispObject {
     arg
 }
 
-pub fn rust_init_syms() {
-    unsafe {
-        defsubr(&*Seq);
-        defsubr(&*Seql);
-        defsubr(&*Sequal);
-        defsubr(&*Sequal_including_properties);
-        defsubr(&*Sidentity);
-        defsubr(&*Snull);
-    }
+export_lisp_fns! {
+    eq,
+    eql,
+    equal,
+    equal_including_properties,
+    identity,
+    null
 }

--- a/rust_src/src/process.rs
+++ b/rust_src/src/process.rs
@@ -103,14 +103,12 @@ pub fn set_process_plist(process: LispObject, plist: LispObject) -> LispObject {
     }
 }
 
-pub fn rust_init_syms() {
-    unsafe {
-        defsubr(&*Sget_buffer_process);
-        defsubr(&*Sget_process);
-        defsubr(&*Sprocess_buffer);
-        defsubr(&*Sprocess_list);
-        defsubr(&*Sprocess_name);
-        defsubr(&*Sprocessp);
-        defsubr(&*Sset_process_plist);
-    }
+export_lisp_fns! {
+    get_buffer_process,
+    get_process,
+    process_buffer,
+    process_list,
+    process_name,
+    processp,
+    set_process_plist
 }

--- a/rust_src/src/strings.rs
+++ b/rust_src/src/strings.rs
@@ -155,15 +155,13 @@ fn multibyte_string_p(object: LispObject) -> LispObject {
     LispObject::from_bool(object.as_string().map_or(false, |s| s.is_multibyte()))
 }
 
-pub fn rust_init_syms() {
-    unsafe {
-        defsubr(&*Smultibyte_string_p);
-        defsubr(&*Sstring_as_multibyte);
-        defsubr(&*Sstring_bytes);
-        defsubr(&*Sstring_equal);
-        defsubr(&*Sstring_lessp);
-        defsubr(&*Sstring_to_multibyte);
-        defsubr(&*Sstring_to_unibyte);
-        defsubr(&*Sstringp);
-    }
+export_lisp_fns! {
+    multibyte_string_p,
+    string_as_multibyte,
+    string_bytes,
+    string_equal,
+    string_lessp,
+    string_to_multibyte,
+    string_to_unibyte,
+    stringp
 }

--- a/rust_src/src/symbols.rs
+++ b/rust_src/src/symbols.rs
@@ -208,18 +208,16 @@ pub fn symbol_value(symbol: LispObject) -> LispObject {
     LispObject::from(val)
 }
 
-pub fn rust_init_syms() {
-    unsafe {
-        defsubr(&*Sfboundp);
-        defsubr(&*Sfmakunbound);
-        defsubr(&*Sindirect_variable);
-        defsubr(&*Skeywordp);
-        defsubr(&*Smakunbound);
-        defsubr(&*Ssetplist);
-        defsubr(&*Ssymbol_function);
-        defsubr(&*Ssymbol_name);
-        defsubr(&*Ssymbol_plist);
-        defsubr(&*Ssymbol_value);
-        defsubr(&*Ssymbolp);
-    }
+export_lisp_fns! {
+    fboundp,
+    fmakunbound,
+    indirect_variable,
+    keywordp,
+    makunbound,
+    setplist,
+    symbol_function,
+    symbol_name,
+    symbol_plist,
+    symbol_value,
+    symbolp
 }

--- a/rust_src/src/threads.rs
+++ b/rust_src/src/threads.rs
@@ -33,8 +33,6 @@ pub fn thread_name(thread: LispObject) -> LispObject {
     thread.as_thread_or_error().name()
 }
 
-pub fn rust_init_syms() {
-    unsafe {
-        defsubr(&*Sthread_name);
-    }
+export_lisp_fns! {
+    thread_name
 }

--- a/rust_src/src/vectors.rs
+++ b/rust_src/src/vectors.rs
@@ -361,23 +361,21 @@ macro_rules! allocate_pseudovector {
     }
 }
 
-pub fn rust_init_syms() {
-    unsafe {
-        defsubr(&*Sarrayp);
-        defsubr(&*Sbool_vector_p);
-        defsubr(&*Sbufferp);
-        defsubr(&*Sbyte_code_function_p);
-        defsubr(&*Schar_table_p);
-        defsubr(&*Scondition_variable_p);
-        defsubr(&*Selt);
-        defsubr(&*Slength);
-        defsubr(&*Smutexp);
-        defsubr(&*Srecordp);
-        defsubr(&*Ssequencep);
-        defsubr(&*Ssort);
-        defsubr(&*Ssubrp);
-        defsubr(&*Sthreadp);
-        defsubr(&*Svector_or_char_table_p);
-        defsubr(&*Svectorp);
-    }
+export_lisp_fns! {
+    arrayp,
+    bool_vector_p,
+    bufferp,
+    byte_code_function_p,
+    char_table_p,
+    condition_variable_p,
+    elt,
+    length,
+    mutexp,
+    recordp,
+    sequencep,
+    sort,
+    subrp,
+    threadp,
+    vector_or_char_table_p,
+    vectorp
 }

--- a/rust_src/src/windows.rs
+++ b/rust_src/src/windows.rs
@@ -344,22 +344,20 @@ pub fn window_frame(window: LispObject) -> LispObject {
     win.frame()
 }
 
-pub fn rust_init_syms() {
-    unsafe {
-        defsubr(&*Sminibuffer_selected_window);
-        defsubr(&*Sselected_window);
-        defsubr(&*Sset_window_combination_limit);
-        defsubr(&*Swindow_buffer);
-        defsubr(&*Swindow_combination_limit);
-        defsubr(&*Swindow_frame);
-        defsubr(&*Swindow_live_p);
-        defsubr(&*Swindow_margins);
-        defsubr(&*Swindow_minibuffer_p);
-        defsubr(&*Swindow_point);
-        defsubr(&*Swindow_start);
-        defsubr(&*Swindow_total_height);
-        defsubr(&*Swindow_total_width);
-        defsubr(&*Swindow_valid_p);
-        defsubr(&*Swindowp);
-    }
+export_lisp_fns! {
+    minibuffer_selected_window,
+    selected_window,
+    set_window_combination_limit,
+    window_buffer,
+    window_combination_limit,
+    window_frame,
+    window_live_p,
+    window_margins,
+    window_minibuffer_p,
+    window_point,
+    window_start,
+    window_total_height,
+    window_total_width,
+    window_valid_p,
+    windowp
 }


### PR DESCRIPTION
The goal is to allow changes to calls of `defsubr` to be made in one
place. Hopefully this also makes it a little easier for PRs to add
new lisp functions.