### PR TITLE
Reducing appveyor make to 1 core in an effort to fix stalling builds

### DIFF
--- a/.appveyor.bat
+++ b/.appveyor.bat
@@ -66,5 +66,5 @@ C:\msys64\usr\bin\bash --login -c "pacman -Syu --noconfirm mingw-w64-x86_64-libr
 C:\msys64\usr\bin\bash --login -c "pacman -Syu --noconfirm mingw-w64-x86_64-gnutls"
 C:\msys64\usr\bin\bash --login -c "cd /c/projects/remacs && ./autogen.sh"
 C:\msys64\usr\bin\bash --login -c "cd /c/projects/remacs && PKG_CONFIG_PATH=/mingw64/lib/pkgconfig ./configure --without-imagemagick"
-C:\msys64\usr\bin\bash --login -c "cd /c/projects/remacs && make -j 3 && make check"
+C:\msys64\usr\bin\bash --login -c "cd /c/projects/remacs && make && make check"
 if %ERRORLEVEL% NEQ 0 exit 1


### PR DESCRIPTION
https://ci.appveyor.com/project/Wilfred/remacs/build/1.0.144 seems to have stalled. Remote-desktoping into the build doesn't reveal any obvious signs. I believe it may be related to our parallelism, so I would like to cut us down to 1 core down from 3 to see if that helps. 