### PR TITLE
Port forward-char and backward-char

### DIFF
--- a/rust_src/remacs-sys/lib.rs
+++ b/rust_src/remacs-sys/lib.rs
@@ -1030,6 +1030,7 @@ extern "C" {
         multibyte: bool,
     ) -> Lisp_Object;
     pub fn string_to_multibyte(string: Lisp_Object) -> Lisp_Object;
+    pub fn initial_define_key(keymap: Lisp_Object, key: c_int, defname: *const c_char);
 
     pub fn preferred_coding_system() -> Lisp_Object;
     pub fn Fcoding_system_p(o: Lisp_Object) -> Lisp_Object;

--- a/rust_src/src/keymap.rs
+++ b/rust_src/src/keymap.rs
@@ -5,6 +5,10 @@ use remacs_macros::lisp_fn;
 use remacs_sys::{current_global_map as _current_global_map, Flookup_key};
 use threads::ThreadState;
 
+#[inline]
+pub fn Ctl(c: char) -> i32 {
+    (c as i32) & 0x1f
+}
 
 /// Return the binding for command KEYS in current local keymap only.
 /// KEYS is a string or vector, a sequence of keystrokes.
@@ -30,13 +34,13 @@ fn local_key_binding(keys: LispObject, accept_default: LispObject) -> LispObject
 /// Return current buffer's local keymap, or nil if it has none.
 /// Normally the local keymap is set by the major mode with `use-local-map'.
 #[lisp_fn]
-fn current_local_map() -> LispObject {
+pub fn current_local_map() -> LispObject {
     LispObject::from(ThreadState::current_buffer().keymap)
 }
 
 /// Return the current global keymap.
 #[lisp_fn]
-fn current_global_map() -> LispObject {
+pub fn current_global_map() -> LispObject {
     unsafe { LispObject::from(_current_global_map) }
 }
 

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -82,6 +82,11 @@ use alloc_unexecmacosx::OsxUnexecAlloc;
 #[global_allocator]
 static ALLOCATOR: OsxUnexecAlloc = OsxUnexecAlloc;
 
+#[no_mangle]
+pub extern "C" fn rust_initial_keys() {
+    cmds::initial_keys();
+}
+
 include!(concat!(env!("OUT_DIR"), "/c_exports.rs"));
 
 #[cfg(test)]

--- a/src/cmds.c
+++ b/src/cmds.c
@@ -31,69 +31,6 @@ along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.  */
 
 static int internal_self_insert (int, EMACS_INT);
 
-/* Add N to point; or subtract N if FORWARD is false.  N defaults to 1.
-   Validate the new location.  Return nil.  */
-static Lisp_Object
-move_point (Lisp_Object n, bool forward)
-{
-  /* This used to just set point to point + XINT (n), and then check
-     to see if it was within boundaries.  But now that SET_PT can
-     potentially do a lot of stuff (calling entering and exiting
-     hooks, etcetera), that's not a good approach.  So we validate the
-     proposed position, then set point.  */
-
-  EMACS_INT new_point;
-
-  if (NILP (n))
-    XSETFASTINT (n, 1);
-  else
-    CHECK_NUMBER (n);
-
-  new_point = PT + (forward ? XINT (n) : - XINT (n));
-
-  if (new_point < BEGV)
-    {
-      SET_PT (BEGV);
-      xsignal0 (Qbeginning_of_buffer);
-    }
-  if (new_point > ZV)
-    {
-      SET_PT (ZV);
-      xsignal0 (Qend_of_buffer);
-    }
-
-  SET_PT (new_point);
-  return Qnil;
-}
-
-DEFUN ("forward-char", Fforward_char, Sforward_char, 0, 1, "^p",
-       doc: /* Move point N characters forward (backward if N is negative).
-On reaching end or beginning of buffer, stop and signal error.
-Interactively, N is the numeric prefix argument.
-If N is omitted or nil, move point 1 character forward.
-
-Depending on the bidirectional context, the movement may be to the
-right or to the left on the screen.  This is in contrast with
-\\[right-char], which see.  */)
-  (Lisp_Object n)
-{
-  return move_point (n, 1);
-}
-
-DEFUN ("backward-char", Fbackward_char, Sbackward_char, 0, 1, "^p",
-       doc: /* Move point N characters backward (forward if N is negative).
-On attempt to pass beginning or end of buffer, stop and signal error.
-Interactively, N is the numeric prefix argument.
-If N is omitted or nil, move point 1 character backward.
-
-Depending on the bidirectional context, the movement may be to the
-right or to the left on the screen.  This is in contrast with
-\\[left-char], which see.  */)
-  (Lisp_Object n)
-{
-  return move_point (n, 0);
-}
-
 DEFUN ("forward-line", Fforward_line, Sforward_line, 0, 1, "^p",
        doc: /* Move N lines forward (backward if N is negative).
 Precisely, if point is on line I, move to the start of line I + N
@@ -432,8 +369,6 @@ syms_of_cmds (void)
 This is run after inserting the character.  */);
   Vpost_self_insert_hook = Qnil;
 
-  defsubr (&Sforward_char);
-  defsubr (&Sbackward_char);
   defsubr (&Sforward_line);
 
   defsubr (&Sdelete_char);
@@ -450,9 +385,4 @@ keys_of_cmds (void)
     initial_define_key (global_map, n, "self-insert-command");
   for (n = 0240; n < 0400; n++)
     initial_define_key (global_map, n, "self-insert-command");
-
-  initial_define_key (global_map, Ctl ('A'), "beginning-of-line");
-  initial_define_key (global_map, Ctl ('B'), "backward-char");
-  initial_define_key (global_map, Ctl ('E'), "end-of-line");
-  initial_define_key (global_map, Ctl ('F'), "forward-char");
 }

--- a/src/emacs.c
+++ b/src/emacs.c
@@ -111,6 +111,8 @@ static const char emacs_version[] = PACKAGE_VERSION;
 static const char emacs_copyright[] = COPYRIGHT;
 static const char emacs_bugreport[] = PACKAGE_BUGREPORT;
 
+extern void rust_initial_keys(void);
+
 /* Empty lisp strings.  To avoid having to build any others.  */
 Lisp_Object empty_unibyte_string, empty_multibyte_string;
 
@@ -1567,6 +1569,7 @@ Using an Emacs configured with --with-x-toolkit=lucid does not have this problem
       keys_of_keyboard ();
       keys_of_keymap ();
       keys_of_window ();
+      rust_initial_keys ();
     }
   else
     {


### PR DESCRIPTION
Add mechanism to set initial keybindings in Rust.