### PR TITLE
lisp_fn exported functions should be public within rust too.

### DIFF
--- a/rust_src/build.rs
+++ b/rust_src/build.rs
@@ -114,7 +114,10 @@ where
 
                 if line.starts_with("fn") {
                     panic!(format!(
-                        "{} is not public in {} module.\nlisp_fn functions are meant to be used from within remacs as well as in lisp code.",
+                        "
+{} is not public in {} module.
+lisp_fn functions are meant to be used from within remacs as well as in lisp code.
+",
                         name.unwrap_or("<unknown>".to_string()),
                         modname
                     ));

--- a/rust_src/src/base64.rs
+++ b/rust_src/src/base64.rs
@@ -147,7 +147,7 @@ fn test_base64_decode_1() {
 /// Optional second argument NO-LINE-BREAK means do not break long lines
 /// into shorter lines.
 #[lisp_fn(min = "1")]
-fn base64_encode_string(string: LispObject, no_line_break: LispObject) -> LispObject {
+pub fn base64_encode_string(string: LispObject, no_line_break: LispObject) -> LispObject {
     let mut string = string.as_string_or_error();
 
     // We need to allocate enough room for the encoded text
@@ -182,7 +182,7 @@ fn base64_encode_string(string: LispObject, no_line_break: LispObject) -> LispOb
 
 /// Base64-decode STRING and return the result.
 #[lisp_fn]
-fn base64_decode_string(string: LispObject) -> LispObject {
+pub fn base64_decode_string(string: LispObject) -> LispObject {
     let mut string = string.as_string_or_error();
 
     let length = string.len_bytes();

--- a/rust_src/src/buffers.rs
+++ b/rust_src/src/buffers.rs
@@ -274,7 +274,7 @@ pub fn buffer_name(buffer: LispObject) -> LispObject {
 /// text in that buffer is changed.  It wraps around occasionally.
 /// No argument or nil as argument means use current buffer as BUFFER.
 #[lisp_fn(min = "0")]
-fn buffer_modified_tick(buffer: LispObject) -> LispObject {
+pub fn buffer_modified_tick(buffer: LispObject) -> LispObject {
     LispObject::from_fixnum(buffer.as_buffer_or_current_buffer().modifications())
 }
 
@@ -287,20 +287,20 @@ fn buffer_modified_tick(buffer: LispObject) -> LispObject {
 /// between these calls.  No argument or nil as argument means use current
 /// buffer as BUFFER.
 #[lisp_fn(min = "0")]
-fn buffer_chars_modified_tick(buffer: LispObject) -> LispObject {
+pub fn buffer_chars_modified_tick(buffer: LispObject) -> LispObject {
     LispObject::from_fixnum(buffer.as_buffer_or_current_buffer().char_modifications())
 }
 
 /// Return the position at which OVERLAY starts.
 #[lisp_fn]
-fn overlay_start(overlay: LispObject) -> LispObject {
+pub fn overlay_start(overlay: LispObject) -> LispObject {
     let marker = overlay.as_overlay_or_error().start();
     marker_position(marker)
 }
 
 /// Return the position at which OVERLAY ends.
 #[lisp_fn]
-fn overlay_end(overlay: LispObject) -> LispObject {
+pub fn overlay_end(overlay: LispObject) -> LispObject {
     let marker = overlay.as_overlay_or_error().end();
     marker_position(marker)
 }
@@ -308,7 +308,7 @@ fn overlay_end(overlay: LispObject) -> LispObject {
 /// Return the buffer OVERLAY belongs to.
 /// Return nil if OVERLAY has been deleted.
 #[lisp_fn]
-fn overlay_buffer(overlay: LispObject) -> LispObject {
+pub fn overlay_buffer(overlay: LispObject) -> LispObject {
     let marker = overlay.as_overlay_or_error().start();
     marker_buffer(marker)
 }
@@ -347,7 +347,7 @@ pub extern "C" fn validate_region(b: *mut Lisp_Object, e: *mut Lisp_Object) {
 /// `pop-to-buffer' to switch buffers permanently.
 /// The return value is the buffer made current.
 #[lisp_fn]
-fn set_buffer(buffer_or_name: LispObject) -> LispObject {
+pub fn set_buffer(buffer_or_name: LispObject) -> LispObject {
     let buffer = get_buffer(buffer_or_name);
     if buffer.is_nil() {
         unsafe { nsberror(buffer_or_name.to_raw()) }

--- a/rust_src/src/category.rs
+++ b/rust_src/src/category.rs
@@ -9,7 +9,7 @@ use threads::ThreadState;
 
 /// Return t if ARG is a category table.
 #[lisp_fn]
-fn category_table_p(arg: LispObject) -> LispObject {
+pub fn category_table_p(arg: LispObject) -> LispObject {
     LispObject::from_bool(arg.as_char_table().map_or(false, |table| {
         LispObject::from(table.purpose).eq(LispObject::from(Qcategory_table))
     }))
@@ -18,7 +18,7 @@ fn category_table_p(arg: LispObject) -> LispObject {
 /// Return the current category table.
 /// This is the one specified by the current buffer.
 #[lisp_fn]
-fn category_table() -> LispObject {
+pub fn category_table() -> LispObject {
     let buffer_ref = ThreadState::current_buffer();
     LispObject::from(buffer_ref.category_table)
 }

--- a/rust_src/src/character.rs
+++ b/rust_src/src/character.rs
@@ -10,7 +10,7 @@ use multibyte::MAX_CHAR;
 
 /// Return the character of the maximum code.
 #[lisp_fn]
-fn max_char() -> LispObject {
+pub fn max_char() -> LispObject {
     LispObject::from_fixnum(MAX_CHAR as EmacsInt)
 }
 
@@ -20,19 +20,19 @@ fn max_char() -> LispObject {
 /// maximum character code.
 /// usage: (fn OBJECT)
 #[lisp_fn(min = "1")]
-fn characterp(object: LispObject, _ignore: LispObject) -> LispObject {
+pub fn characterp(object: LispObject, _ignore: LispObject) -> LispObject {
     LispObject::from_bool(object.is_character())
 }
 
 /// Return t if OBJECT is a character or a string.
 #[lisp_fn]
-fn char_or_string_p(object: LispObject) -> LispObject {
+pub fn char_or_string_p(object: LispObject) -> LispObject {
     LispObject::from_bool(object.is_character() || object.is_string())
 }
 
 /// Convert the byte CH to multibyte character.
 #[lisp_fn]
-fn unibyte_char_to_multibyte(ch: LispObject) -> LispObject {
+pub fn unibyte_char_to_multibyte(ch: LispObject) -> LispObject {
     let c = ch.as_character_or_error();
     if c >= 0x100 {
         error!("Not a unibyte character: {}", c);
@@ -43,7 +43,7 @@ fn unibyte_char_to_multibyte(ch: LispObject) -> LispObject {
 /// Convert the multibyte character CH to a byte.
 /// If the multibyte character does not represent a byte, return -1.
 #[lisp_fn]
-fn multibyte_char_to_unibyte(ch: LispObject) -> LispObject {
+pub fn multibyte_char_to_unibyte(ch: LispObject) -> LispObject {
     let c = ch.as_character_or_error();
     if c < 256 {
         // Can't distinguish a byte read from a unibyte buffer from

--- a/rust_src/src/chartable.rs
+++ b/rust_src/src/chartable.rs
@@ -10,7 +10,7 @@ pub type LispCharTableRef = ExternalPtr<Lisp_Char_Table>;
 
 /// Return the subtype of char-table CHARTABLE.  The value is a symbol.
 #[lisp_fn]
-fn char_table_subtype(chartable: LispObject) -> LispObject {
+pub fn char_table_subtype(chartable: LispObject) -> LispObject {
     let table = chartable.as_char_table_or_error();
     LispObject::from(table.purpose)
 }
@@ -21,7 +21,7 @@ fn char_table_subtype(chartable: LispObject) -> LispObject {
 /// then the actual applicable value is inherited from the parent char-table
 /// (or from its parents, if necessary).
 #[lisp_fn]
-fn char_table_parent(chartable: LispObject) -> LispObject {
+pub fn char_table_parent(chartable: LispObject) -> LispObject {
     let table = chartable.as_char_table_or_error();
     LispObject::from(table.parent)
 }
@@ -29,7 +29,7 @@ fn char_table_parent(chartable: LispObject) -> LispObject {
 /// Set the parent char-table of CHARTABLE to PARENT.
 /// Return PARENT.  PARENT must be either nil or another char-table.
 #[lisp_fn]
-fn set_char_table_parent(chartable: LispObject, parent: LispObject) -> LispObject {
+pub fn set_char_table_parent(chartable: LispObject, parent: LispObject) -> LispObject {
     let mut curr_table = chartable.as_char_table_or_error();
 
     if parent.is_not_nil() {

--- a/rust_src/src/crypto/mod.rs
+++ b/rust_src/src/crypto/mod.rs
@@ -329,7 +329,7 @@ fn get_input(
 /// If NOERROR is non-nil, silently assume the `raw-text' coding if the
 /// guesswork fails.  Normally, an error is signaled in such case.
 #[lisp_fn(min = "1")]
-fn md5(
+pub fn md5(
     object: LispObject,
     start: LispObject,
     end: LispObject,
@@ -359,7 +359,7 @@ fn md5(
 ///
 /// If BINARY is non-nil, returns a string in binary form.
 #[lisp_fn(min = "2")]
-fn secure_hash(
+pub fn secure_hash(
     algorithm: LispObject,
     object: LispObject,
     start: LispObject,
@@ -492,7 +492,7 @@ fn sha512_buffer(buffer: &[u8], dest_buf: &mut [u8]) {
 /// This hash is performed on the raw internal format of the buffer,
 /// disregarding any coding systems.  If nil, use the current buffer.
 #[lisp_fn(min = "0")]
-fn buffer_hash(buffer_or_name: LispObject) -> LispObject {
+pub fn buffer_hash(buffer_or_name: LispObject) -> LispObject {
     let buffer = if buffer_or_name.is_nil() {
         current_buffer()
     } else {

--- a/rust_src/src/dispnew.rs
+++ b/rust_src/src/dispnew.rs
@@ -17,7 +17,7 @@ use lisp::defsubr;
 /// additional wait period, in milliseconds; this is for backwards compatibility.
 /// (Not all operating systems support waiting for a fraction of a second.)
 #[lisp_fn(min = "1")]
-fn sleep_for(seconds: LispObject, milliseconds: LispObject) -> LispObject {
+pub fn sleep_for(seconds: LispObject, milliseconds: LispObject) -> LispObject {
     let mut duration = extract_float(seconds.to_raw());
     if milliseconds.is_not_nil() {
         let milliseconds = milliseconds.as_fixnum_or_error() as f64;

--- a/rust_src/src/editfns.rs
+++ b/rust_src/src/editfns.rs
@@ -106,13 +106,13 @@ fn region_limit(beginningp: bool) -> LispObject {
 
 /// Return the integer value of point or mark, whichever is smaller.
 #[lisp_fn]
-fn region_beginning() -> LispObject {
+pub fn region_beginning() -> LispObject {
     region_limit(true)
 }
 
 /// Return the integer value of point or mark, whichever is larger.
 #[lisp_fn]
-fn region_end() -> LispObject {
+pub fn region_end() -> LispObject {
     region_limit(false)
 }
 
@@ -120,7 +120,7 @@ fn region_end() -> LispObject {
 /// Watch out!  Moving this marker changes the mark position.
 /// If you set the marker not to point anywhere, the buffer will have no mark.
 #[lisp_fn]
-fn mark_marker() -> LispObject {
+pub fn mark_marker() -> LispObject {
     ThreadState::current_buffer().mark()
 }
 

--- a/rust_src/src/floatfns.rs
+++ b/rust_src/src/floatfns.rs
@@ -101,7 +101,7 @@ pub fn float_arith_driver(
 
 /// Return non nil if argument X is a NaN.
 #[lisp_fn]
-fn isnan(x: LispObject) -> LispObject {
+pub fn isnan(x: LispObject) -> LispObject {
     let f = x.as_float_or_error();
     LispObject::from_bool(f.is_nan())
 }
@@ -112,7 +112,7 @@ fn isnan(x: LispObject) -> LispObject {
 /// divided by X, i.e. the angle in radians between the vector (X, Y)
 /// and the x-axis
 #[lisp_fn(min = "1")]
-fn atan(y: LispObject, x: LispObject) -> LispObject {
+pub fn atan(y: LispObject, x: LispObject) -> LispObject {
     let y = y.any_to_float_or_error();
 
     if x.is_nil() {
@@ -126,7 +126,7 @@ fn atan(y: LispObject, x: LispObject) -> LispObject {
 /// Return the natural logarithm of ARG.
 /// If the optional argument BASE is given, return log ARG using that base.
 #[lisp_fn(min = "1")]
-fn log(arg: LispObject, base: LispObject) -> LispObject {
+pub fn log(arg: LispObject, base: LispObject) -> LispObject {
     let d = arg.any_to_float_or_error();
     let res = if base.is_nil() {
         d.ln()
@@ -148,7 +148,7 @@ fn log(arg: LispObject, base: LispObject) -> LispObject {
 /// Return the smallest integer no less than ARG, as a float.
 /// (Round toward +inf.)
 #[lisp_fn]
-fn fceiling(arg: LispObject) -> LispObject {
+pub fn fceiling(arg: LispObject) -> LispObject {
     let d = arg.as_float_or_error();
     LispObject::from_float(d.ceil())
 }
@@ -156,7 +156,7 @@ fn fceiling(arg: LispObject) -> LispObject {
 /// Return the largest integer no greater than ARG, as a float.
 /// (Round toward -inf.)
 #[lisp_fn]
-fn ffloor(arg: LispObject) -> LispObject {
+pub fn ffloor(arg: LispObject) -> LispObject {
     let d = arg.as_float_or_error();
     LispObject::from_float(d.floor())
 }
@@ -164,7 +164,7 @@ fn ffloor(arg: LispObject) -> LispObject {
 /// Truncate a floating point number to an integral float value.
 /// (Round toward zero.)
 #[lisp_fn]
-fn ftruncate(arg: LispObject) -> LispObject {
+pub fn ftruncate(arg: LispObject) -> LispObject {
     let d = arg.as_float_or_error();
     if d > 0.0 {
         LispObject::from_float(d.floor())
@@ -175,7 +175,7 @@ fn ftruncate(arg: LispObject) -> LispObject {
 
 /// Return the floating point number equal to ARG.
 #[lisp_fn]
-fn float(arg: LispObject) -> LispObject {
+pub fn float(arg: LispObject) -> LispObject {
     if arg.is_float() {
         arg
     } else if let Some(n) = arg.as_fixnum() {
@@ -188,7 +188,7 @@ fn float(arg: LispObject) -> LispObject {
 /// Copy sign of X2 to value of X1, and return the result.
 /// Cause an error if X1 or X2 is not a float.
 #[lisp_fn]
-fn copysign(x1: LispObject, x2: LispObject) -> LispObject {
+pub fn copysign(x1: LispObject, x2: LispObject) -> LispObject {
     let f1 = x1.as_float_or_error();
     let f2 = x2.as_float_or_error();
     if libm::signbit(f1) != libm::signbit(f2) {
@@ -208,7 +208,7 @@ fn copysign(x1: LispObject, x2: LispObject) -> LispObject {
 /// The function returns the cons cell (SGNFCAND . EXP).
 /// If X is zero, both parts (SGNFCAND and EXP) are zero.
 #[lisp_fn]
-fn frexp(x: LispObject) -> LispObject {
+pub fn frexp(x: LispObject) -> LispObject {
     let f = x.any_to_float_or_error();
     let (significand, exponent) = libm::frexp(f);
     LispObject::cons(
@@ -220,7 +220,7 @@ fn frexp(x: LispObject) -> LispObject {
 /// Return SGNFCAND * 2**EXPONENT, as a floating point number.
 /// EXPONENT must be an integer.
 #[lisp_fn]
-fn ldexp(sgnfcand: LispObject, exponent: LispObject) -> LispObject {
+pub fn ldexp(sgnfcand: LispObject, exponent: LispObject) -> LispObject {
     let exponent = exponent.as_fixnum_or_error();
     let significand = sgnfcand.any_to_float_or_error();
     let result = libm::ldexp(significand, exponent as libc::c_int);
@@ -229,7 +229,7 @@ fn ldexp(sgnfcand: LispObject, exponent: LispObject) -> LispObject {
 
 /// Return the exponential ARG1 ** ARG2.
 #[lisp_fn]
-fn expt(arg1: LispObject, arg2: LispObject) -> LispObject {
+pub fn expt(arg1: LispObject, arg2: LispObject) -> LispObject {
     if let (Some(x), Some(y)) = (arg1.as_fixnum(), arg2.as_fixnum()) {
         if y >= 0 && y <= u32::max_value() as EmacsInt {
             return LispObject::from_fixnum(x.pow(y as u32));
@@ -243,7 +243,7 @@ fn expt(arg1: LispObject, arg2: LispObject) -> LispObject {
 /// Returns largest integer <= the base 2 log of the magnitude of ARG.
 /// This is the same as the exponent of a float.
 #[lisp_fn]
-fn logb(arg: LispObject) -> LispObject {
+pub fn logb(arg: LispObject) -> LispObject {
     let res = if let Some(n) = arg.as_fixnum() {
         let i = n.abs();
         if i == 0 {
@@ -268,7 +268,7 @@ fn logb(arg: LispObject) -> LispObject {
 
 /// Return the nearest integer to ARG, as a float.
 #[lisp_fn]
-fn fround(arg: LispObject) -> LispObject {
+pub fn fround(arg: LispObject) -> LispObject {
     let d = arg.as_float_or_error();
     LispObject::from_float(libm::rint(d))
 }
@@ -277,7 +277,7 @@ fn fround(arg: LispObject) -> LispObject {
 /// This rounds the value towards +inf.
 /// With optional DIVISOR, return the smallest integer no less than ARG/DIVISOR.
 #[lisp_fn(min = "1")]
-fn ceiling(arg: LispObject, divisor: LispObject) -> LispObject {
+pub fn ceiling(arg: LispObject, divisor: LispObject) -> LispObject {
     rounding_driver(arg, divisor, |x| x.ceil(), ceiling2, "ceiling")
 }
 
@@ -285,7 +285,7 @@ fn ceiling(arg: LispObject, divisor: LispObject) -> LispObject {
 /// This rounds the value towards -inf.
 /// With optional DIVISOR, return the largest integer no greater than ARG/DIVISOR.
 #[lisp_fn(min = "1")]
-fn floor(arg: LispObject, divisor: LispObject) -> LispObject {
+pub fn floor(arg: LispObject, divisor: LispObject) -> LispObject {
     rounding_driver(arg, divisor, |x| x.floor(), floor2, "floor")
 }
 
@@ -297,7 +297,7 @@ fn floor(arg: LispObject, divisor: LispObject) -> LispObject {
 /// your machine.  For example, (round 2.5) can return 3 on some
 /// systems, but 2 on others.
 #[lisp_fn(min = "1")]
-fn round(arg: LispObject, divisor: LispObject) -> LispObject {
+pub fn round(arg: LispObject, divisor: LispObject) -> LispObject {
     rounding_driver(arg, divisor, libm::rint, round2, "round")
 }
 
@@ -305,7 +305,7 @@ fn round(arg: LispObject, divisor: LispObject) -> LispObject {
 /// Rounds ARG toward zero.
 /// With optional DIVISOR, truncate ARG/DIVISOR.
 #[lisp_fn(min = "1")]
-fn truncate(arg: LispObject, divisor: LispObject) -> LispObject {
+pub fn truncate(arg: LispObject, divisor: LispObject) -> LispObject {
     rounding_driver(arg, divisor, |x| x.trunc(), truncate2, "truncate")
 }
 

--- a/rust_src/src/fns.rs
+++ b/rust_src/src/fns.rs
@@ -17,7 +17,7 @@ use lists::{assq, get, member, memq, put};
 /// looks at the value of the variable `features'.  The optional argument
 /// SUBFEATURE can be used to check a specific subfeature of FEATURE.
 #[lisp_fn(min = "1")]
-fn featurep(feature: LispObject, subfeature: LispObject) -> LispObject {
+pub fn featurep(feature: LispObject, subfeature: LispObject) -> LispObject {
     feature.as_symbol_or_error();
     let mut tem = memq(feature, LispObject::from(unsafe { globals.f_Vfeatures }));
     if tem.is_not_nil() && subfeature.is_not_nil() {
@@ -34,7 +34,7 @@ fn featurep(feature: LispObject, subfeature: LispObject) -> LispObject {
 /// The optional argument SUBFEATURES should be a list of symbols listing
 /// particular subfeatures supported in this version of FEATURE.
 #[lisp_fn(min = "1")]
-fn provide(feature: LispObject, subfeature: LispObject) -> LispObject {
+pub fn provide(feature: LispObject, subfeature: LispObject) -> LispObject {
     feature.as_symbol_or_error();
     if !subfeature.is_list() {
         wrong_type!(Qlistp, subfeature)

--- a/rust_src/src/hashtable.rs
+++ b/rust_src/src/hashtable.rs
@@ -181,7 +181,7 @@ impl LispHashTableRef {
 /// Return a copy of hash table TABLE.
 /// Keys and values are not copied, only the table itself is.
 #[lisp_fn]
-fn copy_hash_table(htable: LispObject) -> LispObject {
+pub fn copy_hash_table(htable: LispObject) -> LispObject {
     let mut table = htable.as_hash_table_or_error();
     let mut new_table = LispHashTableRef::allocate();
     unsafe { new_table.copy(table) };
@@ -209,7 +209,7 @@ fn copy_hash_table(htable: LispObject) -> LispObject {
 /// Look up KEY in TABLE and return its associated value.
 /// If KEY is not found, return DFLT which defaults to nil.
 #[lisp_fn(min = "2")]
-fn gethash(key: LispObject, table: LispObject, dflt: LispObject) -> LispObject {
+pub fn gethash(key: LispObject, table: LispObject, dflt: LispObject) -> LispObject {
     let hash_table = table.as_hash_table_or_error();
     let idx = hash_table.lookup(key, ptr::null_mut());
 
@@ -224,7 +224,7 @@ fn gethash(key: LispObject, table: LispObject, dflt: LispObject) -> LispObject {
 /// If KEY is already present in table, replace its current value with
 /// VALUE.  In any case, return VALUE.
 #[lisp_fn]
-fn puthash(key: LispObject, value: LispObject, table: LispObject) -> LispObject {
+pub fn puthash(key: LispObject, value: LispObject, table: LispObject) -> LispObject {
     let hash_table = table.as_hash_table_or_error();
     hash_table.check_impure(table);
 
@@ -242,7 +242,7 @@ fn puthash(key: LispObject, value: LispObject, table: LispObject) -> LispObject 
 
 /// Remove KEY from TABLE.
 #[lisp_fn]
-fn remhash(key: LispObject, table: LispObject) -> LispObject {
+pub fn remhash(key: LispObject, table: LispObject) -> LispObject {
     let hash_table = table.as_hash_table_or_error();
     hash_table.check_impure(table);
     hash_table.remove(key);
@@ -254,7 +254,7 @@ fn remhash(key: LispObject, table: LispObject) -> LispObject {
 /// FUNCTION is called with two arguments, KEY and VALUE.
 /// `maphash' always returns nil.
 #[lisp_fn]
-fn maphash(function: LispObject, table: LispObject) -> LispObject {
+pub fn maphash(function: LispObject, table: LispObject) -> LispObject {
     let hash_table = table.as_hash_table_or_error();
     for (key, value) in hash_table.iter() {
         call!(function, key, value);
@@ -265,19 +265,19 @@ fn maphash(function: LispObject, table: LispObject) -> LispObject {
 
 /// Return t if OBJ is a Lisp hash table object.
 #[lisp_fn]
-fn hash_table_p(obj: LispObject) -> LispObject {
+pub fn hash_table_p(obj: LispObject) -> LispObject {
     LispObject::from_bool(obj.is_hash_table())
 }
 
 /// Return the number of elements in TABLE.
 #[lisp_fn]
-fn hash_table_count(table: LispObject) -> LispObject {
+pub fn hash_table_count(table: LispObject) -> LispObject {
     LispObject::from_natnum(table.as_hash_table_or_error().count as EmacsInt)
 }
 
 /// Return the current rehash threshold of TABLE.
 #[lisp_fn]
-fn hash_table_rehash_threshold(table: LispObject) -> LispObject {
+pub fn hash_table_rehash_threshold(table: LispObject) -> LispObject {
     LispObject::from_float(table.as_hash_table_or_error().rehash_threshold as EmacsDouble)
 }
 
@@ -286,25 +286,25 @@ fn hash_table_rehash_threshold(table: LispObject) -> LispObject {
 /// a hash table than can hold as many elements as TABLE holds
 /// without need for resizing.
 #[lisp_fn]
-fn hash_table_size(table: LispObject) -> LispObject {
+pub fn hash_table_size(table: LispObject) -> LispObject {
     LispObject::from_natnum(table.as_hash_table_or_error().size() as EmacsInt)
 }
 
 /// Return the test TABLE uses.
 #[lisp_fn]
-fn hash_table_test(table: LispObject) -> LispObject {
+pub fn hash_table_test(table: LispObject) -> LispObject {
     LispObject::from(table.as_hash_table_or_error().test.name)
 }
 
 /// Return the weakness of TABLE.
 #[lisp_fn]
-fn hash_table_weakness(table: LispObject) -> LispObject {
+pub fn hash_table_weakness(table: LispObject) -> LispObject {
     table.as_hash_table_or_error().get_weak()
 }
 
 /// Clear hash table TABLE and return it.
 #[lisp_fn]
-fn clrhash(table: LispObject) -> LispObject {
+pub fn clrhash(table: LispObject) -> LispObject {
     let hash_table = table.as_hash_table_or_error();
     hash_table.check_impure(table);
     hash_table.clear();
@@ -322,7 +322,7 @@ fn clrhash(table: LispObject) -> LispObject {
 /// It should be the case that if (eq (funcall HASH x1) (funcall HASH x2))
 /// returns nil, then (funcall TEST x1 x2) also returns nil.
 #[lisp_fn]
-fn define_hash_table_test(name: LispObject, test: LispObject, hash: LispObject) -> LispObject {
+pub fn define_hash_table_test(name: LispObject, test: LispObject, hash: LispObject) -> LispObject {
     let sym = LispObject::from(Qhash_table_test);
     put(name, sym, list(&mut [test, hash]))
 }

--- a/rust_src/src/interactive.rs
+++ b/rust_src/src/interactive.rs
@@ -10,7 +10,7 @@ use lisp::defsubr;
 /// A raw prefix argument is what you get from `(interactive "P")'.
 /// Its numeric meaning is what you would get from `(interactive "p")'.
 #[lisp_fn]
-fn prefix_numeric_value(raw: LispObject) -> LispObject {
+pub fn prefix_numeric_value(raw: LispObject) -> LispObject {
     if raw.is_nil() {
         LispObject::from_fixnum(1)
     } else if raw.eq(LispObject::from(Qminus)) {

--- a/rust_src/src/keymap.rs
+++ b/rust_src/src/keymap.rs
@@ -16,7 +16,7 @@ pub fn Ctl(c: char) -> i32 {
 /// If optional argument ACCEPT-DEFAULT is non-nil, recognize default
 /// bindings; see the description of `lookup-key' for more details about this.
 #[lisp_fn(min = "1")]
-fn local_key_binding(keys: LispObject, accept_default: LispObject) -> LispObject {
+pub fn local_key_binding(keys: LispObject, accept_default: LispObject) -> LispObject {
     let map = current_local_map();
     if map.is_nil() {
         LispObject::constant_nil()

--- a/rust_src/src/lists.rs
+++ b/rust_src/src/lists.rs
@@ -9,26 +9,26 @@ use lisp::defsubr;
 
 /// Return t if OBJECT is not a cons cell.  This includes nil.
 #[lisp_fn]
-fn atom(object: LispObject) -> LispObject {
+pub fn atom(object: LispObject) -> LispObject {
     LispObject::from_bool(!object.is_cons())
 }
 
 /// Return t if OBJECT is a cons cell.
 #[lisp_fn]
-fn consp(object: LispObject) -> LispObject {
+pub fn consp(object: LispObject) -> LispObject {
     LispObject::from_bool(object.is_cons())
 }
 
 /// Return t if OBJECT is a list, that is, a cons cell or nil.
 /// Otherwise, return nil.
 #[lisp_fn]
-fn listp(object: LispObject) -> LispObject {
+pub fn listp(object: LispObject) -> LispObject {
     LispObject::from_bool(object.is_cons() || object.is_nil())
 }
 
 /// Return t if OBJECT is not a list.  Lists include nil.
 #[lisp_fn]
-fn nlistp(object: LispObject) -> LispObject {
+pub fn nlistp(object: LispObject) -> LispObject {
     LispObject::from_bool(!(object.is_cons() || object.is_nil()))
 }
 
@@ -43,7 +43,7 @@ pub fn setcar(cell: LispObject, newcar: LispObject) -> LispObject {
 
 /// Set the cdr of CELL to be NEWCDR.  Returns NEWCDR.
 #[lisp_fn]
-fn setcdr(cell: LispObject, newcdr: LispObject) -> LispObject {
+pub fn setcdr(cell: LispObject, newcdr: LispObject) -> LispObject {
     let cell = cell.as_cons_or_error();
     cell.check_impure();
     cell.set_cdr(newcdr);
@@ -80,7 +80,7 @@ pub fn cdr(list: LispObject) -> LispObject {
 
 /// Return the car of OBJECT if it is a cons cell, or else nil.
 #[lisp_fn]
-fn car_safe(object: LispObject) -> LispObject {
+pub fn car_safe(object: LispObject) -> LispObject {
     object
         .as_cons()
         .map_or(LispObject::constant_nil(), |cons| cons.car())
@@ -88,7 +88,7 @@ fn car_safe(object: LispObject) -> LispObject {
 
 /// Return the cdr of OBJECT if it is a cons cell, or else nil.
 #[lisp_fn]
-fn cdr_safe(object: LispObject) -> LispObject {
+pub fn cdr_safe(object: LispObject) -> LispObject {
     object
         .as_cons()
         .map_or(LispObject::constant_nil(), |cons| cons.cdr())
@@ -116,7 +116,7 @@ pub fn nthcdr(n: LispObject, list: LispObject) -> LispObject {
 /// Return the Nth element of LIST.
 /// N counts from zero.  If LIST is not that long, nil is returned.
 #[lisp_fn]
-fn nth(n: LispObject, list: LispObject) -> LispObject {
+pub fn nth(n: LispObject, list: LispObject) -> LispObject {
     car(nthcdr(n, list))
 }
 
@@ -135,7 +135,7 @@ pub fn memq(elt: LispObject, list: LispObject) -> LispObject {
 /// Return non-nil if ELT is an element of LIST.  Comparison done with `eql'.
 /// The value is actually the tail of LIST whose car is ELT.
 #[lisp_fn]
-fn memql(elt: LispObject, list: LispObject) -> LispObject {
+pub fn memql(elt: LispObject, list: LispObject) -> LispObject {
     if !elt.is_float() {
         return memq(elt, list);
     }
@@ -200,7 +200,7 @@ pub fn assoc(key: LispObject, list: LispObject, testfn: LispObject) -> LispObjec
 /// Return non-nil if KEY is `eq' to the cdr of an element of LIST.
 /// The value is actually the first element of LIST whose cdr is KEY.
 #[lisp_fn]
-fn rassq(key: LispObject, list: LispObject) -> LispObject {
+pub fn rassq(key: LispObject, list: LispObject) -> LispObject {
     for tail in list.iter_tails() {
         let item = tail.car();
         if let Some(item_cons) = item.as_cons() {
@@ -216,7 +216,7 @@ fn rassq(key: LispObject, list: LispObject) -> LispObject {
 /// The value is actually the first element of LIST whose cdr equals KEY.
 /// (fn KEY LIST)
 #[lisp_fn]
-fn rassoc(key: LispObject, list: LispObject) -> LispObject {
+pub fn rassoc(key: LispObject, list: LispObject) -> LispObject {
     for tail in list.iter_tails() {
         let item = tail.car();
         if let Some(item_cons) = item.as_cons() {
@@ -238,7 +238,7 @@ fn rassoc(key: LispObject, list: LispObject) -> LispObject {
 /// the value of a list `foo'.  See also `remq', which does not modify the
 /// argument.
 #[lisp_fn]
-fn delq(elt: LispObject, mut list: LispObject) -> LispObject {
+pub fn delq(elt: LispObject, mut list: LispObject) -> LispObject {
     let mut prev = LispObject::constant_nil();
     for tail in list.iter_tails() {
         let item = tail.car();
@@ -262,7 +262,7 @@ fn delq(elt: LispObject, mut list: LispObject) -> LispObject {
 /// corresponding to the given PROP, or nil if PROP is not one of the
 /// properties on the list.  This function never signals an error.
 #[lisp_fn]
-fn plist_get(plist: LispObject, prop: LispObject) -> LispObject {
+pub fn plist_get(plist: LispObject, prop: LispObject) -> LispObject {
     let mut prop_item = true;
     for tail in plist.iter_tails_safe() {
         if prop_item {
@@ -284,7 +284,7 @@ fn plist_get(plist: LispObject, prop: LispObject) -> LispObject {
 /// corresponding to the given PROP, or nil if PROP is not
 /// one of the properties on the list.
 #[lisp_fn]
-fn lax_plist_get(plist: LispObject, prop: LispObject) -> LispObject {
+pub fn lax_plist_get(plist: LispObject, prop: LispObject) -> LispObject {
     let mut prop_item = true;
     for tail in plist.iter_tails_plist() {
         if prop_item {
@@ -313,7 +313,7 @@ fn lax_plist_get(plist: LispObject, prop: LispObject) -> LispObject {
 /// property and a property with the value nil.
 /// The value is actually the tail of PLIST whose car is PROP.
 #[lisp_fn]
-fn plist_member(plist: LispObject, prop: LispObject) -> LispObject {
+pub fn plist_member(plist: LispObject, prop: LispObject) -> LispObject {
     let mut prop_item = true;
     for tail in plist.iter_tails_plist() {
         if prop_item && prop.eq(tail.car()) {
@@ -382,7 +382,7 @@ pub fn plist_put(plist: LispObject, prop: LispObject, val: LispObject) -> LispOb
 /// use `(setq x (lax-plist-put x prop val))' to be sure to use the new value.
 /// The PLIST is modified by side effects.
 #[lisp_fn]
-fn lax_plist_put(plist: LispObject, prop: LispObject, val: LispObject) -> LispObject {
+pub fn lax_plist_put(plist: LispObject, prop: LispObject, val: LispObject) -> LispObject {
     internal_plist_put(plist, prop, val, LispObject::equal)
 }
 
@@ -424,7 +424,7 @@ pub fn list(args: &mut [LispObject]) -> LispObject {
 
 /// Return a newly created list of length LENGTH, with each element being INIT.
 #[lisp_fn]
-fn make_list(length: LispObject, init: LispObject) -> LispObject {
+pub fn make_list(length: LispObject, init: LispObject) -> LispObject {
     let length = length.as_natnum_or_error();
     (0..length).fold(LispObject::constant_nil(), |list, _| {
         LispObject::cons(init, list)
@@ -436,7 +436,7 @@ fn make_list(length: LispObject, init: LispObject) -> LispObject {
 /// it returns 0.  If LIST is circular, it returns a finite value
 /// which is at least the number of distinct elements.
 #[lisp_fn]
-fn safe_length(list: LispObject) -> LispObject {
+pub fn safe_length(list: LispObject) -> LispObject {
     LispObject::int_or_float_from_fixnum(list.iter_tails_safe().count() as EmacsInt)
 }
 

--- a/rust_src/src/marker.rs
+++ b/rust_src/src/marker.rs
@@ -53,7 +53,7 @@ impl LispMarkerRef {
 
 /// Return t if OBJECT is a marker (editor pointer).
 #[lisp_fn]
-fn markerp(object: LispObject) -> LispObject {
+pub fn markerp(object: LispObject) -> LispObject {
     LispObject::from_bool(object.is_marker())
 }
 

--- a/rust_src/src/math.rs
+++ b/rust_src/src/math.rs
@@ -12,7 +12,7 @@ use lisp::defsubr;
 /// Both X and Y must be numbers or markers.
 /// (fn X Y)
 #[lisp_fn(name = "mod", c_name = "mod")]
-fn lisp_mod(x: LispObject, y: LispObject) -> LispObject {
+pub fn lisp_mod(x: LispObject, y: LispObject) -> LispObject {
     match (
         x.as_number_coerce_marker_or_error(),
         y.as_number_coerce_marker_or_error(),
@@ -143,7 +143,7 @@ fn arith_driver(code: ArithOp, args: &[LispObject]) -> LispObject {
 /// Return sum of any number of arguments, which are numbers or markers.
 /// usage: (fn &rest NUMBERS-OR-MARKERS)
 #[lisp_fn(name = "+")]
-fn plus(args: &mut [LispObject]) -> LispObject {
+pub fn plus(args: &mut [LispObject]) -> LispObject {
     arith_driver(ArithOp::Add, args)
 }
 
@@ -152,14 +152,14 @@ fn plus(args: &mut [LispObject]) -> LispObject {
 /// subtracts all but the first from the first.
 /// usage: (fn &optional NUMBER-OR-MARKER &rest MORE-NUMBERS-OR-MARKERS)
 #[lisp_fn(name = "-")]
-fn minus(args: &mut [LispObject]) -> LispObject {
+pub fn minus(args: &mut [LispObject]) -> LispObject {
     arith_driver(ArithOp::Sub, args)
 }
 
 /// Return product of any number of arguments, which are numbers or markers.
 /// usage: (fn &rest NUMBER-OR-MARKERS)
 #[lisp_fn(name = "*")]
-fn times(args: &mut [LispObject]) -> LispObject {
+pub fn times(args: &mut [LispObject]) -> LispObject {
     arith_driver(ArithOp::Mult, args)
 }
 
@@ -169,7 +169,7 @@ fn times(args: &mut [LispObject]) -> LispObject {
 /// The arguments must be numbers or markers.
 /// usage: (fn NUMBER &rest DIVISORS)
 #[lisp_fn(name = "/", min = "1")]
-fn quo(args: &mut [LispObject]) -> LispObject {
+pub fn quo(args: &mut [LispObject]) -> LispObject {
     for argnum in 2..args.len() {
         let arg = args[argnum];
         if arg.is_float() {
@@ -183,7 +183,7 @@ fn quo(args: &mut [LispObject]) -> LispObject {
 /// Arguments may be integers, or markers, converted to integers.
 /// usage: (fn &rest INTS-OR-MARKERS)
 #[lisp_fn]
-fn logand(args: &mut [LispObject]) -> LispObject {
+pub fn logand(args: &mut [LispObject]) -> LispObject {
     arith_driver(ArithOp::Logand, args)
 }
 
@@ -191,7 +191,7 @@ fn logand(args: &mut [LispObject]) -> LispObject {
 /// Arguments may be integers, or markers converted to integers.
 /// usage: (fn &rest INTS-OR-MARKERS)
 #[lisp_fn]
-fn logior(args: &mut [LispObject]) -> LispObject {
+pub fn logior(args: &mut [LispObject]) -> LispObject {
     arith_driver(ArithOp::Logior, args)
 }
 
@@ -199,7 +199,7 @@ fn logior(args: &mut [LispObject]) -> LispObject {
 /// Arguments may be integers, or markers converted to integers.
 /// usage: (fn &rest INTS-OR-MARKERS)
 #[lisp_fn]
-fn logxor(args: &mut [LispObject]) -> LispObject {
+pub fn logxor(args: &mut [LispObject]) -> LispObject {
     arith_driver(ArithOp::Logxor, args)
 }
 
@@ -226,7 +226,7 @@ fn minmax_driver(args: &[LispObject], comparison: ArithComparison) -> LispObject
 /// The value is always a number; markers are converted to numbers.
 /// usage: (fn NUMBER-OR-MARKER &rest NUMBERS-OR-MARKERS)
 #[lisp_fn(min = "1")]
-fn max(args: &mut [LispObject]) -> LispObject {
+pub fn max(args: &mut [LispObject]) -> LispObject {
     minmax_driver(args, ArithComparison::Grtr)
 }
 
@@ -234,13 +234,13 @@ fn max(args: &mut [LispObject]) -> LispObject {
 /// The value is always a number; markers are converted to numbers.
 /// usage: (fn NUMBER-OR-MARKER &rest NUMBERS-OR-MARKERS)
 #[lisp_fn(min = "1")]
-fn min(args: &mut [LispObject]) -> LispObject {
+pub fn min(args: &mut [LispObject]) -> LispObject {
     minmax_driver(args, ArithComparison::Less)
 }
 
 /// Return the absolute value of ARG.
 #[lisp_fn]
-fn abs(arg: LispObject) -> LispObject {
+pub fn abs(arg: LispObject) -> LispObject {
     if let Some(f) = arg.as_float() {
         LispObject::from_float(f.abs())
     } else if let Some(n) = arg.as_fixnum() {
@@ -337,48 +337,48 @@ fn arithcompare_driver(args: &[LispObject], comparison: ArithComparison) -> Lisp
 /// Return t if args, all numbers or markers, are equal.
 /// usage: (fn NUMBER-OR-MARKER &rest NUMBERS-OR-MARKERS)
 #[lisp_fn(name = "=", min = "1")]
-fn eqlsign(args: &mut [LispObject]) -> LispObject {
+pub fn eqlsign(args: &mut [LispObject]) -> LispObject {
     arithcompare_driver(args, ArithComparison::Equal)
 }
 
 /// Return t if each arg (a number or marker), is less than the next arg.
 /// usage: (fn NUMBER-OR-MARKER &rest NUMBERS-OR-MARKERS)
 #[lisp_fn(name = "<", min = "1")]
-fn lss(args: &mut [LispObject]) -> LispObject {
+pub fn lss(args: &mut [LispObject]) -> LispObject {
     arithcompare_driver(args, ArithComparison::Less)
 }
 
 /// Return t if each arg (a number or marker) is greater than the next arg.
 /// usage: (fn NUMBER-OR-MARKER &rest NUMBERS-OR-MARKERS)
 #[lisp_fn(name = ">", min = "1")]
-fn gtr(args: &mut [LispObject]) -> LispObject {
+pub fn gtr(args: &mut [LispObject]) -> LispObject {
     arithcompare_driver(args, ArithComparison::Grtr)
 }
 
 /// Return t if each arg (a number or marker) is less than or equal to the next.
 /// usage: (fn NUMBER-OR-MARKER &rest NUMBERS-OR-MARKERS)
 #[lisp_fn(name = "<=", min = "1")]
-fn leq(args: &mut [LispObject]) -> LispObject {
+pub fn leq(args: &mut [LispObject]) -> LispObject {
     arithcompare_driver(args, ArithComparison::LessOrEqual)
 }
 
 /// Return t if each arg (a number or marker) is greater than or equal to the next.
 /// usage: (fn NUMBER-OR-MARKER &rest NUMBERS-OR-MARKERS)
 #[lisp_fn(name = ">=", min = "1")]
-fn geq(args: &mut [LispObject]) -> LispObject {
+pub fn geq(args: &mut [LispObject]) -> LispObject {
     arithcompare_driver(args, ArithComparison::GrtrOrEqual)
 }
 
 /// Return t if first arg is not equal to second arg.  Both must be numbers or markers.
 #[lisp_fn(name = "/=")]
-fn neq(num1: LispObject, num2: LispObject) -> LispObject {
+pub fn neq(num1: LispObject, num2: LispObject) -> LispObject {
     arithcompare(num1, num2, ArithComparison::Notequal)
 }
 
 /// Return remainder of X divided by Y.
 /// Both must be integers or markers.
 #[lisp_fn(name = "%")]
-fn rem(x: LispObject, y: LispObject) -> LispObject {
+pub fn rem(x: LispObject, y: LispObject) -> LispObject {
     let x = x.as_fixnum_coerce_marker_or_error();
     let y = y.as_fixnum_coerce_marker_or_error();
 
@@ -392,7 +392,7 @@ fn rem(x: LispObject, y: LispObject) -> LispObject {
 /// Return NUMBER plus one.  NUMBER may be a number or a marker.
 /// Markers are converted to integers.
 #[lisp_fn(name = "1+")]
-fn add1(number: LispObject) -> LispObject {
+pub fn add1(number: LispObject) -> LispObject {
     match number.as_number_coerce_marker_or_error() {
         LispNumber::Fixnum(num) => LispObject::from_fixnum(num + 1),
         LispNumber::Float(num) => LispObject::from_float(num + 1.0),
@@ -402,7 +402,7 @@ fn add1(number: LispObject) -> LispObject {
 /// Return NUMBER minus one.  NUMBER may be a number or a marker.
 /// Markers are converted to integers.
 #[lisp_fn(name = "1-")]
-fn sub1(number: LispObject) -> LispObject {
+pub fn sub1(number: LispObject) -> LispObject {
     match number.as_number_coerce_marker_or_error() {
         LispNumber::Fixnum(num) => LispObject::from_fixnum(num - 1),
         LispNumber::Float(num) => LispObject::from_float(num - 1.0),
@@ -411,7 +411,7 @@ fn sub1(number: LispObject) -> LispObject {
 
 /// Return the bitwise complement of NUMBER.  NUMBER must be an integer.
 #[lisp_fn]
-fn lognot(number: LispObject) -> LispObject {
+pub fn lognot(number: LispObject) -> LispObject {
     LispObject::from_fixnum(!number.as_fixnum_or_error())
 }
 

--- a/rust_src/src/minibuf.rs
+++ b/rust_src/src/minibuf.rs
@@ -28,7 +28,7 @@ pub fn minibufferp(object: LispObject) -> LispObject {
 
 /// Return the currently active minibuffer window, or nil if none.
 #[lisp_fn]
-fn active_minibuffer_window() -> LispObject {
+pub fn active_minibuffer_window() -> LispObject {
     unsafe {
         if minibuf_level == 0 {
             LispObject::constant_nil()

--- a/rust_src/src/numbers.rs
+++ b/rust_src/src/numbers.rs
@@ -16,37 +16,37 @@ lazy_static! {
 
 /// Return t if OBJECT is a floating point number.
 #[lisp_fn]
-fn floatp(object: LispObject) -> LispObject {
+pub fn floatp(object: LispObject) -> LispObject {
     LispObject::from_bool(object.is_float())
 }
 
 /// Return t if OBJECT is an integer.
 #[lisp_fn]
-fn integerp(object: LispObject) -> LispObject {
+pub fn integerp(object: LispObject) -> LispObject {
     LispObject::from_bool(object.is_integer())
 }
 
 /// Return t if OBJECT is an integer or a marker (editor pointer).
 #[lisp_fn]
-fn integer_or_marker_p(object: LispObject) -> LispObject {
+pub fn integer_or_marker_p(object: LispObject) -> LispObject {
     LispObject::from_bool(object.is_marker() || object.is_integer())
 }
 
 /// Return t if OBJECT is a non-negative integer.
 #[lisp_fn]
-fn natnump(object: LispObject) -> LispObject {
+pub fn natnump(object: LispObject) -> LispObject {
     LispObject::from_bool(object.is_natnum())
 }
 
 /// Return t if OBJECT is a number (floating point or integer).
 #[lisp_fn]
-fn numberp(object: LispObject) -> LispObject {
+pub fn numberp(object: LispObject) -> LispObject {
     LispObject::from_bool(object.is_number())
 }
 
 /// Return t if OBJECT is a number or a marker (editor pointer).
 #[lisp_fn]
-fn number_or_marker_p(object: LispObject) -> LispObject {
+pub fn number_or_marker_p(object: LispObject) -> LispObject {
     LispObject::from_bool(object.is_number() || object.is_marker())
 }
 
@@ -62,7 +62,7 @@ fn number_or_marker_p(object: LispObject) -> LispObject {
 ///
 /// See Info node `(elisp)Random Numbers' for more details.
 #[lisp_fn(min = "0")]
-fn random(limit: LispObject) -> LispObject {
+pub fn random(limit: LispObject) -> LispObject {
     let mut rng = RNG.lock().unwrap();
     if limit.is_t() {
         *rng = StdRng::new().unwrap();

--- a/rust_src/src/obarray.rs
+++ b/rust_src/src/obarray.rs
@@ -123,7 +123,7 @@ pub extern "C" fn intern_1(s: *const libc::c_char, len: libc::ptrdiff_t) -> Lisp
 /// A second optional argument specifies the obarray to use;
 /// it defaults to the value of `obarray'.
 #[lisp_fn(min = "1")]
-fn intern_soft(name: LispObject, obarray: LispObject) -> LispObject {
+pub fn intern_soft(name: LispObject, obarray: LispObject) -> LispObject {
     let tem = if obarray.is_nil() {
         LispObarrayRef::constant_obarray().lookup(name)
     } else {
@@ -142,7 +142,7 @@ fn intern_soft(name: LispObject, obarray: LispObject) -> LispObject {
 /// A second optional argument specifies the obarray to use;
 /// it defaults to the value of `obarray'.
 #[lisp_fn(min = "1")]
-fn intern(string: LispObject, obarray: LispObject) -> LispObject {
+pub fn intern(string: LispObject, obarray: LispObject) -> LispObject {
     if obarray.is_nil() {
         LispObarrayRef::constant_obarray().intern(string)
     } else {

--- a/rust_src/src/objects.rs
+++ b/rust_src/src/objects.rs
@@ -9,20 +9,20 @@ use lisp::defsubr;
 
 /// Return t if OBJECT is nil, and return nil otherwise.
 #[lisp_fn]
-fn null(object: LispObject) -> LispObject {
+pub fn null(object: LispObject) -> LispObject {
     LispObject::from_bool(object.is_nil())
 }
 
 /// Return t if the two args are the same Lisp object.
 #[lisp_fn]
-fn eq(obj1: LispObject, obj2: LispObject) -> LispObject {
+pub fn eq(obj1: LispObject, obj2: LispObject) -> LispObject {
     LispObject::from_bool(obj1.eq(obj2))
 }
 
 /// Return t if the two args are the same Lisp object.
 /// Floating-point numbers of equal value are `eql', but they may not be `eq'.
 #[lisp_fn]
-fn eql(obj1: LispObject, obj2: LispObject) -> LispObject {
+pub fn eql(obj1: LispObject, obj2: LispObject) -> LispObject {
     LispObject::from_bool(obj1.eql(obj2))
 }
 
@@ -34,7 +34,7 @@ fn eql(obj1: LispObject, obj2: LispObject) -> LispObject {
 ///  (Use `=' if you want integers and floats to be able to be equal.)
 /// Symbols must match exactly.
 #[lisp_fn]
-fn equal(o1: LispObject, o2: LispObject) -> LispObject {
+pub fn equal(o1: LispObject, o2: LispObject) -> LispObject {
     LispObject::from_bool(o1.equal(o2))
 }
 
@@ -42,7 +42,7 @@ fn equal(o1: LispObject, o2: LispObject) -> LispObject {
 /// This is like `equal' except that it compares the text properties
 /// of strings.  (`equal' ignores text properties.)
 #[lisp_fn]
-fn equal_including_properties(o1: LispObject, o2: LispObject) -> LispObject {
+pub fn equal_including_properties(o1: LispObject, o2: LispObject) -> LispObject {
     let res = unsafe {
         internal_equal(
             o1.to_raw(),
@@ -57,7 +57,7 @@ fn equal_including_properties(o1: LispObject, o2: LispObject) -> LispObject {
 
 /// Return the argument unchanged.
 #[lisp_fn]
-fn identity(arg: LispObject) -> LispObject {
+pub fn identity(arg: LispObject) -> LispObject {
     arg
 }
 

--- a/rust_src/src/process.rs
+++ b/rust_src/src/process.rs
@@ -80,7 +80,7 @@ pub fn processp(object: LispObject) -> LispObject {
 
 /// Return the process named NAME, or nil if there is none.
 #[lisp_fn]
-fn get_process(name: LispObject) -> LispObject {
+pub fn get_process(name: LispObject) -> LispObject {
     if name.is_process() {
         name
     } else {
@@ -97,14 +97,14 @@ fn get_process(name: LispObject) -> LispObject {
 /// This is the name of the program invoked in PROCESS,
 /// possibly modified to make it unique among process names.
 #[lisp_fn]
-fn process_name(process: LispObject) -> LispObject {
+pub fn process_name(process: LispObject) -> LispObject {
     process.as_process_or_error().name()
 }
 
 /// Return the buffer PROCESS is associated with.
 /// The default process filter inserts output from PROCESS into this buffer.
 #[lisp_fn]
-fn process_buffer(process: LispObject) -> LispObject {
+pub fn process_buffer(process: LispObject) -> LispObject {
     process.as_process_or_error().buffer()
 }
 
@@ -112,7 +112,7 @@ fn process_buffer(process: LispObject) -> LispObject {
 /// This is the pid of the external process which PROCESS uses or talks to.
 /// For a network, serial, and pipe connections, this value is nil.
 #[lisp_fn]
-fn process_id(process: LispObject) -> LispObject {
+pub fn process_id(process: LispObject) -> LispObject {
     let pid = unsafe { pget_pid(process.as_process_or_error().as_ptr()) };
     if pid != 0 {
         LispObject::from_fixnum(pid as EmacsInt)
@@ -256,7 +256,7 @@ pub fn process_status(process: LispObject) -> LispObject {
 /// Set buffer associated with PROCESS to BUFFER (a buffer, or nil).
 /// Return BUFFER.
 #[lisp_fn]
-fn set_process_buffer(process: LispObject, buffer: LispObject) -> LispObject {
+pub fn set_process_buffer(process: LispObject, buffer: LispObject) -> LispObject {
     let mut p_ref = process.as_process_or_error();
     if buffer.is_not_nil() {
         buffer.as_buffer_or_error();
@@ -287,7 +287,7 @@ fn set_process_buffer(process: LispObject, buffer: LispObject) -> LispObject {
 /// If PROCESS is a non-blocking network process that hasn't been fully
 /// set up yet, this function will block until socket setup has completed.
 #[lisp_fn]
-fn process_send_string(process: LispObject, string: LispObject) -> LispObject {
+pub fn process_send_string(process: LispObject, string: LispObject) -> LispObject {
     let s = string.as_string_or_error();
     unsafe {
         send_process(

--- a/rust_src/src/strings.rs
+++ b/rust_src/src/strings.rs
@@ -24,7 +24,7 @@ pub fn stringp(object: LispObject) -> LispObject {
 /// Return the number of bytes in STRING.
 /// If STRING is multibyte, this may be greater than the length of STRING.
 #[lisp_fn]
-fn string_bytes(string: LispObject) -> LispObject {
+pub fn string_bytes(string: LispObject) -> LispObject {
     let string = string.as_string_or_error();
     LispObject::from_natnum(string.len_bytes() as EmacsInt)
 }
@@ -57,7 +57,7 @@ pub fn string_equal(s1: LispObject, s2: LispObject) -> LispObject {
 /// If you're not sure, whether to use `string-as-multibyte' or
 /// `string-to-multibyte', use `string-to-multibyte'.
 #[lisp_fn]
-fn string_as_multibyte(string: LispObject) -> LispObject {
+pub fn string_as_multibyte(string: LispObject) -> LispObject {
     let s = string.as_string_or_error();
     if s.is_multibyte() {
         return string;
@@ -92,7 +92,7 @@ fn string_as_multibyte(string: LispObject) -> LispObject {
 /// utf-8 sequence to an eight-bit character, not just bytes that don't form a
 /// correct sequence.
 #[lisp_fn]
-fn string_to_multibyte(string: LispObject) -> LispObject {
+pub fn string_to_multibyte(string: LispObject) -> LispObject {
     let _ = string.as_string_or_error();
     unsafe { LispObject::from(c_string_to_multibyte(string.to_raw())) }
 }
@@ -104,7 +104,7 @@ fn string_to_multibyte(string: LispObject) -> LispObject {
 /// If STRING contains a non-ASCII, non-`eight-bit' character,
 /// an error is signaled.
 #[lisp_fn]
-fn string_to_unibyte(string: LispObject) -> LispObject {
+pub fn string_to_unibyte(string: LispObject) -> LispObject {
     let lispstr = string.as_string_or_error();
     if lispstr.is_multibyte() {
         let size = lispstr.len_bytes();
@@ -126,7 +126,7 @@ fn string_to_unibyte(string: LispObject) -> LispObject {
 /// Return non-nil if STRING1 is less than STRING2 in lexicographic order.
 /// Case is significant.
 #[lisp_fn]
-fn string_lessp(string1: LispObject, string2: LispObject) -> LispObject {
+pub fn string_lessp(string1: LispObject, string2: LispObject) -> LispObject {
     let s1 = LispObject::symbol_or_string_as_string(string1);
     let s2 = LispObject::symbol_or_string_as_string(string2);
 
@@ -136,7 +136,7 @@ fn string_lessp(string1: LispObject, string2: LispObject) -> LispObject {
 /// Return t if OBJECT is a multibyte string.
 /// Return nil if OBJECT is either a unibyte string, or not a string.
 #[lisp_fn]
-fn multibyte_string_p(object: LispObject) -> LispObject {
+pub fn multibyte_string_p(object: LispObject) -> LispObject {
     LispObject::from_bool(object.as_string().map_or(false, |s| s.is_multibyte()))
 }
 

--- a/rust_src/src/symbols.rs
+++ b/rust_src/src/symbols.rs
@@ -87,7 +87,7 @@ pub unsafe extern "C" fn indirect_variable(symbol: *mut Lisp_Symbol) -> *mut Lis
 
 /// Return t if OBJECT is a symbol.
 #[lisp_fn]
-fn symbolp(object: LispObject) -> LispObject {
+pub fn symbolp(object: LispObject) -> LispObject {
     LispObject::from_bool(object.is_symbol())
 }
 
@@ -112,19 +112,19 @@ pub fn fboundp(symbol: LispObject) -> LispObject {
 
 /// Return SYMBOL's function definition, or nil if that is void.
 #[lisp_fn]
-fn symbol_function(symbol: LispObject) -> LispObject {
+pub fn symbol_function(symbol: LispObject) -> LispObject {
     symbol.as_symbol_or_error().get_function()
 }
 
 /// Return SYMBOL's property list.
 #[lisp_fn]
-fn symbol_plist(symbol: LispObject) -> LispObject {
+pub fn symbol_plist(symbol: LispObject) -> LispObject {
     symbol.as_symbol_or_error().get_plist()
 }
 
 /// Set SYMBOL's property list to NEWPLIST, and return NEWPLIST.
 #[lisp_fn]
-fn setplist(symbol: LispObject, newplist: LispObject) -> LispObject {
+pub fn setplist(symbol: LispObject, newplist: LispObject) -> LispObject {
     symbol.as_symbol_or_error().set_plist(newplist);
     newplist
 }
@@ -132,7 +132,7 @@ fn setplist(symbol: LispObject, newplist: LispObject) -> LispObject {
 /// Make SYMBOL's function definition be nil.
 /// Return SYMBOL.
 #[lisp_fn]
-fn fmakunbound(symbol: LispObject) -> LispObject {
+pub fn fmakunbound(symbol: LispObject) -> LispObject {
     let mut sym = symbol.as_symbol_or_error();
     if symbol.is_nil() || symbol.is_t() {
         xsignal!(Qsetting_constant, symbol);
@@ -149,7 +149,7 @@ fn fmakunbound(symbol: LispObject) -> LispObject {
 /// This means that it is a symbol with a print name beginning with `:'
 /// interned in the initial obarray.
 #[lisp_fn]
-fn keywordp(object: LispObject) -> LispObject {
+pub fn keywordp(object: LispObject) -> LispObject {
     if let Some(sym) = object.as_symbol() {
         let name = sym.symbol_name().as_string_or_error();
         LispObject::from_bool(name.byte_at(0) == b':' && sym.is_interned_in_initial_obarray())
@@ -166,7 +166,7 @@ fn keywordp(object: LispObject) -> LispObject {
 /// If OBJECT is not a symbol, just return it.  If there is a loop in the
 /// chain of aliases, signal a `cyclic-variable-indirection' error.
 #[lisp_fn(name = "indirect-variable", c_name = "indirect_variable")]
-fn indirect_variable_lisp(object: LispObject) -> LispObject {
+pub fn indirect_variable_lisp(object: LispObject) -> LispObject {
     if let Some(symbol) = object.as_symbol() {
         let val = symbol.get_indirect_variable();
         val.as_lisp_obj()
@@ -178,7 +178,7 @@ fn indirect_variable_lisp(object: LispObject) -> LispObject {
 /// Make SYMBOL's value be void.
 /// Return SYMBOL.
 #[lisp_fn]
-fn makunbound(symbol: LispObject) -> LispObject {
+pub fn makunbound(symbol: LispObject) -> LispObject {
     let sym = symbol.as_symbol_or_error();
     if sym.is_constant() {
         xsignal!(Qsetting_constant, symbol);

--- a/rust_src/src/vectors.rs
+++ b/rust_src/src/vectors.rs
@@ -218,7 +218,7 @@ pub fn elt(sequence: LispObject, n: LispObject) -> LispObject {
 /// SEQ, and should return non-nil if the first element should sort before
 /// the second.
 #[lisp_fn]
-fn sort(seq: LispObject, predicate: LispObject) -> LispObject {
+pub fn sort(seq: LispObject, predicate: LispObject) -> LispObject {
     if seq.is_cons() {
         sort_list(seq, predicate)
     } else if let Some(vec) = seq.as_vectorlike().and_then(|v| v.as_vector()) {

--- a/rust_src/src/windows.rs
+++ b/rust_src/src/windows.rs
@@ -186,7 +186,7 @@ fn window_valid_or_selected(window: LispObject) -> LispWindowRef {
 
 /// Return t if OBJECT is a window and nil otherwise.
 #[lisp_fn]
-fn windowp(object: LispObject) -> LispObject {
+pub fn windowp(object: LispObject) -> LispObject {
     LispObject::from_bool(object.is_window())
 }
 


### PR DESCRIPTION
Enforce this by in the build process.
Also, remove export files if there are no longer exported functions.
This prevents odd compilation issues when the sole exported function
in a module has its #[lisp_fn] macro commented out to help debug a
compilation error.