### PR TITLE
Refresh base64 support

### DIFF
--- a/rust_src/Cargo.lock
+++ b/rust_src/Cargo.lock
@@ -7,7 +7,7 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -179,7 +179,7 @@ name = "remacs"
 version = "0.1.0"
 dependencies = [
  "alloc_unexecmacosx 0.1.0",
- "base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "md5 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -292,7 +292,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
-"checksum base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "96434f987501f0ed4eb336a411e0631ecd1afa11574fe148587adc4ff96143c9"
+"checksum base64 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c4a342b450b268e1be8036311e2c613d7f8a7ed31214dff1cc3b60852a3168d"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum byte-tools 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0919189ba800c7ffe8778278116b7e0de3905ab81c72abb69c85cbfef7991279"
 "checksum byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff81738b726f5d099632ceaffe7fb65b90212e8dce59d518729e7e8634032d3d"

--- a/rust_src/Cargo.toml
+++ b/rust_src/Cargo.toml
@@ -16,7 +16,7 @@ remacs-macros = { version = "0.1.0", path = "remacs-macros" }
 libc = "0.2"
 rand = "0.3.15"
 md5 = "0.3.5"
-base64 = "0.6.0"
+base64 = "0.8.0"
 sha1 = "0.2.0"
 sha2 = "0.4.2"
 mock_derive = "0.7.0"

--- a/rust_src/src/base64.rs
+++ b/rust_src/src/base64.rs
@@ -23,7 +23,13 @@ pub extern "C" fn base64_encode_1(
     multibyte: bool,
 ) -> ptrdiff_t {
     let config = if line_break {
-        base64_crate::MIME
+        // base64_crate::MIME, but with LF instead of CRLF
+        base64_crate::Config::new(
+            base64_crate::CharacterSet::Standard,
+            true, // pad
+            true, // strip whitespace
+            base64_crate::LineWrap::Wrap(76, base64_crate::LineEnding::LF),
+        )
     } else {
         base64_crate::STANDARD
     };

--- a/src/fns.c
+++ b/src/fns.c
@@ -2130,7 +2130,7 @@ The data read from the system are decoded using `locale-coding-system'.  */)
 
 #define MIME_LINE_LENGTH 76
 
-ptrdiff_t base64_encode_1 (const char *, char *, ptrdiff_t, bool, bool);
+ptrdiff_t base64_encode_1 (const char *, ptrdiff_t, char *, ptrdiff_t, bool, bool);
 ptrdiff_t base64_decode_1 (const char *, char *, ptrdiff_t, bool,
 				  ptrdiff_t *);
 
@@ -2162,8 +2162,9 @@ into shorter lines.  */)
   allength += allength / MIME_LINE_LENGTH + 1 + 6;
 
   encoded = SAFE_ALLOCA (allength);
-  encoded_length = base64_encode_1 ((char *) BYTE_POS_ADDR (ibeg),
-				    encoded, length, NILP (no_line_break),
+  encoded_length = base64_encode_1 ((char *) BYTE_POS_ADDR (ibeg), length,
+                                    encoded, allength,
+                                    NILP (no_line_break),
 				    !NILP (BVAR (current_buffer, enable_multibyte_characters)));
   if (encoded_length > allength)
     emacs_abort ();


### PR DESCRIPTION
I would like to move decode to no allocation as well. However, the
only mechanism upstream uses a Vector which cannot be traded with C.
Once I get information about decode we can merge this.