### PR TITLE
Porting clear_string to Rust.

### DIFF
--- a/rust_src/remacs-sys/lib.rs
+++ b/rust_src/remacs-sys/lib.rs
@@ -1001,6 +1001,7 @@ extern "C" {
     pub static selected_window: Lisp_Object;
     pub static minibuf_selected_window: Lisp_Object;
     pub static selected_frame: Lisp_Object;
+    pub static empty_unibyte_string: Lisp_Object;
 
     pub fn Faref(array: Lisp_Object, idx: Lisp_Object) -> Lisp_Object;
     pub fn Fcons(car: Lisp_Object, cdr: Lisp_Object) -> Lisp_Object;

--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -932,11 +932,7 @@ impl LispObject {
 
     #[inline]
     pub fn as_string_or_error(self) -> LispStringRef {
-        if let Some(string) = self.as_string() {
-            string
-        } else {
-            wrong_type!(Qstringp, self)
-        }
+        self.as_string().unwrap_or_else(|| wrong_type!(Qstringp, self))
     }
 
     #[inline]

--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -932,7 +932,8 @@ impl LispObject {
 
     #[inline]
     pub fn as_string_or_error(self) -> LispStringRef {
-        self.as_string().unwrap_or_else(|| wrong_type!(Qstringp, self))
+        self.as_string()
+            .unwrap_or_else(|| wrong_type!(Qstringp, self))
     }
 
     #[inline]

--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -924,9 +924,7 @@ impl LispObject {
     #[inline]
     pub fn as_string(self) -> Option<LispStringRef> {
         if self.is_string() {
-            Some(LispStringRef::new(
-                unsafe { mem::transmute(self.get_untaggedptr()) },
-            ))
+            Some(unsafe { self.as_string_unchecked() })
         } else {
             None
         }
@@ -934,11 +932,16 @@ impl LispObject {
 
     #[inline]
     pub fn as_string_or_error(self) -> LispStringRef {
-        if self.is_string() {
-            LispStringRef::new(unsafe { mem::transmute(self.get_untaggedptr()) })
+        if let Some(string) = self.as_string() {
+            string
         } else {
             wrong_type!(Qstringp, self)
         }
+    }
+
+    #[inline]
+    pub unsafe fn as_string_unchecked(self) -> LispStringRef {
+        LispStringRef::new(mem::transmute(self.get_untaggedptr()))
     }
 }
 

--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -23,7 +23,7 @@ use remacs_sys::{Qarrayp, Qbufferp, Qchar_table_p, Qcharacterp, Qconsp, Qfloatp,
                  Qnumber_or_marker_p, Qnumberp, Qoverlayp, Qplistp, Qprocessp, Qstringp, Qsymbolp,
                  Qt, Qthreadp, Qunbound, Qwholenump, Qwindow_live_p, Qwindow_valid_p, Qwindowp};
 
-use remacs_sys::{internal_equal, lispsym, make_float, misc_get_ty};
+use remacs_sys::{empty_unibyte_string, internal_equal, lispsym, make_float, misc_get_ty};
 
 use buffers::{LispBufferRef, LispOverlayRef};
 use chartable::LispCharTableRef;
@@ -1016,6 +1016,23 @@ impl LispObject {
     #[inline]
     pub unsafe fn as_string_unchecked(self) -> LispStringRef {
         LispStringRef::new(mem::transmute(self.get_untaggedptr()))
+    }
+
+    #[inline]
+    pub fn empty_unibyte_string() -> LispObject {
+        LispObject::from(unsafe { empty_unibyte_string })
+    }
+
+    /// Replaces STRING_SET_UNIBYTE in C. If your string has size 0,
+    /// it will replace your string variable with 'empty_unibyte_string'.
+    #[inline]
+    pub fn set_string_unibyte(lstring: &mut LispObject) {
+        let mut string = lstring.as_string_or_error();
+        if string.size == 0 {
+            *lstring = Self::empty_unibyte_string();
+        } else {
+            string.size_byte = -1;
+        }
     }
 }
 

--- a/rust_src/src/multibyte.rs
+++ b/rust_src/src/multibyte.rs
@@ -124,8 +124,9 @@ impl LispStringRef {
     /// This function does not allocate. It will not change the size of the data allocation.
     /// It will only set the 'size' variable of the string, if it is safe to do so.
     /// Replaces STRING_SET_CHARS from C.
-    pub fn set_num_chars(mut self, newsize: isize) {
-        assert!(if self.is_multibyte() {
+    #[inline]
+    pub unsafe fn set_num_chars(mut self, newsize: isize) {
+        debug_assert!(if self.is_multibyte() {
             0 <= newsize && newsize == self.len_bytes()
         } else {
             newsize == self.len_chars()

--- a/rust_src/src/multibyte.rs
+++ b/rust_src/src/multibyte.rs
@@ -125,11 +125,11 @@ impl LispStringRef {
     /// It will only set the 'size' variable of the string, if it is safe to do so.
     /// Replaces STRING_SET_CHARS from C.
     pub fn set_num_chars(mut self, newsize: isize) {
-        if self.is_multibyte() {
-            assert!(0 <= newsize && newsize == self.len_bytes());
+        assert!(if self.is_multibyte() {
+            0 <= newsize && newsize == self.len_bytes()
         } else {
-            assert!(newsize == self.len_chars());
-        }
+            newsize == self.len_chars()
+        });
 
         self.size = newsize;
     }

--- a/rust_src/src/multibyte.rs
+++ b/rust_src/src/multibyte.rs
@@ -111,16 +111,6 @@ impl LispStringRef {
         unsafe { *self.const_data_ptr().offset(index) }
     }
 
-    /// (Somewhat) Replaces STRING_SET_UNIBYTE in C. That macro has the behavior that
-    /// if your string has size 0, it will replace your string variable with
-    /// 'empty_unibyte_string'. This function does not have that side-effect.
-    #[inline]
-    pub fn set_unibyte(mut self) {
-        if self.size != 0 {
-            self.size_byte = -1;
-        }
-    }
-
     /// This function does not allocate. It will not change the size of the data allocation.
     /// It will only set the 'size' variable of the string, if it is safe to do so.
     /// Replaces STRING_SET_CHARS from C.

--- a/rust_src/src/strings.rs
+++ b/rust_src/src/strings.rs
@@ -143,7 +143,7 @@ pub fn multibyte_string_p(object: LispObject) -> LispObject {
 /// Clear the contents of STRING.
 /// This makes STRING unibyte and may change its length.
 #[lisp_fn]
-fn clear_string(string: LispObject) -> LispObject {
+pub fn clear_string(string: LispObject) -> LispObject {
     let lisp_string = string.as_string_or_error();
     lisp_string.clear_data();
     unsafe {

--- a/rust_src/src/strings.rs
+++ b/rust_src/src/strings.rs
@@ -146,7 +146,7 @@ fn multibyte_string_p(object: LispObject) -> LispObject {
 fn clear_string(string: LispObject) -> LispObject {
     let lisp_string = string.as_string_or_error();
     lisp_string.clear_data();
-    lisp_string.set_num_chars(lisp_string.len_bytes());
+    unsafe { lisp_string.set_num_chars(lisp_string.len_bytes()); }
     lisp_string.set_unibyte();
 
     LispObject::constant_nil()

--- a/rust_src/src/strings.rs
+++ b/rust_src/src/strings.rs
@@ -143,13 +143,13 @@ pub fn multibyte_string_p(object: LispObject) -> LispObject {
 /// Clear the contents of STRING.
 /// This makes STRING unibyte and may change its length.
 #[lisp_fn]
-pub fn clear_string(string: LispObject) -> LispObject {
+pub fn clear_string(mut string: LispObject) -> LispObject {
     let lisp_string = string.as_string_or_error();
     lisp_string.clear_data();
     unsafe {
         lisp_string.set_num_chars(lisp_string.len_bytes());
     }
-    lisp_string.set_unibyte();
+    LispObject::set_string_unibyte(&mut string);
 
     LispObject::constant_nil()
 }

--- a/rust_src/src/strings.rs
+++ b/rust_src/src/strings.rs
@@ -192,27 +192,3 @@ fn test_stringlessp() {
     assert_t!(string_lessp(string, string2));
     assert_nil!(string_lessp(string2, string));
 }
-
-#[test]
-fn clear_string_unibyte() {
-    let string = mock_unibyte_string!("Hello World");
-
-    clear_string(string);
-    assert_nil!(multibyte_string_p(string));
-    assert!(string_bytes(string) == LispObject::from_natnum(11));
-
-    let empty = vec![0; 11];
-    assert!(string.as_string_or_error().as_slice() == empty.as_slice());
-}
-
-#[test]
-fn clear_string_multibyte() {
-    let string = mock_multibyte_string!("Hello World");
-
-    clear_string(string);
-    assert_nil!(multibyte_string_p(string));
-    assert!(string_bytes(string) == LispObject::from_natnum(11));
-
-    let empty = vec![0; 11];
-    assert!(string.as_string_or_error().as_slice() == empty.as_slice());
-}

--- a/rust_src/src/strings.rs
+++ b/rust_src/src/strings.rs
@@ -146,7 +146,9 @@ fn multibyte_string_p(object: LispObject) -> LispObject {
 fn clear_string(string: LispObject) -> LispObject {
     let lisp_string = string.as_string_or_error();
     lisp_string.clear_data();
-    unsafe { lisp_string.set_num_chars(lisp_string.len_bytes()); }
+    unsafe {
+        lisp_string.set_num_chars(lisp_string.len_bytes());
+    }
     lisp_string.set_unibyte();
 
     LispObject::constant_nil()

--- a/src/fns.c
+++ b/src/fns.c
@@ -1575,20 +1575,6 @@ ARRAY is a vector, string, char-table, or bool-vector.  */)
   return array;
 }
 
-DEFUN ("clear-string", Fclear_string, Sclear_string,
-       1, 1, 0,
-       doc: /* Clear the contents of STRING.
-This makes STRING unibyte and may change its length.  */)
-  (Lisp_Object string)
-{
-  ptrdiff_t len;
-  CHECK_STRING (string);
-  len = SBYTES (string);
-  memset (SDATA (string), 0, len);
-  STRING_SET_CHARS (string, len);
-  STRING_SET_UNIBYTE (string);
-  return Qnil;
-}
 
 /* ARGSUSED */
 Lisp_Object
@@ -3667,7 +3653,6 @@ this variable.  */);
   defsubr (&Snreverse);
   defsubr (&Sreverse);
   defsubr (&Sfillarray);
-  defsubr (&Sclear_string);
   defsubr (&Snconc);
   defsubr (&Smapcar);
   defsubr (&Smapc);


### PR DESCRIPTION
Includes a minor refactor of the as_string_* APIs, to make them a little more DRY. Adds new functions to LispStringRef, to replace some C macros used in clear_string. 