### PR TITLE
[WIP] Add rollup helpers

### DIFF
--- a/rust_src/admin/rollups/both-modified
+++ b/rust_src/admin/rollups/both-modified
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+files=$(git status | grep 'both modified:' | cut -f2 -d:)
+
+if [ ! -z "$files" ]; then
+    echo $commit
+    git show $commit
+
+    for i in $files; do
+        emacsclient "$i"
+    done
+fi
+
+git cherry-pick --continue

--- a/rust_src/admin/rollups/build-and-test
+++ b/rust_src/admin/rollups/build-and-test
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+make -j4 && make check

--- a/rust_src/admin/rollups/cleanup
+++ b/rust_src/admin/rollups/cleanup
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+(cd rust_src && cargo clean)
+make clean

--- a/rust_src/admin/rollups/deleted-by-us
+++ b/rust_src/admin/rollups/deleted-by-us
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+(git status | grep 'deleted by us:' | cut -f2 -d: | xargs git rm) && git cherry-pick --continue

--- a/rust_src/admin/rollups/rollup
+++ b/rust_src/admin/rollups/rollup
@@ -1,0 +1,120 @@
+#!/bin/bash
+
+# Author: Thomas Berezansky <tsbere@mvlc.org>
+# Author: Jason Stephenson <jason@sigio.com>
+#
+# Feel free to use and to share this script in anyway you like.
+
+# This script is intended as a shortcut for the git cherry-pick
+# command when you have several commits that you want to cherry-pick
+# into your local branch from another branch.  It often results in a
+# cleaner commit history than simply doing a git merge.
+
+# It can be run in two ways and either method takes an optional
+# parameter, -s.  If provided the -s parameter will add your git
+# signature to each incoming commit as they are cherry-picked.  This
+# is a handy way to sign off on someone else's commits in bulk when
+# your project has a policy of requiring sign offs on anything going
+# into the main git repository.  If you supply the -s parameter, it
+# should come before any branch or commit arguments on the command
+# line.
+
+# The simpler way to run this script is to simply supply the branch
+# name whose commits you want to cherry-pick into your current branch.
+# For instance, if you want to cherry-pick the commits from branch
+# `bar' of remote `foo' that do not exist in your current branch you
+# would use the following:
+#
+# rollup foo/bar
+#
+# or
+#
+# rollup -s foo/bar
+#
+# to include your sign off.
+
+# The second way to use this script is to specify two branches: the
+# base and the feature.  In this case the base is the branch, other
+# than the current branch, to compare with the feature branch.  This
+# mode will use git cherry to pull out those commit in feature branch
+# that do not exist in base.  This is useful if you're trying to merge
+# commits into a branch that does not share a common history with
+# feature branch.  Let's say that our branch, local, is based on a
+# fork of the master at some point in the past, and feature branch is
+# based on the current master branch.  We want to pull the new commits
+# from feature into our local branch without getting the commits
+# common to the master and feature branch that are not in our local
+# branch.  We do that by running this command in a checkout of our
+# local branch:
+#
+# rollup master feature
+
+# Should you run into a conflict while cherry-picking, you would
+# resolve in the usual way.  Should you still have outstanding commits
+# left to pull in, you may pickup where you left off by using the
+# special argument `--continue.'  Even if you believe that your
+# conflict occurred in the final cherry-pick, it won't hurt to use the
+# --continue argument as a precaution against missing any commits.
+# The script keeps track of the commits that have been cherry-picked
+# as it runs, and so it would be safe to run --continue when there are
+# none left.
+
+if [ "$1" == "-s" ]; then
+    SIGN="-s"
+    shift
+else
+    SIGN=""
+fi
+
+GIT_TOP_LEVEL=$(git rev-parse --show-toplevel)
+HELPERS_DIR=$GIT_TOP_LEVEL/rust_src/admin/rollups
+
+START=${1:-'FAIL'}
+END=${2:-'CHERRY'}
+if [ "$START" == 'FAIL' ]; then
+    echo "NEED SOURCE BRANCH"
+    exit 1;
+fi
+if [ "$START" == '--continue' ]; then
+    COMMITS=`cat ${GIT_TOP_LEVEL}/.git-cherrypick-resume-commits`
+    SIGN=`cat ${GIT_TOP_LEVEL}/.git-cherrypick-resume-sign`
+else
+    if [ "$END" == 'CHERRY' ]; then
+        END=$START
+        START='HEAD'
+    fi
+    COMMITS=`git cherry $START $END | grep ^+ | cut -f2 -d' '`
+fi
+if [ "$SIGN" != "-s" ]; then
+    SIGN=''
+fi
+for commit in $COMMITS
+do
+    COMMITS=`echo $COMMITS | sed -e "s/.*$commit\s*//"`
+    git cherry-pick --keep-redundant-commits -Xpatience $SIGN $commit \
+        && $HELPERS_DIR/build-and-test
+    if [ $? -ne 0 ]; then
+        if git status | grep 'deleted by us'; then
+            $HELPERS_DIR/deleted-by-us
+        else
+            false  # still a failure....
+        fi
+    fi
+    if [ $? -ne 0 ]; then
+       $HELPERS_DIR/both-modified
+    fi
+    if [ $? -ne 0 ]; then
+        echo -n "Want to allow empty? [YN] "
+        read choice
+        if [ "$choice" = "y" -o "$choice" = "Y" ]; then
+            git commit --allow-empty
+        else
+            echo $COMMITS > ${GIT_TOP_LEVEL}/.git-cherrypick-resume-commits
+            echo "$SIGN" > ${GIT_TOP_LEVEL}/.git-cherrypick-resume-sign
+            exit 1
+        fi
+    fi
+    $HELPERS_DIR/cleanup
+done
+rm -f ${GIT_TOP_LEVEL}/.git-cherrypick-resume-commits ${GIT_TOP_LEVEL}/.git-cherrypick-resume-sign
+exit 0


### PR DESCRIPTION
My goal was to make it easier for people to do small rollups. This looks at a branch, and uses git cherry-pick to get a list of needed commits then applies them. But it tests the tree between each commit. So we know where our code breaks or where the upstream missed something.