### PR TITLE
Refactor as_obj

### DIFF
--- a/rust_src/src/buffers.rs
+++ b/rust_src/src/buffers.rs
@@ -1,11 +1,11 @@
 //! Functions operating on buffers.
 
-use libc::{c_int, c_uchar, c_void, ptrdiff_t};
+use libc::{c_int, c_uchar, ptrdiff_t};
 use std::{mem, ptr};
 
 use remacs_macros::lisp_fn;
-use remacs_sys::{EmacsInt, Lisp_Buffer, Lisp_Object, Lisp_Overlay, Lisp_Type, Vbuffer_alist};
-use remacs_sys::{make_lisp_ptr, nsberror, set_buffer_internal};
+use remacs_sys::{EmacsInt, Lisp_Buffer, Lisp_Object, Lisp_Overlay, Vbuffer_alist};
+use remacs_sys::{nsberror, set_buffer_internal};
 
 use lisp::{ExternalPtr, LispObject};
 use lisp::defsubr;
@@ -232,12 +232,7 @@ pub fn get_buffer(buffer_or_name: LispObject) -> LispObject {
 #[lisp_fn]
 pub fn current_buffer() -> LispObject {
     let buffer_ref = ThreadState::current_buffer();
-    unsafe {
-        LispObject::from(make_lisp_ptr(
-            buffer_ref.as_ptr() as *mut c_void,
-            Lisp_Type::Lisp_Vectorlike,
-        ))
-    }
+    buffer_ref.as_obj()
 }
 
 /// Return name of file BUFFER is visiting, or nil if none.

--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -22,8 +22,7 @@ use remacs_sys::{Qarrayp, Qbufferp, Qchar_table_p, Qcharacterp, Qconsp, Qfloatp,
                  Qframep, Qhash_table_p, Qinteger_or_marker_p, Qintegerp, Qlistp, Qmarkerp, Qnil,
                  Qnumber_or_marker_p, Qnumberp, Qoverlayp, Qplistp, Qprocessp, Qstringp, Qsymbolp,
                  Qt, Qthreadp, Qunbound, Qwholenump, Qwindow_live_p, Qwindow_valid_p, Qwindowp};
-
-use remacs_sys::{internal_equal, lispsym, make_float, misc_get_ty};
+use remacs_sys::{internal_equal, lispsym, make_float, make_lisp_ptr, misc_get_ty};
 
 use buffers::{LispBufferRef, LispOverlayRef};
 use chartable::LispCharTableRef;
@@ -209,16 +208,29 @@ impl<T> Clone for ExternalPtr<T> {
 impl<T> Copy for ExternalPtr<T> {}
 
 impl<T> ExternalPtr<T> {
+    #[inline]
     pub fn new(p: *mut T) -> ExternalPtr<T> {
         ExternalPtr(p)
     }
 
+    #[inline]
     pub fn as_ptr(&self) -> *const T {
         self.0
     }
 
+    #[inline]
     pub fn as_mut(&mut self) -> *mut T {
         self.0
+    }
+
+    #[inline]
+    pub fn as_obj(self) -> LispObject {
+        unsafe {
+            LispObject::from(make_lisp_ptr(
+                self.0 as *mut c_void,
+                Lisp_Type::Lisp_Vectorlike,
+            ))
+        }
     }
 }
 


### PR DESCRIPTION
Add `as_obj` to `ExternPtr` so all instances can be converted into a
`LispObject`.