### PR TITLE
Add explicit linting code.

### DIFF
--- a/rust_src/build.rs
+++ b/rust_src/build.rs
@@ -45,7 +45,7 @@ impl LintMsg {
 }
 
 fn lint_nomangle(line: &str, modname: &str, lineno: i32) -> Result<(), LintMsg> {
-    if !line.starts_with("pub extern \"C\" ") {
+    if !(line.starts_with("pub extern \"C\" ") || line.starts_with("pub unsafe extern \"C\" ")) {
         Err(LintMsg::new(
             modname,
             lineno,

--- a/rust_src/src/buffers.rs
+++ b/rust_src/src/buffers.rs
@@ -113,6 +113,7 @@ impl LispBufferRef {
         LispObject::from(self.mark)
     }
 
+    #[allow(dead_code)]
     #[inline]
     pub fn name(&self) -> LispObject {
         LispObject::from(self.name)

--- a/rust_src/src/data.rs
+++ b/rust_src/src/data.rs
@@ -1,7 +1,7 @@
 //! data helpers
 
 use remacs_macros::lisp_fn;
-use remacs_sys::{Lisp_Misc_Type, Lisp_Object, Lisp_Type, PseudovecType};
+use remacs_sys::{Lisp_Misc_Type, Lisp_Type, PseudovecType};
 use remacs_sys::{Qbool_vector, Qbuffer, Qchar_table, Qcompiled_function, Qcondition_variable,
                  Qcons, Qcyclic_function_indirection, Qfinalizer, Qfloat, Qfont, Qfont_entity,
                  Qfont_object, Qfont_spec, Qframe, Qhash_table, Qinteger, Qmarker,
@@ -20,13 +20,7 @@ use lisp::defsubr;
 ///
 /// This is like `Findirect_function`, except that it doesn't signal an
 /// error if the chain ends up unbound.
-#[no_mangle]
-pub extern "C" fn indirect_function(object: Lisp_Object) -> Lisp_Object {
-    let result = indirect_function_1(LispObject::from(object));
-    result.to_raw()
-}
-
-pub fn indirect_function_1(object: LispObject) -> LispObject {
+pub fn indirect_function(object: LispObject) -> LispObject {
     let mut tortoise = object;
     let mut hare = object;
     loop {
@@ -58,7 +52,7 @@ pub fn indirect_function_lisp(object: LispObject, _noerror: LispObject) -> LispO
     if let Some(symbol) = result.as_symbol() {
         result = symbol.get_function();
         if result.is_symbol() {
-            result = indirect_function_1(result)
+            result = indirect_function(result)
         }
     }
     return result;

--- a/rust_src/src/ffi.rs
+++ b/rust_src/src/ffi.rs
@@ -1,0 +1,55 @@
+//! Module that is used for FFI exports.These calls should NOT be used in Rust directly.
+use remacs_sys::{Lisp_Object, Lisp_Window};
+
+use data;
+use keyboard;
+use lisp::LispObject;
+use lists;
+use math;
+use windows;
+
+#[no_mangle]
+pub extern "C" fn circular_list(obj: Lisp_Object) -> ! {
+    lists::circular_list(LispObject::from(obj))
+}
+
+#[no_mangle]
+pub extern "C" fn merge(l1: Lisp_Object, l2: Lisp_Object, pred: Lisp_Object) -> Lisp_Object {
+    let result = lists::merge(
+        LispObject::from(l1),
+        LispObject::from(l2),
+        LispObject::from(pred),
+    );
+    result.to_raw()
+}
+
+#[no_mangle]
+pub extern "C" fn indirect_function(object: Lisp_Object) -> Lisp_Object {
+    let result = data::indirect_function(LispObject::from(object));
+    result.to_raw()
+}
+
+#[no_mangle]
+pub extern "C" fn arithcompare(
+    obj1: Lisp_Object,
+    obj2: Lisp_Object,
+    comparison: math::ArithComparison,
+) -> Lisp_Object {
+    let result = math::arithcompare(LispObject::from(obj1), LispObject::from(obj2), comparison);
+    result.to_raw()
+}
+
+#[no_mangle]
+pub extern "C" fn lucid_event_type_list_p(event: Lisp_Object) -> bool {
+    keyboard::lucid_event_type_list_p(LispObject::from(event))
+}
+
+#[no_mangle]
+pub extern "C" fn window_wants_mode_line(window: *mut Lisp_Window) -> bool {
+    windows::window_wants_mode_line(windows::LispWindowRef::new(window))
+}
+
+#[no_mangle]
+pub extern "C" fn window_wants_header_line(window: *mut Lisp_Window) -> bool {
+    windows::window_wants_header_line(windows::LispWindowRef::new(window))
+}

--- a/rust_src/src/keyboard.rs
+++ b/rust_src/src/keyboard.rs
@@ -63,8 +63,7 @@ pub fn posn_at_point(pos: LispObject, window: LispObject) -> LispObject {
 /// Return true if EVENT is a list whose elements are all integers or symbols.
 /// Such a list is not valid as an event,
 /// but it can be a Lucid-style event type list.
-#[no_mangle]
-pub extern "C" fn lucid_event_type_list_p(event: LispObject) -> bool {
+pub fn lucid_event_type_list_p(event: LispObject) -> bool {
     if !event.is_cons() {
         return false;
     }

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -50,6 +50,7 @@ mod crypto;
 mod data;
 mod dispnew;
 mod editfns;
+mod ffi;
 mod floatfns;
 mod fns;
 mod fonts;

--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -1139,6 +1139,7 @@ impl LispObject {
         self == other
     }
 
+    #[allow(dead_code)]
     #[inline]
     pub fn ne(self, other: LispObject) -> bool {
         self != other

--- a/rust_src/src/lists.rs
+++ b/rust_src/src/lists.rs
@@ -457,7 +457,6 @@ pub fn inorder(pred: LispObject, a: LispObject, b: LispObject) -> bool {
 }
 
 /// Merge step of linked-list sorting.
-#[no_mangle]
 pub fn merge(mut l1: LispObject, mut l2: LispObject, pred: LispObject) -> LispObject {
     let mut tail = LispObject::constant_nil();
     let mut value = LispObject::constant_nil();
@@ -495,7 +494,6 @@ pub fn merge(mut l1: LispObject, mut l2: LispObject, pred: LispObject) -> LispOb
     }
 }
 
-#[no_mangle]
 pub fn circular_list(obj: LispObject) -> ! {
     xsignal!(Qcircular_list, obj);
 }

--- a/rust_src/src/math.rs
+++ b/rust_src/src/math.rs
@@ -260,12 +260,7 @@ pub enum ArithComparison {
     GrtrOrEqual,
 }
 
-#[no_mangle]
-pub extern "C" fn arithcompare(
-    obj1: LispObject,
-    obj2: LispObject,
-    comparison: ArithComparison,
-) -> LispObject {
+pub fn arithcompare(obj1: LispObject, obj2: LispObject, comparison: ArithComparison) -> LispObject {
     // If either arg is floating point, set F1 and F2 to the 'double'
     // approximations of the two arguments, and set FNEQ if floating-point
     // comparison reports that F1 is not equal to F2, possibly because F1

--- a/rust_src/src/vectors.rs
+++ b/rust_src/src/vectors.rs
@@ -160,6 +160,7 @@ impl LispVectorRef {
         ptr::read(mem::transmute::<_, *const LispObject>(&self.contents).offset(idx))
     }
 
+    #[allow(dead_code)]
     #[inline]
     pub fn get(&self, idx: ptrdiff_t) -> LispObject {
         assert!(0 <= idx && idx < self.len() as ptrdiff_t);

--- a/rust_src/src/windows.rs
+++ b/rust_src/src/windows.rs
@@ -434,12 +434,10 @@ pub fn minibuffer_window(frame: LispObject) -> LispObject {
     frame.minibuffer_window()
 }
 
-#[no_mangle]
 pub fn window_wants_mode_line(window: LispWindowRef) -> bool {
     window.wants_mode_line()
 }
 
-#[no_mangle]
 pub fn window_wants_header_line(window: LispWindowRef) -> bool {
     window.wants_header_line()
 }


### PR DESCRIPTION
Catch no_mangle without extern "C"
Catch LispObject arguments or returns for extern "C" functions

Part of #496 and PR #528