### PR TITLE
Fix systemd user remacs service

### DIFF
--- a/etc/remacs.service
+++ b/etc/remacs.service
@@ -8,8 +8,8 @@ Documentation=info:remacs man:emacs(1) https://gnu.org/software/emacs/
 
 [Service]
 Type=simple
-ExecStart=emacs --fg-daemon
-ExecStop=emacsclient --eval "(kill-emacs)"
+ExecStart=remacs --fg-daemon
+ExecStop=remacsclient --eval "(kill-emacs)"
 Environment=SSH_AUTH_SOCK=%t/keyring/ssh
 Restart=on-failure
 


### PR DESCRIPTION
remacs service now launches `remacs` instead of `emacs`.