### PR TITLE
Incorrect casts for 32 bits

### DIFF
--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -657,19 +657,19 @@ impl LispObject {
 
     pub fn is_font_entity(self) -> bool {
         self.is_font() && self.as_vectorlike().map_or(false, |vec| {
-            vec.pseudovector_size() == font::FONT_ENTITY_MAX as i64
+            vec.pseudovector_size() == font::FONT_ENTITY_MAX as EmacsInt
         })
     }
 
     pub fn is_font_object(self) -> bool {
         self.is_font() && self.as_vectorlike().map_or(false, |vec| {
-            vec.pseudovector_size() == font::FONT_OBJECT_MAX as i64
+            vec.pseudovector_size() == font::FONT_OBJECT_MAX as EmacsInt
         })
     }
 
     pub fn is_font_spec(self) -> bool {
         self.is_font() && self.as_vectorlike().map_or(false, |vec| {
-            vec.pseudovector_size() == font::FONT_SPEC_MAX as i64
+            vec.pseudovector_size() == font::FONT_SPEC_MAX as EmacsInt
         })
     }
 


### PR DESCRIPTION
Should use EmacsInt not i64.

Closes #497