### PR TITLE
implements LispObj::from(&str)

### DIFF
--- a/rust_src/src/data.rs
+++ b/rust_src/src/data.rs
@@ -1,7 +1,5 @@
 //! data helpers
 
-use std::ffi::CString;
-
 use remacs_macros::lisp_fn;
 use remacs_sys::{Lisp_Misc_Type, Lisp_Type, PseudovecType};
 use remacs_sys::{Lisp_Subr_Lang_C, Lisp_Subr_Lang_Rust};
@@ -10,7 +8,6 @@ use remacs_sys::{Qbool_vector, Qbuffer, Qchar_table, Qcompiled_function, Qcondit
                  Qfont_object, Qfont_spec, Qframe, Qhash_table, Qinteger, Qmarker,
                  Qmodule_function, Qmutex, Qnone, Qoverlay, Qprocess, Qstring, Qsubr, Qsymbol,
                  Qterminal, Qthread, Quser_ptr, Qvector, Qwindow, Qwindow_configuration};
-use remacs_sys::build_string;
 
 use lisp::{LispObject, LispSubrRef};
 use lisp::defsubr;
@@ -133,9 +130,9 @@ pub fn type_of(object: LispObject) -> LispObject {
 #[lisp_fn]
 pub fn subr_lang(subr: LispSubrRef) -> LispObject {
     if subr.lang == Lisp_Subr_Lang_C {
-        LispObject::from_raw(unsafe { build_string(CString::new("C").unwrap().as_ptr()) })
+        LispObject::from("C")
     } else if subr.lang == Lisp_Subr_Lang_Rust {
-        LispObject::from_raw(unsafe { build_string(CString::new("Rust").unwrap().as_ptr()) })
+        LispObject::from("Rust")
     } else {
         unreachable!()
     }

--- a/rust_src/src/floatfns.rs
+++ b/rust_src/src/floatfns.rs
@@ -7,7 +7,6 @@ use remacs_macros::lisp_fn;
 use remacs_sys::{EmacsDouble, EmacsInt, EmacsUint, Lisp_Object, MOST_NEGATIVE_FIXNUM,
                  MOST_POSITIVE_FIXNUM};
 use remacs_sys::{Qarith_error, Qinteger_or_marker_p, Qnumberp, Qrange_error};
-use remacs_sys::build_string;
 use remacs_sys::libm;
 
 use lisp::{LispNumber, LispObject};
@@ -334,9 +333,8 @@ where
             return ir;
         }
     }
-    let errstr =
-        LispObject::from_raw(unsafe { build_string(name.as_ptr() as *const libc::c_char) });
-    xsignal!(Qrange_error, errstr, arg)
+
+    xsignal!(Qrange_error, LispObject::from(name), arg)
 }
 
 fn ceiling2(i1: EmacsInt, i2: EmacsInt) -> EmacsInt {

--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -24,8 +24,8 @@ use remacs_sys::{Qarrayp, Qbufferp, Qchar_table_p, Qcharacterp, Qconsp, Qfloatp,
                  Qnumber_or_marker_p, Qnumberp, Qoverlayp, Qplistp, Qprocessp, Qstringp, Qsubrp,
                  Qsymbolp, Qt, Qthreadp, Qunbound, Qwholenump, Qwindow_live_p, Qwindow_valid_p,
                  Qwindowp};
-use remacs_sys::build_string;
-use remacs_sys::{empty_unibyte_string, internal_equal, lispsym, make_float, misc_get_ty};
+use remacs_sys::{build_string, empty_unibyte_string, internal_equal, lispsym, make_float,
+                 misc_get_ty};
 
 use buffers::{LispBufferRef, LispOverlayRef};
 use chartable::LispCharTableRef;
@@ -144,7 +144,7 @@ impl From<bool> for LispObject {
 }
 
 /// Copies a Rust str into a new Lisp string
-impl<'a> From<& 'a str> for LispObject {
+impl<'a> From<&'a str> for LispObject {
     #[inline]
     fn from(s: &str) -> Self {
         LispObject(unsafe { build_string(CString::new(s).unwrap().as_ptr()) })

--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -4,6 +4,7 @@
 //! lisp.h.
 
 use libc::{c_char, c_void, intptr_t, ptrdiff_t, uintptr_t};
+use std::ffi::CString;
 
 #[cfg(test)]
 use std::cmp::max;
@@ -23,7 +24,7 @@ use remacs_sys::{Qarrayp, Qbufferp, Qchar_table_p, Qcharacterp, Qconsp, Qfloatp,
                  Qnumber_or_marker_p, Qnumberp, Qoverlayp, Qplistp, Qprocessp, Qstringp, Qsubrp,
                  Qsymbolp, Qt, Qthreadp, Qunbound, Qwholenump, Qwindow_live_p, Qwindow_valid_p,
                  Qwindowp};
-
+use remacs_sys::build_string;
 use remacs_sys::{empty_unibyte_string, internal_equal, lispsym, make_float, misc_get_ty};
 
 use buffers::{LispBufferRef, LispOverlayRef};
@@ -139,6 +140,14 @@ impl From<bool> for LispObject {
         } else {
             LispObject::constant_nil()
         }
+    }
+}
+
+/// Copies a Rust str into a new Lisp string
+impl<'a> From<& 'a str> for LispObject {
+    #[inline]
+    fn from(s: &str) -> Self {
+        LispObject(unsafe { build_string(CString::new(s).unwrap().as_ptr()) })
     }
 }
 


### PR DESCRIPTION
This depends on #539, which introduces a call to build_string and all the attendant hoops, prompting me to write this.