### PR TITLE
Port thread-alive-p.

### DIFF
--- a/rust_src/src/threads.rs
+++ b/rust_src/src/threads.rs
@@ -24,6 +24,11 @@ impl ThreadStateRef {
     pub fn name(self) -> LispObject {
         LispObject::from_raw(self.name)
     }
+
+    #[inline]
+    pub fn is_alive(self) -> bool {
+        !self.m_specpdl.is_null()
+    }
 }
 
 /// Return the name of the THREAD.
@@ -31,6 +36,12 @@ impl ThreadStateRef {
 #[lisp_fn]
 pub fn thread_name(thread: ThreadStateRef) -> LispObject {
     thread.name()
+}
+
+/// Return t if THREAD is alive, or nil if it has exited.
+#[lisp_fn]
+pub fn thread_alive_p(thread: LispObject) -> bool {
+    thread.as_thread_or_error().is_alive()
 }
 
 include!(concat!(env!("OUT_DIR"), "/threads_exports.rs"));

--- a/src/thread.c
+++ b/src/thread.c
@@ -854,18 +854,6 @@ or `thread-join' in the target thread.  */)
   return Qnil;
 }
 
-DEFUN ("thread-alive-p", Fthread_alive_p, Sthread_alive_p, 1, 1, 0,
-       doc: /* Return t if THREAD is alive, or nil if it has exited.  */)
-  (Lisp_Object thread)
-{
-  struct thread_state *tstate;
-
-  CHECK_THREAD (thread);
-  tstate = XTHREAD (thread);
-
-  return thread_alive_p (tstate) ? Qt : Qnil;
-}
-
 DEFUN ("thread--blocker", Fthread_blocker, Sthread_blocker, 1, 1, 0,
        doc: /* Return the object that THREAD is blocking on.
 If THREAD is blocked in `thread-join' on a second thread, return that
@@ -1020,7 +1008,6 @@ syms_of_threads (void)
       defsubr (&Smake_thread);
       defsubr (&Scurrent_thread);
       defsubr (&Sthread_signal);
-      defsubr (&Sthread_alive_p);
       defsubr (&Sthread_join);
       defsubr (&Sthread_blocker);
       defsubr (&Sall_threads);


### PR DESCRIPTION
Address #422.

#325 is an older PR but I used it as a guide on how the thread functions are being ported. PR could probably use some work before getting merged so I've put what I have so far (simple stuff right now) for critique. Specifically it would be nice to avoid the mucking around with `std::ptr::null_mut`, I saw that the field I'm using it for is marked TODO in the thread struct anyway, not sure what future plans are on that.

And are the boolean conversions in match necessary for returning Lisp objects? I was surprised at the lack of a `From` impl for `bool` to `LispObject`.