### PR TITLE
Precommit should not bail when called programs error.

### DIFF
--- a/rust_src/admin/pre-commit
+++ b/rust_src/admin/pre-commit
@@ -14,7 +14,7 @@ finish() {
 
 trap finish EXIT
 
-set -eu
+set -u
 
 git stash save -q --keep-index $STASH_NAME
 


### PR DESCRIPTION
The `set -e` line caused the script to exit prematurely. This
prevented the script from emitting a pretty error.