### PR TITLE
Revert "port barf-if-buffer-read-only"

### DIFF
--- a/rust_src/remacs-sys/lib.rs
+++ b/rust_src/remacs-sys/lib.rs
@@ -1012,7 +1012,6 @@ extern "C" {
     pub static Vprocess_alist: Lisp_Object;
     pub static Vminibuffer_list: Lisp_Object;
     pub static Vfeatures: Lisp_Object;
-    pub static Vinhibit_read_only: Lisp_Object;
     pub static mut Vautoload_queue: Lisp_Object;
     pub static minibuf_level: EmacsInt;
     pub static mut minibuf_window: Lisp_Object;
@@ -1260,12 +1259,6 @@ extern "C" {
     pub fn window_box_left_offset(w: *const Lisp_Window, area: glyph_row_area) -> c_int;
     pub fn window_menu_bar_p(w: *const Lisp_Window) -> bool;
     pub fn window_tool_bar_p(w: *const Lisp_Window) -> bool;
-
-    pub fn Fget_text_property(
-        position: Lisp_Object,
-        prop: Lisp_Object,
-        object: Lisp_Object,
-    ) -> Lisp_Object;
 
 }
 

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -2045,6 +2045,25 @@ set_buffer_if_live (Lisp_Object buffer)
     set_buffer_internal (XBUFFER (buffer));
 }
 
+DEFUN ("barf-if-buffer-read-only", Fbarf_if_buffer_read_only,
+				   Sbarf_if_buffer_read_only, 0, 1, 0,
+       doc: /* Signal a `buffer-read-only' error if the current buffer is read-only.
+If the text under POSITION (which defaults to point) has the
+`inhibit-read-only' text property set, the error will not be raised.  */)
+  (Lisp_Object position)
+{
+  if (NILP (position))
+    XSETFASTINT (position, PT);
+  else
+    CHECK_NUMBER (position);
+
+  if (!NILP (BVAR (current_buffer, read_only))
+      && NILP (Vinhibit_read_only)
+      && NILP (Fget_text_property (position, Qinhibit_read_only, Qnil)))
+    xsignal1 (Qbuffer_read_only, Fcurrent_buffer ());
+  return Qnil;
+}
+
 DEFUN ("erase-buffer", Ferase_buffer, Serase_buffer, 0, 0, "*",
        doc: /* Delete the entire contents of the current buffer.
 Any narrowing restriction in effect (see `narrow-to-region') is removed,
@@ -6078,6 +6097,7 @@ Functions running this hook are, `get-buffer-create',
   defsubr (&Skill_buffer);
   defsubr (&Sbury_buffer_internal);
   defsubr (&Sset_buffer_major_mode);
+  defsubr (&Sbarf_if_buffer_read_only);
   defsubr (&Serase_buffer);
   defsubr (&Sbuffer_swap_text);
   defsubr (&Sset_buffer_multibyte);


### PR DESCRIPTION
This seems to work, but calls LispObject::from on Lisp_Object values,
which is incorrect. When corrected to LispObject::from_raw, half a
dozen tests faile.

This reverts commit 9e9ece6902ebba7676669f5400ccd2c9ba159adb.