### PR TITLE
Bring back emoji 👿

### DIFF
--- a/src/macfont.m
+++ b/src/macfont.m
@@ -2358,9 +2358,9 @@ macfont_list (struct frame *f, Lisp_Object spec)
                   != (spacing >= FONT_SPACING_MONO)))
             continue;
 
-          /* Don't use a color bitmap font until it is supported on
-	     free platforms.  */
-          if (sym_traits & kCTFontTraitColorGlyphs)
+          /* Don't use a color bitmap font unless its family is
+             explicitly specified.  */
+          if ((sym_traits & kCTFontTraitColorGlyphs) && NILP (family))
             continue;
 
           if (j > 0


### PR DESCRIPTION
Took this from here: https://lists.gnu.org/archive/html/emacs-devel/2016-06/msg00630.html

I don't know if Remacs wants to get into political territory (stand up for emojis ✊!) or not, but this change made my day =)

Please feel free to completely ignore this, and many thanks for Remacs!

Revert "Disable multicolor fonts on OS X since they are not supported on free systems"

This reverts commit 9344612d3cd164317170b6189ec43175757e4231.