### PR TITLE
remove buffer-has-markers-at ?

### DIFF
--- a/src/emacs.c
+++ b/src/emacs.c
@@ -1455,7 +1455,6 @@ Using an Emacs configured with --with-x-toolkit=lucid does not have this problem
       syms_of_insdel ();
       /* syms_of_keymap (); */
       syms_of_macros ();
-      syms_of_marker ();
       syms_of_minibuf ();
       syms_of_process ();
       syms_of_search ();

--- a/src/marker.c
+++ b/src/marker.c
@@ -620,23 +620,6 @@ marker_byte_position (Lisp_Object marker)
   return m->bytepos;
 }
 
-DEFUN ("buffer-has-markers-at", Fbuffer_has_markers_at, Sbuffer_has_markers_at,
-       1, 1, 0,
-       doc: /* Return t if there are markers pointing at POSITION in the current buffer.  */)
-  (Lisp_Object position)
-{
-  register struct Lisp_Marker *tail;
-  register ptrdiff_t charpos;
-
-  charpos = clip_to_bounds (BEG, XINT (position), Z);
-
-  for (tail = BUF_MARKERS (current_buffer); tail; tail = tail->next)
-    if (tail->charpos == charpos)
-      return Qt;
-
-  return Qnil;
-}
-
 #ifdef MARKER_DEBUG
 
 /* For debugging -- count the markers in buffer BUF.  */
@@ -673,11 +656,6 @@ verify_bytepos (ptrdiff_t charpos)
 
 #endif /* MARKER_DEBUG */
 
-void
-syms_of_marker (void)
-{
-  defsubr (&Sbuffer_has_markers_at);
-}
 
 /* Accessors to enable Rust code to get data from the Lisp_Marker struct */
 


### PR DESCRIPTION
This function is marked as obsolete, isn't used anywhere and doesn't work correctly.