### PR TITLE
escape quotes and backslashes when we use a byte literal in the lisp_fn macro

### DIFF
--- a/rust_src/Cargo.lock
+++ b/rust_src/Cargo.lock
@@ -1,4 +1,12 @@
 [[package]]
+name = "aho-corasick"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "alloc_unexecmacosx"
 version = "0.1.0"
 dependencies = [
@@ -136,6 +144,11 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "lazy_static"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "libc"
 version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,6 +157,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "md5"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "memchr"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "mock_derive"
@@ -177,6 +198,23 @@ dependencies = [
 [[package]]
 name = "redox_syscall"
 version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "regex"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -214,7 +252,9 @@ dependencies = [
 name = "remacs-macros"
 version = "0.1.0"
 dependencies = [
+ "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "remacs-util 0.1.0",
  "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -278,6 +318,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "time"
 version = "0.1.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -299,6 +348,24 @@ version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "unreachable"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "utf8-ranges"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "winapi"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,6 +376,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
+"checksum aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4"
 "checksum base64 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c4a342b450b268e1be8036311e2c613d7f8a7ed31214dff1cc3b60852a3168d"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum byte-tools 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0919189ba800c7ffe8778278116b7e0de3905ab81c72abb69c85cbfef7991279"
@@ -326,20 +394,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum ident_case 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c9826188e666f2ed92071d2dadef6edc430b11b158b5b2b3f4babbcc891eaaa"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
+"checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
 "checksum libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "5ba3df4dcb460b9dfbd070d41c94c19209620c191b0340b929ce748a2bcd42d2"
 "checksum md5 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b6d9aab58e540f50b59d5cfa7f0da4c3d437476890e1e0b6206e230dce55a23c"
+"checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
 "checksum mock_derive 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "45e48902efe666fd2df2857c4b2cc98606e0016137a0541b1b36f83a60c9215e"
 "checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)" = "6475140dfd8655aeb72e1fd4b7a1cc1c202be65d71669476e392fe62532b9edd"
 "checksum redox_syscall 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "ab105df655884ede59d45b7070c8a65002d921461ee813a024558ca16030eea0"
+"checksum regex 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "744554e01ccbd98fff8c457c3b092cd67af62a555a43bfe97ae8a0451f7799fa"
+"checksum regex-syntax 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8e931c58b93d86f080c734bfd2bce7dd0079ae2331235818133c8be7f422e20e"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
 "checksum sha1 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cc30b1e1e8c40c121ca33b86c23308a090d19974ef001b4bf6e61fd1a0fb095c"
 "checksum sha2 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "25405172e8d8325cbbb72af68adc28931dacd1482d067facc46ac808f48df55c"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
+"checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
 "checksum time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)" = "d5d788d3aa77bc0ef3e9621256885555368b47bd495c13dd2e7413c89f845520"
 "checksum typenum 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "13a99dc6780ef33c78780b826cf9d2a78840b72cae9474de4bcaf9051e60ebbd"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
+"checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
+"checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
+"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/rust_src/remacs-macros/Cargo.toml
+++ b/rust_src/remacs-macros/Cargo.toml
@@ -11,6 +11,7 @@ proc-macro = true
 quote = "0.3"
 syn = { version = "0.11.11", features = ["full"] }
 remacs-util = { version = "0.1.0", path = "../remacs-util" }
+regex = "0.2"
 
 [dev-dependencies]
 syn = { version = "0.11.11", features = ["full"] }

--- a/rust_src/remacs-macros/Cargo.toml
+++ b/rust_src/remacs-macros/Cargo.toml
@@ -12,6 +12,7 @@ quote = "0.3"
 syn = { version = "0.11.11", features = ["full"] }
 remacs-util = { version = "0.1.0", path = "../remacs-util" }
 regex = "0.2"
+lazy_static = "1.0"
 
 [dev-dependencies]
 syn = { version = "0.11.11", features = ["full"] }

--- a/rust_src/remacs-macros/lib.rs
+++ b/rust_src/remacs-macros/lib.rs
@@ -7,6 +7,7 @@ extern crate quote;
 extern crate regex;
 extern crate remacs_util;
 extern crate syn;
+#[macro_use] extern crate lazy_static;
 
 use proc_macro::TokenStream;
 use regex::Regex;
@@ -139,8 +140,10 @@ struct CByteLiteral<'a>(&'a str);
 
 impl<'a> quote::ToTokens for CByteLiteral<'a> {
     fn to_tokens(&self, tokens: &mut quote::Tokens) {
-        let re = Regex::new(r#"["\\]"#).unwrap();
-        let s = re.replace_all(self.0, |caps: &regex::Captures| {
+        lazy_static! {
+            static ref RE: Regex = Regex::new(r#"["\\]"#).unwrap();
+        }
+        let s = RE.replace_all(self.0, |caps: &regex::Captures| {
             format!("\\x{:x}", u32::from(caps[0].chars().next().unwrap()))
         });
         tokens.append(&format!(r#"b"{}\0""#, s));

--- a/rust_src/remacs-macros/lib.rs
+++ b/rust_src/remacs-macros/lib.rs
@@ -1,13 +1,14 @@
 #![feature(proc_macro)]
 #![recursion_limit = "128"]
 
+#[macro_use]
+extern crate lazy_static;
 extern crate proc_macro;
 #[macro_use]
 extern crate quote;
 extern crate regex;
 extern crate remacs_util;
 extern crate syn;
-#[macro_use] extern crate lazy_static;
 
 use proc_macro::TokenStream;
 use regex::Regex;

--- a/rust_src/remacs-macros/lib.rs
+++ b/rust_src/remacs-macros/lib.rs
@@ -4,9 +4,9 @@
 extern crate proc_macro;
 #[macro_use]
 extern crate quote;
+extern crate regex;
 extern crate remacs_util;
 extern crate syn;
-extern crate regex;
 
 use proc_macro::TokenStream;
 use regex::Regex;
@@ -140,7 +140,9 @@ struct CByteLiteral<'a>(&'a str);
 impl<'a> quote::ToTokens for CByteLiteral<'a> {
     fn to_tokens(&self, tokens: &mut quote::Tokens) {
         let re = Regex::new(r#"["\\]"#).unwrap();
-        let s = re.replace_all(self.0, |caps: &regex::Captures| { format!("\\x{:x}", u32::from(caps[0].chars().next().unwrap())) });
+        let s = re.replace_all(self.0, |caps: &regex::Captures| {
+            format!("\\x{:x}", u32::from(caps[0].chars().next().unwrap()))
+        });
         tokens.append(&format!(r#"b"{}\0""#, s));
     }
 }

--- a/rust_src/remacs-macros/lib.rs
+++ b/rust_src/remacs-macros/lib.rs
@@ -6,8 +6,10 @@ extern crate proc_macro;
 extern crate quote;
 extern crate remacs_util;
 extern crate syn;
+extern crate regex;
 
 use proc_macro::TokenStream;
+use regex::Regex;
 
 mod function;
 
@@ -137,7 +139,9 @@ struct CByteLiteral<'a>(&'a str);
 
 impl<'a> quote::ToTokens for CByteLiteral<'a> {
     fn to_tokens(&self, tokens: &mut quote::Tokens) {
-        tokens.append(&format!(r#"b"{}\0""#, self.0));
+        let re = Regex::new(r#"["\\]"#).unwrap();
+        let s = re.replace_all(self.0, |caps: &regex::Captures| { format!("\\x{:x}", u32::from(caps[0].chars().next().unwrap())) });
+        tokens.append(&format!(r#"b"{}\0""#, s));
     }
 }
 


### PR DESCRIPTION
otherwise, even a properly-escape quote or baskslash in the macro
invocation will cause us to emmit code that can't compile.