### PR TITLE
Don't require OS X to build correctly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,3 +70,5 @@ jobs:
 notifications:
   fast_finish: true
   email: false
+  allow_failures:
+    - os: osx


### PR DESCRIPTION
We've had PRs just hang waiting for an OS X build on Travis, and we
also have a few flaky unit tests on OS X.

Run the OS X build, but don't fail the build if OS X fails. Mark the
build as green immediately after the other parts have succeeded.

This is an alternative approach to #607.