### PR TITLE
Port window-display-table (#571)

### DIFF
--- a/rust_src/src/windows.rs
+++ b/rust_src/src/windows.rs
@@ -478,6 +478,14 @@ pub fn minibuffer_window(frame: LispObject) -> LispObject {
     frame.minibuffer_window()
 }
 
+/// Return the display-table that WINDOW is using.
+/// WINDOW must be a live window and defaults to the selected one.
+#[lisp_fn(min = "0")]
+pub fn window_display_table(window: LispObject) -> LispObject {
+    let win = window_live_or_selected(window);
+    LispObject::from_raw(win.display_table)
+}
+
 pub fn window_wants_mode_line(window: LispWindowRef) -> bool {
     window.wants_mode_line()
 }

--- a/src/window.c
+++ b/src/window.c
@@ -1940,20 +1940,6 @@ Return VALUE.  */)
   return value;
 }
 
-DEFUN ("window-display-table", Fwindow_display_table, Swindow_display_table,
-       0, 1, 0,
-       doc: /* Return the display-table that WINDOW is using.
-WINDOW must be a live window and defaults to the selected one.  */)
-  (Lisp_Object window)
-{
-  return decode_live_window (window)->display_table;
-}
-
-/* Get the display table for use on window W.  This is either W's
-   display table or W's buffer's display table.  Ignore the specified
-   tables if they are not valid; if no valid table is specified,
-   return 0.  */
-
 struct Lisp_Char_Table *
 window_display_table (struct window *w)
 {
@@ -7475,7 +7461,6 @@ displayed after a scrolling operation to be somewhat inaccurate.  */);
   defsubr (&Swindow_dedicated_p);
   defsubr (&Swindow_lines_pixel_dimensions);
   defsubr (&Sset_window_dedicated_p);
-  defsubr (&Swindow_display_table);
   defsubr (&Sset_window_display_table);
   defsubr (&Snext_window);
   defsubr (&Sprevious_window);

--- a/test/rust_src/src/windows-tests.el
+++ b/test/rust_src/src/windows-tests.el
@@ -1,0 +1,19 @@
+(require 'ert)
+
+(ert-deftest window-display-table-nil ()
+  (should (eq (window-display-table) nil)))
+
+(ert-deftest window-display-table-not-nil ()
+  (with-temp-buffer
+    (let ((disptab (make-display-table)))
+      ;; populate the display table
+      ;; https://www.gnu.org/software/emacs/manual/html_node/elisp/Display-Tables.html
+      (dotimes (i 32)
+        (or (= i ?\t)
+            (= i ?\n)
+            (aset disptab i
+                  (vector (make-glyph-code ?^ 'escape-glyph)
+                          (make-glyph-code (+ i 64) 'escape-glyph)))))
+      ;; change the display table for the current window
+      (set-window-display-table (get-buffer-window) disptab)
+      (should (eq (window-display-table) disptab)))))


### PR DESCRIPTION
Tested it with:

```
(window-display-table)

;; https://www.gnu.org/software/emacs/manual/html_node/elisp/Display-Tables.html
(setq disptab (make-display-table))
(dotimes (i 32)
  (or (= i ?\t)
      (= i ?\n)
      (aset disptab i
            (vector (make-glyph-code ?^ 'escape-glyph)
                    (make-glyph-code (+ i 64) 'escape-glyph)))))
(aset disptab 127
      (vector (make-glyph-code ?^ 'escape-glyph)
              (make-glyph-code ?? 'escape-glyph)))

(set-window-display-table (get-buffer-window) disptab)

(window-display-table)
```

This is my very first PR. So there's a good chance that I might have missed something.
But I  successfully built Remacs, and the above snippet works the same on regular Emacs.
Should I also start porting `set-window-display-table` ?