### PR TITLE
Port require

### DIFF
--- a/rust_src/remacs-sys/build.rs
+++ b/rust_src/remacs-sys/build.rs
@@ -164,7 +164,7 @@ fn generate_globals() {
                     let value = parts.next().unwrap();
                     write!(
                         out_file,
-                        "pub static {}: Lisp_Object = Lisp_Object( \
+                        "pub const {}: Lisp_Object = Lisp_Object( \
                          {} * (::std::mem::size_of::<Lisp_Symbol>() as EmacsInt));\n",
                         symbol_name, value
                     ).expect("Write error in reading symbols stage");

--- a/rust_src/remacs-sys/lib.rs
+++ b/rust_src/remacs-sys/lib.rs
@@ -1111,7 +1111,6 @@ extern "C" {
 
     pub static mut Vautoload_queue: Lisp_Object;
     pub static Vbuffer_alist: Lisp_Object;
-    pub static Vfeatures: Lisp_Object;
     pub static Vminibuffer_list: Lisp_Object;
     pub static Vprocess_alist: Lisp_Object;
 

--- a/rust_src/src/fns.rs
+++ b/rust_src/src/fns.rs
@@ -1,14 +1,21 @@
 //* Random utility Lisp functions.
 
 use remacs_macros::lisp_fn;
-use remacs_sys::{Fcons, Fmapc, Vautoload_queue};
-use remacs_sys::{Qfuncall, Qlistp, Qprovide, Qquote, Qsubfeatures, Qwrong_number_of_arguments};
-use remacs_sys::globals;
+use remacs_sys::{Fcons, Fload, Fmapc};
+use remacs_sys::{Qfuncall, Qlistp, Qnil, Qprovide, Qquote, Qrequire, Qsubfeatures, Qt,
+                 Qwrong_number_of_arguments};
+use remacs_sys::{globals, record_unwind_protect, unbind_to};
+use remacs_sys::Lisp_Object;
+use remacs_sys::Vautoload_queue;
 
+use eval::un_autoload;
 use lisp::{LispCons, LispObject};
 use lisp::defsubr;
-use lists::{assq, get, member, memq, put};
+use lists::{assq, car, get, member, memq, put};
+use obarray::loadhist_attach;
+use objects::equal;
 use symbols::LispSymbolRef;
+use threads::c_specpdl_index;
 use vectors::length;
 
 /// Return t if FEATURE is present in this Emacs.
@@ -103,5 +110,159 @@ pub fn quote(args: LispCons) -> LispObject {
 
     args.car()
 }
+
+/* List of features currently being require'd, innermost first.  */
+
+declare_GC_protected_static!(require_nesting_list, Qnil);
+
+unsafe extern "C" fn require_unwind(old_value: Lisp_Object) {
+    require_nesting_list = old_value;
+}
+
+/// If feature FEATURE is not loaded, load it from FILENAME.
+/// If FEATURE is not a member of the list `features', then the feature is
+/// not loaded; so load the file FILENAME.
+///
+/// If FILENAME is omitted, the printname of FEATURE is used as the file
+/// name, and `load' will try to load this name appended with the suffix
+/// `.elc', `.el', or the system-dependent suffix for dynamic module
+/// files, in that order.  The name without appended suffix will not be
+/// used.  See `get-load-suffixes' for the complete list of suffixes.
+///
+/// The directories in `load-path' are searched when trying to find the
+/// file name.
+///
+/// If the optional third argument NOERROR is non-nil, then return nil if
+/// the file is not found instead of signaling an error.  Normally the
+/// return value is FEATURE.
+///
+/// The normal messages at start and end of loading FILENAME are
+/// suppressed.
+#[lisp_fn(min = "1")]
+pub fn require(feature: LispObject, filename: LispObject, noerror: LispObject) -> LispObject {
+    let mut from_file = unsafe { globals.f_load_in_progress };
+
+    let feature_sym = feature.as_symbol_or_error();
+
+    // Record the presence of `require' in this file
+    // even if the feature specified is already loaded.
+    // But not more than once in any file,
+    // and not when we aren't loading or reading from a file.
+    if !from_file {
+        if LispObject::from_raw(unsafe { globals.f_Vcurrent_load_list })
+            .iter_tails_safe()
+            .any(|tail| {
+                let (first, rest) = tail.as_tuple();
+                rest.is_nil() && first.is_string()
+            }) {
+            from_file = true;
+        }
+    }
+
+    if from_file {
+        let tem = LispObject::cons(LispObject::from_raw(Qrequire), feature);
+        if member(
+            tem,
+            LispObject::from_raw(unsafe { globals.f_Vcurrent_load_list }),
+        ).is_nil()
+        {
+            loadhist_attach(tem.to_raw());
+        }
+    }
+
+    if memq(
+        feature,
+        LispObject::from_raw(unsafe { globals.f_Vfeatures }),
+    ).is_not_nil()
+    {
+        return feature;
+    }
+
+    let count = c_specpdl_index();
+
+    // This is to make sure that loadup.el gives a clear picture
+    // of what files are preloaded and when.
+    if unsafe { globals.f_Vpurify_flag != Qnil } {
+        error!(
+            "(require {}) while preparing to dump",
+            feature_sym.symbol_name().as_string_or_error()
+        );
+    }
+
+    // A certain amount of recursive `require' is legitimate,
+    // but if we require the same feature recursively 3 times,
+    // signal an error.
+    let nesting = LispObject::from_raw(unsafe { require_nesting_list })
+        .iter_cars()
+        .filter(|elt| equal(feature, *elt))
+        .count();
+
+    if nesting > 3 {
+        error!(
+            "Recursive `require' for feature `{}'",
+            feature_sym.symbol_name().as_string_or_error()
+        );
+    }
+
+    unsafe {
+        // Update the list for any nested `require's that occur.
+        record_unwind_protect(require_unwind, require_nesting_list);
+        require_nesting_list = Fcons(feature.to_raw(), require_nesting_list);
+
+        // Value saved here is to be restored into Vautoload_queue
+        record_unwind_protect(un_autoload, Vautoload_queue);
+        Vautoload_queue = Qt;
+
+        // Load the file.
+        let tem = Fload(
+            if filename.is_nil() {
+                feature_sym.symbol_name().to_raw()
+            } else {
+                filename.to_raw()
+            },
+            noerror.to_raw(),
+            Qt,
+            Qnil,
+            if filename.is_nil() { Qt } else { Qnil },
+        );
+
+        // If load failed entirely, return nil.
+        if tem == Qnil {
+            return LispObject::from_raw(unbind_to(count, Qnil));
+        }
+    }
+
+    let tem = memq(
+        feature,
+        LispObject::from_raw(unsafe { globals.f_Vfeatures }),
+    );
+    if tem.is_nil() {
+        let tem3 = car(car(LispObject::from_raw(unsafe {
+            globals.f_Vload_history
+        })));
+
+        if tem3.is_nil() {
+            error!(
+                "Required feature `{}' was not provided",
+                feature.as_string_or_error()
+            );
+        } else {
+            // Cf autoload-do-load.
+            error!(
+                "Loading file {} failed to provide feature `{}'",
+                tem3.as_string_or_error(),
+                feature.as_string_or_error()
+            );
+        }
+    }
+
+    // Once loading finishes, don't undo it.
+    unsafe {
+        Vautoload_queue = Qt;
+    }
+
+    LispObject::from_raw(unsafe { unbind_to(count, feature.to_raw()) })
+}
+def_lisp_sym!(Qrequire, "require");
 
 include!(concat!(env!("OUT_DIR"), "/fns_exports.rs"));

--- a/src/eval.c
+++ b/src/eval.c
@@ -1343,29 +1343,6 @@ error (const char *m, ...)
   verror (m, ap);
 }
 
-void
-un_autoload (Lisp_Object oldqueue)
-{
-  Lisp_Object queue, first, second;
-
-  /* Queue to unwind is current value of Vautoload_queue.
-     oldqueue is the shadowed value to leave in Vautoload_queue.  */
-  queue = Vautoload_queue;
-  Vautoload_queue = oldqueue;
-  while (CONSP (queue))
-    {
-      first = XCAR (queue);
-      second = Fcdr (first);
-      first = Fcar (first);
-      if (EQ (first, make_number (0)))
-	Vfeatures = second;
-      else
-	Ffset (first, second);
-      queue = XCDR (queue);
-    }
-}
-
-
 DEFUN ("eval", Feval, Seval, 1, 2, 0,
        doc: /* Evaluate FORM and return its value.
 If LEXICAL is t, evaluate using lexical scoping.


### PR DESCRIPTION
Also port un_autoload.
Make Qnil and friends const instead of static which allows them in
turn to be used in other statics.