### PR TITLE
Ported keymap-prompt with Tests.

### DIFF
--- a/rust_src/src/keymap.rs
+++ b/rust_src/src/keymap.rs
@@ -2,9 +2,9 @@
 
 use remacs_macros::lisp_fn;
 use remacs_sys::{current_global_map as _current_global_map, globals, EmacsInt, CHAR_META};
-use remacs_sys::{access_keymap, get_keymap, maybe_quit, Fcons, Fevent_convert_list, Ffset,
-                 Fmake_char_table, Fpurecopy, Fset};
+use remacs_sys::{Fcons, Fevent_convert_list, Ffset, Fmake_char_table, Fpurecopy, Fset};
 use remacs_sys::{Qkeymap, Qnil};
+use remacs_sys::{access_keymap, get_keymap, maybe_quit};
 
 use data::aref;
 use keyboard::lucid_event_type_list_p;

--- a/rust_src/src/keymap.rs
+++ b/rust_src/src/keymap.rs
@@ -50,6 +50,29 @@ pub fn keymapp(object: LispObject) -> bool {
     map.is_not_nil()
 }
 
+/// Return the prompt-string of a keymap MAP.
+/// If non-nil, the prompt is shown in the echo-area
+/// when reading a key-sequence to be looked-up in this keymap.
+#[lisp_fn]
+pub fn keymap_prompt(map: LispObject) -> LispObject {
+    let map = unsafe { LispObject::from_raw(get_keymap(map.to_raw(), false, false)) };
+    let mut result = LispObject::constant_nil();
+    for elt in map.iter_cars_safe() {
+        let mut tem = elt;
+        if tem.is_string() {
+            result = tem;
+            break;
+        } else if keymapp(tem) {
+            tem = keymap_prompt(tem);
+            if tem.is_not_nil() {
+                result = tem;
+                break;
+            }
+        }
+    }
+    result
+}
+
 /// Return the binding for command KEYS in current local keymap only.
 /// KEYS is a string or vector, a sequence of keystrokes.
 /// The binding is probably a symbol with a function definition.

--- a/rust_src/src/keymap.rs
+++ b/rust_src/src/keymap.rs
@@ -56,21 +56,18 @@ pub fn keymapp(object: LispObject) -> bool {
 #[lisp_fn]
 pub fn keymap_prompt(map: LispObject) -> LispObject {
     let map = unsafe { LispObject::from_raw(get_keymap(map.to_raw(), false, false)) };
-    let mut result = LispObject::constant_nil();
     for elt in map.iter_cars_safe() {
         let mut tem = elt;
         if tem.is_string() {
-            result = tem;
-            break;
+            return tem;
         } else if keymapp(tem) {
             tem = keymap_prompt(tem);
             if tem.is_not_nil() {
-                result = tem;
-                break;
+                return tem;
             }
         }
     }
-    result
+    LispObject::constant_nil()
 }
 
 /// Return the binding for command KEYS in current local keymap only.

--- a/src/keymap.c
+++ b/src/keymap.c
@@ -126,29 +126,6 @@ initial_define_lispy_key (Lisp_Object keymap, const char *keyname, const char *d
   store_in_keymap (keymap, intern_c_string (keyname), intern_c_string (defname));
 }
 
-DEFUN ("keymap-prompt", Fkeymap_prompt, Skeymap_prompt, 1, 1, 0,
-       doc: /* Return the prompt-string of a keymap MAP.
-If non-nil, the prompt is shown in the echo-area
-when reading a key-sequence to be looked-up in this keymap.  */)
-  (Lisp_Object map)
-{
-  map = get_keymap (map, 0, 0);
-  while (CONSP (map))
-    {
-      Lisp_Object tem = XCAR (map);
-      if (STRINGP (tem))
-	return tem;
-      else if (KEYMAPP (tem))
-	{
-	  tem = Fkeymap_prompt (tem);
-	  if (!NILP (tem))
-	    return tem;
-	}
-      map = XCDR (map);
-    }
-  return Qnil;
-}
-
 /* Check that OBJECT is a keymap (after dereferencing through any
    symbols).  If it is, return it.
 
@@ -3506,7 +3483,6 @@ be preferred.  */);
   staticpro (&where_is_cache_keymaps);
 
   defsubr (&Skeymap_parent);
-  defsubr (&Skeymap_prompt);
   defsubr (&Sset_keymap_parent);
   defsubr (&Smap_keymap_internal);
   defsubr (&Smap_keymap);

--- a/test/rust_src/src/keymaps-test.el
+++ b/test/rust_src/src/keymaps-test.el
@@ -5,9 +5,10 @@
                          (3 keymap
                             ;; C-c C-z
                             (26 . emacs-version)))))
+    (should-not (keymap-prompt nil))
     (should (string= (keymap-prompt (make-keymap "test-prompt")) "test-prompt"))
-    (should (eq (keymap-prompt (make-keymap)) nil))
-    (should (eq (keymap-prompt sample-keymap)) nil)))
+    (should-not (keymap-prompt (make-keymap)))
+    (should-not (keymap-prompt sample-keymap))))
 
 (ert-deftest keymap-make-tests ()
   (should (equal (make-keymap) '(keymap

--- a/test/rust_src/src/keymaps-test.el
+++ b/test/rust_src/src/keymaps-test.el
@@ -1,5 +1,14 @@
 (require 'ert)
 
+(ert-deftest keymap-prompt-tests ()
+  (let ((sample-keymap '(keymap
+                         (3 keymap
+                            ;; C-c C-z
+                            (26 . emacs-version)))))
+    (should (string= (keymap-prompt (make-keymap "test-prompt")) "test-prompt"))
+    (should (eq (keymap-prompt (make-keymap)) nil))
+    (should (eq (keymap-prompt sample-keymap)) nil)))
+
 (ert-deftest keymap-make-tests ()
   (should (equal (make-keymap) '(keymap
                                  #^[nil nil keymap nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil])))


### PR DESCRIPTION
Successfully ported `keymap-prompt` from `keymap.c` with tests. Closes #649.

- The code works but I am unsure if the style I used is correct. 
- I learned that returning inside a for loop doesn't work so I had to pass it to the `result` variable so it can be returned by the function.
- I've also separated the Ffoo imports from the other function imports.

Thanks!