### PR TITLE
Ported map_keymap and map-keymap functions with tests.

### DIFF
--- a/rust_src/remacs-sys/lib.rs
+++ b/rust_src/remacs-sys/lib.rs
@@ -1231,6 +1231,9 @@ pub struct lisp_time {
     pub ps: c_int,
 }
 
+type map_keymap_function_t =
+    unsafe extern "C" fn(Lisp_Object, Lisp_Object, Lisp_Object, *const c_void);
+
 extern "C" {
     pub static initialized: bool;
     pub static mut current_global_map: Lisp_Object;
@@ -1452,6 +1455,19 @@ extern "C" {
     );
     pub fn STRING_BYTES(s: *const Lisp_String) -> ptrdiff_t;
     pub fn Fevent_convert_list(event_desc: Lisp_Object) -> Lisp_Object;
+    pub fn map_keymap(
+        map: Lisp_Object,
+        fun: map_keymap_function_t,
+        args: Lisp_Object,
+        data: *const c_void,
+        autoload: bool,
+    );
+    pub fn map_keymap_call(
+        key: Lisp_Object,
+        val: Lisp_Object,
+        fun: Lisp_Object,
+        void: *const c_void,
+    );
     pub fn access_keymap(
         map: Lisp_Object,
         idx: Lisp_Object,

--- a/rust_src/remacs-sys/lib.rs
+++ b/rust_src/remacs-sys/lib.rs
@@ -1455,13 +1455,6 @@ extern "C" {
     );
     pub fn STRING_BYTES(s: *const Lisp_String) -> ptrdiff_t;
     pub fn Fevent_convert_list(event_desc: Lisp_Object) -> Lisp_Object;
-    pub fn map_keymap(
-        map: Lisp_Object,
-        fun: map_keymap_function_t,
-        args: Lisp_Object,
-        data: *const c_void,
-        autoload: bool,
-    );
     pub fn map_keymap_internal(
         map: Lisp_Object,
         fun: map_keymap_function_t,

--- a/rust_src/remacs-sys/lib.rs
+++ b/rust_src/remacs-sys/lib.rs
@@ -1231,7 +1231,7 @@ pub struct lisp_time {
     pub ps: c_int,
 }
 
-type map_keymap_function_t =
+pub type map_keymap_function_t =
     unsafe extern "C" fn(Lisp_Object, Lisp_Object, Lisp_Object, *const c_void);
 
 extern "C" {
@@ -1462,6 +1462,12 @@ extern "C" {
         data: *const c_void,
         autoload: bool,
     );
+    pub fn map_keymap_internal(
+        map: Lisp_Object,
+        fun: map_keymap_function_t,
+        args: Lisp_Object,
+        data: *const c_void,
+    ) -> Lisp_Object;
     pub fn map_keymap_call(
         key: Lisp_Object,
         val: Lisp_Object,

--- a/rust_src/src/keymap.rs
+++ b/rust_src/src/keymap.rs
@@ -262,7 +262,7 @@ pub fn keymap_prompt(map: LispObject) -> LispObject {
     LispObject::constant_nil()
 }
 
-/// Same as map_keymap_internal, but traverses parent keymaps as well.
+/// Same as `map_keymap_internal`, but traverses parent keymaps as well.
 /// AUTOLOAD indicates that autoloaded keymaps should be loaded.
 #[no_mangle]
 pub extern "C" fn map_keymap(
@@ -274,10 +274,10 @@ pub extern "C" fn map_keymap(
 ) {
     let mut map = LispObject::from_raw(get_keymap(map, true, autoload));
     while map.is_cons() {
-        if let Some(elt) = map.as_cons() {
-            if keymapp(elt.car()) {
-                map_keymap(elt.car().to_raw(), fun, args, data, autoload);
-                map = elt.cdr();
+        if let Some(cons) = map.as_cons() {
+            if keymapp(cons.car()) {
+                map_keymap(cons.car().to_raw(), fun, args, data, autoload);
+                map = cons.cdr();
             } else {
                 map = LispObject::from_raw(unsafe {
                     map_keymap_internal(map.to_raw(), fun, args, data)

--- a/src/keymap.c
+++ b/src/keymap.c
@@ -379,27 +379,6 @@ map_keymap_call (Lisp_Object key, Lisp_Object val, Lisp_Object fun, void *dummy)
   call2 (fun, key, val);
 }
 
-/* Same as map_keymap_internal, but traverses parent keymaps as well.
-   AUTOLOAD indicates that autoloaded keymaps should be loaded.  */
-void
-map_keymap (Lisp_Object map, map_keymap_function_t fun, Lisp_Object args,
-	    void *data, bool autoload)
-{
-  map = get_keymap (map, 1, autoload);
-  while (CONSP (map))
-    {
-      if (KEYMAPP (XCAR (map)))
-	{
-	  map_keymap (XCAR (map), fun, args, data, autoload);
-	  map = XCDR (map);
-	}
-      else
-	map = map_keymap_internal (map, fun, args, data);
-      if (!CONSP (map))
-	map = get_keymap (map, 0, autoload);
-    }
-}
-
 /* Same as map_keymap, but does it right, properly eliminating duplicate
    bindings due to inheritance.   */
 void
@@ -422,24 +401,6 @@ If KEYMAP has a parent, this function returns it without processing it.  */)
   keymap = get_keymap (keymap, 1, 1);
   keymap = map_keymap_internal (keymap, map_keymap_call, function, NULL);
   return keymap;
-}
-
-DEFUN ("map-keymap", Fmap_keymap, Smap_keymap, 2, 3, 0,
-       doc: /* Call FUNCTION once for each event binding in KEYMAP.
-FUNCTION is called with two arguments: the event that is bound, and
-the definition it is bound to.  The event may be a character range.
-
-If KEYMAP has a parent, the parent's bindings are included as well.
-This works recursively: if the parent has itself a parent, then the
-grandparent's bindings are also included and so on.
-usage: (map-keymap FUNCTION KEYMAP)  */)
-  (Lisp_Object function, Lisp_Object keymap, Lisp_Object sort_first)
-{
-  if (! NILP (sort_first))
-    return call2 (intern ("map-keymap-sorted"), function, keymap);
-
-  map_keymap (keymap, map_keymap_call, function, NULL, 1);
-  return Qnil;
 }
 
 /* Given OBJECT which was found in a slot in a keymap,
@@ -3327,7 +3288,6 @@ be preferred.  */);
   staticpro (&command_remapping_vector);
 
   defsubr (&Smap_keymap_internal);
-  defsubr (&Smap_keymap);
   defsubr (&Scopy_keymap);
   defsubr (&Scommand_remapping);
   defsubr (&Skey_binding);

--- a/src/keymap.c
+++ b/src/keymap.c
@@ -373,7 +373,7 @@ map_keymap_internal (Lisp_Object map,
   return tail;
 }
 
-static void
+void
 map_keymap_call (Lisp_Object key, Lisp_Object val, Lisp_Object fun, void *dummy)
 {
   call2 (fun, key, val);

--- a/src/keymap.c
+++ b/src/keymap.c
@@ -335,7 +335,7 @@ map_keymap_char_table_item (Lisp_Object args, Lisp_Object key, Lisp_Object val)
 
 /* Call FUN for every binding in MAP and stop at (and return) the parent.
    FUN is called with 4 arguments: FUN (KEY, BINDING, ARGS, DATA).  */
-static Lisp_Object
+Lisp_Object
 map_keymap_internal (Lisp_Object map,
 		     map_keymap_function_t fun,
 		     Lisp_Object args,

--- a/test/rust_src/src/keymap-tests.el
+++ b/test/rust_src/src/keymap-tests.el
@@ -1,5 +1,68 @@
 (require 'ert)
 
+(ert-deftest keymap-tests--map-keymap ()
+  (let* ((sample-keymap '(keymap
+                         (27 keymap
+                             (24 . lisp-send-defun)
+                             (28 . forward-line))
+                         (3 keymap
+                            (25 . run-lisp))))
+        (sample-keymap-with-parent '(keymap
+                                     (3 keymap
+                                        (25 . run-lisp))
+                                     (27 keymap
+                                         (24 . lisp-send-defun))
+                                     keymap
+                                     (127 . backward-delete-char-untabify)
+                                     (26 keymap
+                                         (17 . indent-sexp))))
+        (keys nil)
+        (values nil)
+        (test-function '(lambda (key value)
+                          (push key keys)
+                          (push value values))))
+
+    ;; Test simple keymap with children
+    (map-keymap test-function sample-keymap)
+    (should (equal keys '(3 27)))
+    (should (equal values '((keymap (25 . run-lisp))
+                            (keymap (24 . lisp-send-defun) (28 . forward-line))
+                            )))
+
+    ;; Test simple keymap with children, sort_first is t
+    (setq keys nil)
+    (setq values nil)
+    (map-keymap test-function sample-keymap t)
+    (should (equal keys '(27 3)))
+    (should (equal values '((keymap (24 . lisp-send-defun) (28 . forward-line))
+                            (keymap (25 . run-lisp)))))
+
+    ;; Test keymap with parent keymap
+    (setq keys nil)
+    (setq values nil)
+    (map-keymap test-function sample-keymap-with-parent)
+    (should (equal keys '(26 127 27 3)))
+    (should (equal values '((keymap (17 . indent-sexp))
+                            backward-delete-char-untabify
+                            (keymap (24 . lisp-send-defun))
+                            (keymap (25 . run-lisp)))))
+
+    ;; Test keymap with parent keymap, sort_first is t
+    (setq keys nil)
+    (setq values nil)
+    (map-keymap test-function sample-keymap-with-parent t)
+    (should (equal keys '(127 27 26 3)))
+    (should (equal values '(backward-delete-char-untabify
+                            (keymap (24 . lisp-send-defun))
+                            (keymap (17 . indent-sexp))
+                            (keymap (25 . run-lisp)))))
+
+    ;; Test invalid inputs
+    (should-error (map-keymap nil nil))
+    (should-error (map-keymap "test" nil))
+    (should-error (map-keymap test-function nil))
+    (should-error (map-keymap test-function '(test)))))
+
 (ert-deftest keymap-tests--set-keymap-parent ()
   (let ((sample-keymap '(keymap
                          (3 keymap

--- a/test/rust_src/src/keymap-tests.el
+++ b/test/rust_src/src/keymap-tests.el
@@ -63,69 +63,6 @@
     (should-error (map-keymap test-function nil))
     (should-error (map-keymap test-function '(test)))))
 
-(ert-deftest keymap-tests--map-keymap-2 ()
-  (let* ((sample-keymap '(keymap
-                         (27 keymap
-                             (24 . lisp-send-defun)
-                             (28 . forward-line))
-                         (3 keymap
-                            (25 . run-lisp))))
-        (sample-keymap-with-parent '(keymap
-                                     (3 keymap
-                                        (25 . run-lisp))
-                                     (27 keymap
-                                         (24 . lisp-send-defun))
-                                     keymap
-                                     (127 . backward-delete-char-untabify)
-                                     (26 keymap
-                                         (17 . indent-sexp))))
-        (keys nil)
-        (values nil)
-        (test-function '(lambda (key value)
-                          (push key keys)
-                          (push value values))))
-
-    ;; Test simple keymap with children
-    (map-keymap-2 test-function sample-keymap)
-    (should (equal keys '(3 27)))
-    (should (equal values '((keymap (25 . run-lisp))
-                            (keymap (24 . lisp-send-defun) (28 . forward-line))
-                            )))
-
-    ;; Test simple keymap with children, sort_first is t
-    (setq keys nil)
-    (setq values nil)
-    (map-keymap-2 test-function sample-keymap t)
-    (should (equal keys '(27 3)))
-    (should (equal values '((keymap (24 . lisp-send-defun) (28 . forward-line))
-                            (keymap (25 . run-lisp)))))
-
-    ;; Test keymap with parent keymap
-    (setq keys nil)
-    (setq values nil)
-    (map-keymap-2 test-function sample-keymap-with-parent)
-    (should (equal keys '(26 127 27 3)))
-    (should (equal values '((keymap (17 . indent-sexp))
-                            backward-delete-char-untabify
-                            (keymap (24 . lisp-send-defun))
-                            (keymap (25 . run-lisp)))))
-
-    ;; Test keymap with parent keymap, sort_first is t
-    (setq keys nil)
-    (setq values nil)
-    (map-keymap-2 test-function sample-keymap-with-parent t)
-    (should (equal keys '(127 27 26 3)))
-    (should (equal values '(backward-delete-char-untabify
-                            (keymap (24 . lisp-send-defun))
-                            (keymap (17 . indent-sexp))
-                            (keymap (25 . run-lisp)))))
-
-    ;; Test invalid inputs
-    (should-error (map-keymap-2 nil nil))
-    (should-error (map-keymap-2 "test" nil))
-    (should-error (map-keymap-2 test-function nil))
-    (should-error (map-keymap-2 test-function '(test)))))
-
 (ert-deftest keymap-tests--set-keymap-parent ()
   (let ((sample-keymap '(keymap
                          (3 keymap

--- a/test/rust_src/src/keymap-tests.el
+++ b/test/rust_src/src/keymap-tests.el
@@ -63,6 +63,69 @@
     (should-error (map-keymap test-function nil))
     (should-error (map-keymap test-function '(test)))))
 
+(ert-deftest keymap-tests--map-keymap-2 ()
+  (let* ((sample-keymap '(keymap
+                         (27 keymap
+                             (24 . lisp-send-defun)
+                             (28 . forward-line))
+                         (3 keymap
+                            (25 . run-lisp))))
+        (sample-keymap-with-parent '(keymap
+                                     (3 keymap
+                                        (25 . run-lisp))
+                                     (27 keymap
+                                         (24 . lisp-send-defun))
+                                     keymap
+                                     (127 . backward-delete-char-untabify)
+                                     (26 keymap
+                                         (17 . indent-sexp))))
+        (keys nil)
+        (values nil)
+        (test-function '(lambda (key value)
+                          (push key keys)
+                          (push value values))))
+
+    ;; Test simple keymap with children
+    (map-keymap-2 test-function sample-keymap)
+    (should (equal keys '(3 27)))
+    (should (equal values '((keymap (25 . run-lisp))
+                            (keymap (24 . lisp-send-defun) (28 . forward-line))
+                            )))
+
+    ;; Test simple keymap with children, sort_first is t
+    (setq keys nil)
+    (setq values nil)
+    (map-keymap-2 test-function sample-keymap t)
+    (should (equal keys '(27 3)))
+    (should (equal values '((keymap (24 . lisp-send-defun) (28 . forward-line))
+                            (keymap (25 . run-lisp)))))
+
+    ;; Test keymap with parent keymap
+    (setq keys nil)
+    (setq values nil)
+    (map-keymap-2 test-function sample-keymap-with-parent)
+    (should (equal keys '(26 127 27 3)))
+    (should (equal values '((keymap (17 . indent-sexp))
+                            backward-delete-char-untabify
+                            (keymap (24 . lisp-send-defun))
+                            (keymap (25 . run-lisp)))))
+
+    ;; Test keymap with parent keymap, sort_first is t
+    (setq keys nil)
+    (setq values nil)
+    (map-keymap-2 test-function sample-keymap-with-parent t)
+    (should (equal keys '(127 27 26 3)))
+    (should (equal values '(backward-delete-char-untabify
+                            (keymap (24 . lisp-send-defun))
+                            (keymap (17 . indent-sexp))
+                            (keymap (25 . run-lisp)))))
+
+    ;; Test invalid inputs
+    (should-error (map-keymap-2 nil nil))
+    (should-error (map-keymap-2 "test" nil))
+    (should-error (map-keymap-2 test-function nil))
+    (should-error (map-keymap-2 test-function '(test)))))
+
 (ert-deftest keymap-tests--set-keymap-parent ()
   (let ((sample-keymap '(keymap
                          (3 keymap


### PR DESCRIPTION
Some notes that I am unsure of and need guidance with:
- The ported functions needed the `map_keymap_function_t` typedef declared in C, so what i did was I declared a similar type on the Rust side with:
```rust
type map_keymap_function_t =
    unsafe extern "C" fn(Lisp_Object, Lisp_Object, Lisp_Object, *const c_void);
```
- I used Rust `c_void` in place of C's `void`.
- I also used `ptr::null_mut()` in place of `NULL`.

As always, thanks for the help!