### PR TITLE
Ported map-keymap-internal and map_keymap_internal functions with tests.

### DIFF
--- a/rust_src/remacs-sys/lib.rs
+++ b/rust_src/remacs-sys/lib.rs
@@ -1363,6 +1363,7 @@ pub struct lisp_time {
 
 pub type map_keymap_function_t =
     unsafe extern "C" fn(Lisp_Object, Lisp_Object, Lisp_Object, *const c_void);
+pub type c_function = unsafe extern "C" fn(Lisp_Object, Lisp_Object, Lisp_Object);
 
 extern "C" {
     pub static initialized: bool;
@@ -1389,6 +1390,12 @@ extern "C" {
     // Use LispObject::tag_ptr instead of make_lisp_ptr
     pub fn make_lisp_ptr(ptr: *const c_void, ty: Lisp_Type) -> Lisp_Object;
     pub fn Fmake_char_table(purpose: Lisp_Object, init: Lisp_Object) -> Lisp_Object;
+    pub fn map_char_table(
+        c_function: unsafe extern "C" fn(Lisp_Object, Lisp_Object, Lisp_Object),
+        function: Lisp_Object,
+        table: Lisp_Object,
+        arg: Lisp_Object,
+    );
     pub fn CHAR_TABLE_SET(ct: Lisp_Object, idx: c_int, val: Lisp_Object);
 
     pub fn aset_multibyte_string(array: Lisp_Object, idxval: EmacsInt, c: c_int);
@@ -1593,6 +1600,14 @@ extern "C" {
         args: Lisp_Object,
         data: *const c_void,
     ) -> Lisp_Object;
+    pub fn map_keymap_item(
+        fun: map_keymap_function_t,
+        args: Lisp_Object,
+        key: Lisp_Object,
+        val: Lisp_Object,
+        data: *const c_void,
+    );
+    pub fn map_keymap_char_table_item(args: Lisp_Object, key: Lisp_Object, val: Lisp_Object);
     pub fn map_keymap_call(
         key: Lisp_Object,
         val: Lisp_Object,
@@ -1613,6 +1628,12 @@ extern "C" {
         x: Lisp_Object,
         y: Lisp_Object,
         t: Time,
+    ) -> Lisp_Object;
+
+    pub fn make_save_funcptr_ptr_obj(
+        a: *const c_void,
+        b: *const c_void,
+        c: Lisp_Object,
     ) -> Lisp_Object;
 
     pub fn Fselect_window(window: Lisp_Object, norecord: Lisp_Object) -> Lisp_Object;

--- a/rust_src/remacs-sys/lib.rs
+++ b/rust_src/remacs-sys/lib.rs
@@ -1595,18 +1595,6 @@ extern "C" {
     );
     pub fn STRING_BYTES(s: *const Lisp_String) -> ptrdiff_t;
     pub fn Fevent_convert_list(event_desc: Lisp_Object) -> Lisp_Object;
-    pub fn map_keymap_internal_test(
-        binding: Lisp_Object,
-        fun: map_keymap_function_t,
-        args: Lisp_Object,
-        data: *const c_void,
-    );
-    pub fn map_keymap_internal(
-        map: Lisp_Object,
-        fun: map_keymap_function_t,
-        args: Lisp_Object,
-        data: *const c_void,
-    ) -> Lisp_Object;
     pub fn map_keymap_item(
         fun: map_keymap_function_t,
         args: Lisp_Object,

--- a/rust_src/remacs-sys/lib.rs
+++ b/rust_src/remacs-sys/lib.rs
@@ -1363,7 +1363,6 @@ pub struct lisp_time {
 
 pub type map_keymap_function_t =
     unsafe extern "C" fn(Lisp_Object, Lisp_Object, Lisp_Object, *const c_void);
-pub type c_function = unsafe extern "C" fn(Lisp_Object, Lisp_Object, Lisp_Object);
 pub type voidfuncptr = unsafe extern "C" fn();
 
 extern "C" {
@@ -1392,7 +1391,7 @@ extern "C" {
     pub fn make_lisp_ptr(ptr: *const c_void, ty: Lisp_Type) -> Lisp_Object;
     pub fn Fmake_char_table(purpose: Lisp_Object, init: Lisp_Object) -> Lisp_Object;
     pub fn map_char_table(
-        c_function: c_function,
+        c_function: unsafe extern "C" fn(Lisp_Object, Lisp_Object, Lisp_Object),
         function: Lisp_Object,
         table: Lisp_Object,
         arg: Lisp_Object,

--- a/rust_src/remacs-sys/lib.rs
+++ b/rust_src/remacs-sys/lib.rs
@@ -1364,6 +1364,7 @@ pub struct lisp_time {
 pub type map_keymap_function_t =
     unsafe extern "C" fn(Lisp_Object, Lisp_Object, Lisp_Object, *const c_void);
 pub type c_function = unsafe extern "C" fn(Lisp_Object, Lisp_Object, Lisp_Object);
+pub type voidfuncptr = unsafe extern "C" fn();
 
 extern "C" {
     pub static initialized: bool;
@@ -1391,7 +1392,7 @@ extern "C" {
     pub fn make_lisp_ptr(ptr: *const c_void, ty: Lisp_Type) -> Lisp_Object;
     pub fn Fmake_char_table(purpose: Lisp_Object, init: Lisp_Object) -> Lisp_Object;
     pub fn map_char_table(
-        c_function: unsafe extern "C" fn(Lisp_Object, Lisp_Object, Lisp_Object),
+        c_function: c_function,
         function: Lisp_Object,
         table: Lisp_Object,
         arg: Lisp_Object,
@@ -1594,6 +1595,12 @@ extern "C" {
     );
     pub fn STRING_BYTES(s: *const Lisp_String) -> ptrdiff_t;
     pub fn Fevent_convert_list(event_desc: Lisp_Object) -> Lisp_Object;
+    pub fn map_keymap_internal_test(
+        binding: Lisp_Object,
+        fun: map_keymap_function_t,
+        args: Lisp_Object,
+        data: *const c_void,
+    );
     pub fn map_keymap_internal(
         map: Lisp_Object,
         fun: map_keymap_function_t,
@@ -1631,7 +1638,7 @@ extern "C" {
     ) -> Lisp_Object;
 
     pub fn make_save_funcptr_ptr_obj(
-        a: *const c_void,
+        a: voidfuncptr,
         b: *const c_void,
         c: Lisp_Object,
     ) -> Lisp_Object;

--- a/rust_src/src/keymap.rs
+++ b/rust_src/src/keymap.rs
@@ -392,7 +392,7 @@ pub extern "C" fn map_keymap_internal_2(
 /// FUNCTION is called with two arguments: the event that is bound, and
 /// the definition it is bound to.  The event may be a character range.
 /// If KEYMAP has a parent, this function returns it without processing it.
-#[lisp_fn(name = "map-keymap-internal")]
+#[lisp_fn(name = "map-keymap-internal-2")]
 pub fn map_keymap_internal_lisp(function: LispObject, mut keymap: LispObject) -> LispObject {
     keymap = LispObject::from_raw(get_keymap(keymap.to_raw(), true, true));
     LispObject::from_raw(map_keymap_internal_2(

--- a/rust_src/src/keymap.rs
+++ b/rust_src/src/keymap.rs
@@ -318,7 +318,7 @@ pub fn map_keymap_lisp(function: LispObject, keymap: LispObject, sort_first: boo
 }
 
 /// Call FUN for every binding in MAP and stop at (and return) the parent.
-/// FUN is called with 4 arguments: FUN (KEY, BINDING, ARGS, DATA).  */
+/// FUN is called with 4 arguments: FUN (KEY, BINDING, ARGS, DATA).
 #[no_mangle]
 pub extern "C" fn map_keymap_internal(
     map: Lisp_Object,

--- a/rust_src/src/keymap.rs
+++ b/rust_src/src/keymap.rs
@@ -326,7 +326,7 @@ pub extern "C" fn map_keymap_internal(
     data: *const c_void,
 ) -> Lisp_Object {
     let map = LispObject::from_raw(map);
-    let mut tail = match map.as_cons() {
+    let tail = match map.as_cons() {
         None => LispObject::constant_nil(),
         Some(cons) => {
             let (car, cdr) = cons.as_tuple();
@@ -338,13 +338,12 @@ pub extern "C" fn map_keymap_internal(
         }
     };
 
+    let mut parent = tail;
     for tail_cons in tail.iter_tails_safe() {
         let binding = tail_cons.car();
         if binding.eq_raw(Qkeymap) {
             break;
         } else {
-            tail = tail_cons.cdr();
-
             // An embedded parent.
             if keymapp(binding) {
                 break;
@@ -382,9 +381,11 @@ pub extern "C" fn map_keymap_internal(
                 }
             }
         }
+
+        parent = tail_cons.cdr();
     }
 
-    tail.to_raw()
+    parent.to_raw()
 }
 
 /// Call FUNCTION once for each event binding in KEYMAP.

--- a/rust_src/src/keymap.rs
+++ b/rust_src/src/keymap.rs
@@ -343,6 +343,8 @@ pub extern "C" fn map_keymap_internal(
         if binding.eq_raw(Qkeymap) {
             break;
         } else {
+            tail = tail_cons.cdr();
+
             // An embedded parent.
             if keymapp(binding) {
                 break;
@@ -380,8 +382,6 @@ pub extern "C" fn map_keymap_internal(
                 }
             }
         }
-
-        tail = tail_cons.cdr();
     }
 
     tail.to_raw()

--- a/rust_src/src/keymap.rs
+++ b/rust_src/src/keymap.rs
@@ -317,6 +317,23 @@ pub fn map_keymap_lisp(function: LispObject, keymap: LispObject, sort_first: boo
     LispObject::constant_nil()
 }
 
+/// Call FUNCTION once for each event binding in KEYMAP.
+/// FUNCTION is called with two arguments: the event that is bound, and
+/// the definition it is bound to.  The event may be a character range.
+/// If KEYMAP has a parent, this function returns it without processing it.
+#[lisp_fn(name = "map-keymap-internal")]
+pub fn map_keymap_internal_lisp(function: LispObject, mut keymap: LispObject) -> LispObject {
+    keymap = LispObject::from_raw(get_keymap(keymap.to_raw(), true, true));
+    LispObject::from_raw(unsafe {
+        map_keymap_internal(
+            keymap.to_raw(),
+            map_keymap_call,
+            function.to_raw(),
+            ptr::null_mut(),
+        )
+    })
+}
+
 /// Return the binding for command KEYS in current local keymap only.
 /// KEYS is a string or vector, a sequence of keystrokes.
 /// The binding is probably a symbol with a function definition.

--- a/src/keymap.c
+++ b/src/keymap.c
@@ -309,7 +309,7 @@ access_keymap (Lisp_Object map, Lisp_Object idx,
   return EQ (val, Qunbound) ? Qnil : val;
 }
 
-static void
+void
 map_keymap_item (map_keymap_function_t fun, Lisp_Object args, Lisp_Object key, Lisp_Object val, void *data)
 {
   if (EQ (val, Qt))
@@ -317,7 +317,7 @@ map_keymap_item (map_keymap_function_t fun, Lisp_Object args, Lisp_Object key, L
   (*fun) (key, val, args, data);
 }
 
-static void
+void
 map_keymap_char_table_item (Lisp_Object args, Lisp_Object key, Lisp_Object val)
 {
   if (!NILP (val))

--- a/src/keymap.c
+++ b/src/keymap.c
@@ -373,6 +373,15 @@ map_keymap_internal (Lisp_Object map,
   return tail;
 }
 
+void map_keymap_internal_test(Lisp_Object binding, map_keymap_function_t fun, Lisp_Object args, void *data)
+{
+  if ( CHAR_TABLE_P(binding)) {
+    map_char_table (map_keymap_char_table_item, Qnil, binding,
+		    make_save_funcptr_ptr_obj ((voidfuncptr) fun, data,
+					       args));
+  }
+}
+
 void
 map_keymap_call (Lisp_Object key, Lisp_Object val, Lisp_Object fun, void *dummy)
 {

--- a/src/keymap.c
+++ b/src/keymap.c
@@ -333,55 +333,6 @@ map_keymap_char_table_item (Lisp_Object args, Lisp_Object key, Lisp_Object val)
     }
 }
 
-/* Call FUN for every binding in MAP and stop at (and return) the parent.
-   FUN is called with 4 arguments: FUN (KEY, BINDING, ARGS, DATA).  */
-Lisp_Object
-map_keymap_internal (Lisp_Object map,
-		     map_keymap_function_t fun,
-		     Lisp_Object args,
-		     void *data)
-{
-  Lisp_Object tail
-    = (CONSP (map) && EQ (Qkeymap, XCAR (map))) ? XCDR (map) : map;
-
-  for (; CONSP (tail) && !EQ (Qkeymap, XCAR (tail)); tail = XCDR (tail))
-    {
-      Lisp_Object binding = XCAR (tail);
-
-      if (KEYMAPP (binding))	/* An embedded parent.  */
-	break;
-      else if (CONSP (binding))
-	map_keymap_item (fun, args, XCAR (binding), XCDR (binding), data);
-      else if (VECTORP (binding))
-	{
-	  /* Loop over the char values represented in the vector.  */
-	  int len = ASIZE (binding);
-	  int c;
-	  for (c = 0; c < len; c++)
-	    {
-	      Lisp_Object character;
-	      XSETFASTINT (character, c);
-	      map_keymap_item (fun, args, character, AREF (binding, c), data);
-	    }
-	}
-      else if (CHAR_TABLE_P (binding))
-	map_char_table (map_keymap_char_table_item, Qnil, binding,
-			make_save_funcptr_ptr_obj ((voidfuncptr) fun, data,
-						   args));
-    }
-
-  return tail;
-}
-
-void map_keymap_internal_test(Lisp_Object binding, map_keymap_function_t fun, Lisp_Object args, void *data)
-{
-  if ( CHAR_TABLE_P(binding)) {
-    map_char_table (map_keymap_char_table_item, Qnil, binding,
-		    make_save_funcptr_ptr_obj ((voidfuncptr) fun, data,
-					       args));
-  }
-}
-
 void
 map_keymap_call (Lisp_Object key, Lisp_Object val, Lisp_Object fun, void *dummy)
 {
@@ -398,18 +349,6 @@ map_keymap_canonical (Lisp_Object map, map_keymap_function_t fun, Lisp_Object ar
   map = safe_call1 (Qkeymap_canonicalize, map);
   /* No need to use `map_keymap' here because canonical map has no parent.  */
   map_keymap_internal (map, fun, args, data);
-}
-
-DEFUN ("map-keymap-internal", Fmap_keymap_internal, Smap_keymap_internal, 2, 2, 0,
-       doc: /* Call FUNCTION once for each event binding in KEYMAP.
-FUNCTION is called with two arguments: the event that is bound, and
-the definition it is bound to.  The event may be a character range.
-If KEYMAP has a parent, this function returns it without processing it.  */)
-  (Lisp_Object function, Lisp_Object keymap)
-{
-  keymap = get_keymap (keymap, 1, 1);
-  keymap = map_keymap_internal (keymap, map_keymap_call, function, NULL);
-  return keymap;
 }
 
 /* Given OBJECT which was found in a slot in a keymap,
@@ -3297,7 +3236,6 @@ be preferred.  */);
   staticpro (&command_remapping_vector);
 
   defsubr (&Scopy_keymap);
-  defsubr (&Smap_keymap_internal);
   defsubr (&Scommand_remapping);
   defsubr (&Skey_binding);
   defsubr (&Sminor_mode_key_binding);

--- a/src/keymap.c
+++ b/src/keymap.c
@@ -391,17 +391,17 @@ map_keymap_canonical (Lisp_Object map, map_keymap_function_t fun, Lisp_Object ar
   map_keymap_internal (map, fun, args, data);
 }
 
-DEFUN ("map-keymap-internal", Fmap_keymap_internal, Smap_keymap_internal, 2, 2, 0,
-       doc: /* Call FUNCTION once for each event binding in KEYMAP.
-FUNCTION is called with two arguments: the event that is bound, and
-the definition it is bound to.  The event may be a character range.
-If KEYMAP has a parent, this function returns it without processing it.  */)
-  (Lisp_Object function, Lisp_Object keymap)
-{
-  keymap = get_keymap (keymap, 1, 1);
-  keymap = map_keymap_internal (keymap, map_keymap_call, function, NULL);
-  return keymap;
-}
+/* DEFUN ("map-keymap-internal", Fmap_keymap_internal, Smap_keymap_internal, 2, 2, 0, */
+/*        doc: /\* Call FUNCTION once for each event binding in KEYMAP. */
+/* FUNCTION is called with two arguments: the event that is bound, and */
+/* the definition it is bound to.  The event may be a character range. */
+/* If KEYMAP has a parent, this function returns it without processing it.  *\/) */
+/*   (Lisp_Object function, Lisp_Object keymap) */
+/* { */
+/*   keymap = get_keymap (keymap, 1, 1); */
+/*   keymap = map_keymap_internal (keymap, map_keymap_call, function, NULL); */
+/*   return keymap; */
+/* } */
 
 /* Given OBJECT which was found in a slot in a keymap,
    trace indirect definitions to get the actual definition of that slot.
@@ -3287,7 +3287,6 @@ be preferred.  */);
   command_remapping_vector = Fmake_vector (make_number (2), Qremap);
   staticpro (&command_remapping_vector);
 
-  defsubr (&Smap_keymap_internal);
   defsubr (&Scopy_keymap);
   defsubr (&Scommand_remapping);
   defsubr (&Skey_binding);

--- a/src/keymap.c
+++ b/src/keymap.c
@@ -391,17 +391,17 @@ map_keymap_canonical (Lisp_Object map, map_keymap_function_t fun, Lisp_Object ar
   map_keymap_internal (map, fun, args, data);
 }
 
-/* DEFUN ("map-keymap-internal", Fmap_keymap_internal, Smap_keymap_internal, 2, 2, 0, */
-/*        doc: /\* Call FUNCTION once for each event binding in KEYMAP. */
-/* FUNCTION is called with two arguments: the event that is bound, and */
-/* the definition it is bound to.  The event may be a character range. */
-/* If KEYMAP has a parent, this function returns it without processing it.  *\/) */
-/*   (Lisp_Object function, Lisp_Object keymap) */
-/* { */
-/*   keymap = get_keymap (keymap, 1, 1); */
-/*   keymap = map_keymap_internal (keymap, map_keymap_call, function, NULL); */
-/*   return keymap; */
-/* } */
+DEFUN ("map-keymap-internal", Fmap_keymap_internal, Smap_keymap_internal, 2, 2, 0,
+       doc: /* Call FUNCTION once for each event binding in KEYMAP.
+FUNCTION is called with two arguments: the event that is bound, and
+the definition it is bound to.  The event may be a character range.
+If KEYMAP has a parent, this function returns it without processing it.  */)
+  (Lisp_Object function, Lisp_Object keymap)
+{
+  keymap = get_keymap (keymap, 1, 1);
+  keymap = map_keymap_internal (keymap, map_keymap_call, function, NULL);
+  return keymap;
+}
 
 /* Given OBJECT which was found in a slot in a keymap,
    trace indirect definitions to get the actual definition of that slot.
@@ -3288,6 +3288,7 @@ be preferred.  */);
   staticpro (&command_remapping_vector);
 
   defsubr (&Scopy_keymap);
+  defsubr (&Smap_keymap_internal);
   defsubr (&Scommand_remapping);
   defsubr (&Skey_binding);
   defsubr (&Sminor_mode_key_binding);

--- a/test/rust_src/src/keymap-tests.el
+++ b/test/rust_src/src/keymap-tests.el
@@ -105,6 +105,13 @@
     ;; If one of the elements is a char-table
     (setq keys nil)
     (setq values nil)
+    (should-not (map-keymap-internal test-function `(keymap (24 . lisp-send-defun) ,(make-char-table 'test 0))))
+    (should (equal keys '((0 . 4194303) 24)))
+    (should (equal values '(0 lisp-send-defun)))
+
+    ;; If one of the elements is a char-table
+    (setq keys nil)
+    (setq values nil)
     (should-not (map-keymap-internal-2 test-function `(keymap (24 . lisp-send-defun) ,(make-char-table 'test 0))))
     (should (equal keys '((0 . 4194303) 24)))
     (should (equal values '(0 lisp-send-defun)))

--- a/test/rust_src/src/keymap-tests.el
+++ b/test/rust_src/src/keymap-tests.el
@@ -109,17 +109,10 @@
     (should (equal keys '((0 . 4194303) 24)))
     (should (equal values '(0 lisp-send-defun)))
 
-    ;; If one of the elements is a char-table
-    (setq keys nil)
-    (setq values nil)
-    (should-not (map-keymap-internal-2 test-function `(keymap (24 . lisp-send-defun) ,(make-char-table 'test 0))))
-    (should (equal keys '((0 . 4194303) 24)))
-    (should (equal values '(0 lisp-send-defun)))
-
     ;; If one of the elements is a vector
     (setq keys nil)
     (setq values nil)
-    (should-not (map-keymap-internal-2 test-function '(keymap (24 . lisp-send-defun) [0 0 0 0 0 0])))
+    (should-not (map-keymap-internal test-function '(keymap (24 . lisp-send-defun) [0 0 0 0 0 0])))
     (should (equal keys '(5 4 3 2 1 0 24)))
     (should (equal values '(0 0 0 0 0 0 lisp-send-defun)))
 

--- a/test/rust_src/src/keymap-tests.el
+++ b/test/rust_src/src/keymap-tests.el
@@ -102,12 +102,26 @@
     (should (equal values '((keymap (24 . lisp-send-defun))
                             (keymap (25 . run-lisp)))))
 
+    ;; If one of the elements is a char-table
+    (setq keys nil)
+    (setq values nil)
+    (should-not (map-keymap-internal-2 test-function `(keymap (24 . lisp-send-defun) ,(make-char-table 'test 0))))
+    (should (equal keys '((0 . 4194303) 24)))
+    (should (equal values '(0 lisp-send-defun)))
+
+    ;; If one of the elements is a vector
+    (setq keys nil)
+    (setq values nil)
+    (should-not (map-keymap-internal-2 test-function '(keymap (24 . lisp-send-defun) [0 0 0 0 0 0])))
+    (should (equal keys '(5 4 3 2 1 0 24)))
+    (should (equal values '(0 0 0 0 0 0 lisp-send-defun)))
+
     ;; Test invalid inputs
     (should-error (map-keymap-internal nil nil))
     (should-error (map-keymap-internal "test" nil))
-    (should-error (map-keymap-internal test-function nil))
+    (should-error (map-keymap-internal  test-function nil))
     (should-error (map-keymap-internal test-function '(test)))))
-
+  
 (ert-deftest keymap-tests--set-keymap-parent ()
   (let ((sample-keymap '(keymap
                          (3 keymap


### PR DESCRIPTION
This took me awhile mostly because of the casting to `voidfuncptr` as stated [here](https://github.com/Wilfred/remacs/issues/684#issuecomment-371837539).

After a lot of trial and error and researching I found that the solution is to use `std::mem::transmute` as shown [here](https://doc.rust-lang.org/std/mem/fn.transmute.html#examples) which worked out great.

There is a caveat though:
> Turning a pointer into a function pointer. This is not portable to machines where function pointers and data pointers have different sizes.

Not sure if this concerns our project or not. By machines they may refer to different OSs? Should we be concerned?

Thanks!

