### PR TITLE
Fix remacs renaming in systemd service

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -720,8 +720,8 @@ install-etc:
 	client_name=`echo remacsclient | sed '$(TRANSFORM)'`${EXEEXT}; \
 	sed -e '/^##/d' \
 	  -e "/^Documentation/ s/emacs(1)/${EMACS_NAME}(1)/" \
-	  -e "/^ExecStart/ s|emacs|${bindir}/${EMACS}|" \
-	  -e "/^ExecStop/ s|emacsclient|${bindir}/$${client_name}|" \
+	  -e "/^ExecStart/ s|remacs|${bindir}/${EMACS}|" \
+	  -e "/^ExecStop/ s|remacsclient|${bindir}/$${client_name}|" \
 	  ${srcdir}/etc/remacs.service > $${tmp}; \
 	$(INSTALL_DATA) $${tmp} "$(DESTDIR)$(systemdunitdir)/${EMACS_NAME}.service"; \
 	rm -f $${tmp}


### PR DESCRIPTION
The generated `remacs.service` file was broken. The `ExecStart` and `ExecStop` were wrongly set (with an `r` character).

```
[Unit]
Description=remacs text editor
Documentation=info:remacs man:remacs(1) https://gnu.org/software/emacs/

[Service]
Type=simple
ExecStart=r/output/bin/remacs --fg-daemon
ExecStop=r/output/bin/remacsclient --eval "(kill-emacs)"
Environment=SSH_AUTH_SOCK=%t/keyring/ssh
Restart=on-failure

[Install]
WantedBy=default.target
```