### PR TITLE
Port process-inherit-coding-system-flag to Rust

### DIFF
--- a/rust_src/remacs-sys/lib.rs
+++ b/rust_src/remacs-sys/lib.rs
@@ -1185,6 +1185,7 @@ pub struct Lisp_Process {
 extern "C" {
     pub fn pget_pid(p: *const Lisp_Process) -> pid_t;
     pub fn pget_kill_without_query(p: *const Lisp_Process) -> BoolBF;
+    pub fn pget_process_inherit_coding_system_flag(p: *const Lisp_Process) -> BoolBF;
 }
 
 /// Functions to set members of `struct Lisp_Process`.

--- a/rust_src/src/process.rs
+++ b/rust_src/src/process.rs
@@ -3,8 +3,9 @@
 use remacs_macros::lisp_fn;
 use remacs_sys::{EmacsInt, Lisp_Process, Lisp_Type, Vprocess_alist};
 use remacs_sys::{current_thread, get_process as cget_process, pget_kill_without_query, pget_pid,
-                 pget_raw_status_new, pset_kill_without_query, send_process,
-                 setup_process_coding_systems, update_status, Fmapcar, STRING_BYTES};
+                 pget_raw_status_new, pget_process_inherit_coding_system_flag,
+                 pset_kill_without_query, send_process, setup_process_coding_systems,
+                 update_status, Fmapcar, STRING_BYTES};
 use remacs_sys::{QCbuffer, Qcdr, Qclosed, Qexit, Qlistp, Qnetwork, Qopen, Qpipe, Qrun, Qserial,
                  Qstop};
 
@@ -325,6 +326,18 @@ pub fn set_process_query_on_exit_flag(mut process: LispProcessRef, flag: LispObj
 #[lisp_fn]
 pub fn waiting_for_user_input_p() -> bool {
     unsafe { (*current_thread).m_waiting_for_user_input_p != 0 }
+}
+
+/// Return the value of inherit-coding-system flag for PROCESS. If this flag is
+/// t, `buffer-file-coding-system` of the buffer associated with process will
+/// inherit the coding system used to decode the process output.
+#[lisp_fn]
+pub fn process_inherit_coding_system_flag(process: LispObject) -> LispObject {
+    let p_ref = process.as_process_or_error();
+    let process_inherit_coding_system_flag = unsafe {
+        pget_process_inherit_coding_system_flag(p_ref.as_ptr())
+    };
+    LispObject::from_bool(process_inherit_coding_system_flag)
 }
 
 include!(concat!(env!("OUT_DIR"), "/process_exports.rs"));

--- a/rust_src/src/process.rs
+++ b/rust_src/src/process.rs
@@ -332,11 +332,8 @@ pub fn waiting_for_user_input_p() -> bool {
 /// t, `buffer-file-coding-system` of the buffer associated with process will
 /// inherit the coding system used to decode the process output.
 #[lisp_fn]
-pub fn process_inherit_coding_system_flag(process: LispObject) -> LispObject {
-    let p_ref = process.as_process_or_error();
-    let process_inherit_coding_system_flag =
-        unsafe { pget_process_inherit_coding_system_flag(p_ref.as_ptr()) };
-    LispObject::from_bool(process_inherit_coding_system_flag)
+pub fn process_inherit_coding_system_flag(process: LispProcessRef) -> bool {
+    unsafe { pget_process_inherit_coding_system_flag(process.as_ptr()) }
 }
 
 include!(concat!(env!("OUT_DIR"), "/process_exports.rs"));

--- a/rust_src/src/process.rs
+++ b/rust_src/src/process.rs
@@ -3,7 +3,7 @@
 use remacs_macros::lisp_fn;
 use remacs_sys::{EmacsInt, Lisp_Process, Lisp_Type, Vprocess_alist};
 use remacs_sys::{current_thread, get_process as cget_process, pget_kill_without_query, pget_pid,
-                 pget_raw_status_new, pget_process_inherit_coding_system_flag,
+                 pget_process_inherit_coding_system_flag, pget_raw_status_new,
                  pset_kill_without_query, send_process, setup_process_coding_systems,
                  update_status, Fmapcar, STRING_BYTES};
 use remacs_sys::{QCbuffer, Qcdr, Qclosed, Qexit, Qlistp, Qnetwork, Qopen, Qpipe, Qrun, Qserial,
@@ -334,9 +334,8 @@ pub fn waiting_for_user_input_p() -> bool {
 #[lisp_fn]
 pub fn process_inherit_coding_system_flag(process: LispObject) -> LispObject {
     let p_ref = process.as_process_or_error();
-    let process_inherit_coding_system_flag = unsafe {
-        pget_process_inherit_coding_system_flag(p_ref.as_ptr())
-    };
+    let process_inherit_coding_system_flag =
+        unsafe { pget_process_inherit_coding_system_flag(p_ref.as_ptr()) };
     LispObject::from_bool(process_inherit_coding_system_flag)
 }
 

--- a/src/process.c
+++ b/src/process.c
@@ -402,6 +402,11 @@ bool_bf pget_kill_without_query(const struct Lisp_Process *p)
 {
   return p->kill_without_query;
 }
+
+bool_bf pget_process_inherit_coding_system_flag(const struct Lisp_Process *p)
+{
+  return p->inherit_coding_system_flag;
+}
 /* End Rust Accessors */
 
 /* Setters to enable Rust code to set data in the Lisp_Process struct */
@@ -7314,19 +7319,6 @@ setup_process_coding_systems (Lisp_Object process)
 		       proc_encode_coding_system[outch]);
 }
 
-DEFUN ("process-inherit-coding-system-flag",
-       Fprocess_inherit_coding_system_flag, Sprocess_inherit_coding_system_flag,
-       1, 1, 0,
-       doc: /* Return the value of inherit-coding-system flag for PROCESS.
-If this flag is t, `buffer-file-coding-system' of the buffer
-associated with PROCESS will inherit the coding system used to decode
-the process output.  */)
-  (register Lisp_Object process)
-{
-  CHECK_PROCESS (process);
-  return XPROCESS (process)->inherit_coding_system_flag ? Qt : Qnil;
-}
-
 /* Kill all processes associated with `buffer'.
    If `buffer' is nil, kill all processes.  */
 
@@ -7775,7 +7767,6 @@ returns non-`nil'.  */);
    Fprovide (intern_c_string ("make-network-process"), subfeatures);
  }
 
-  defsubr (&Sprocess_inherit_coding_system_flag);
   defsubr (&Slist_system_processes);
   defsubr (&Sprocess_attributes);
 }

--- a/src/process.h
+++ b/src/process.h
@@ -208,6 +208,9 @@ pget_pid(const struct Lisp_Process *p);
 bool_bf
 pget_kill_without_query(const struct Lisp_Process *p);
 
+bool_bf
+pget_process_inherit_coding_system_flag(const struct Lisp_Process *p);
+
 INLINE bool
 PROCESSP (Lisp_Object a)
 {

--- a/test/rust_src/src/process-tests.el
+++ b/test/rust_src/src/process-tests.el
@@ -5,8 +5,8 @@
 (require 'ert)
 
 (ert-deftest process-tests--process-inherit-coding-system-flag ()
-  (let ((cmd) (if (eq system-type 'windows-nt) "dir" "ls")
-        (proc (start-process "test" nil command)))
+  (let* ((cmd (if (eq system-type 'windows-nt) "dir" "ls"))
+         (proc (start-process "test" nil command)))
     (should (not (process-inherit-coding-system-flag proc)))
     (set-process-inherit-coding-system-flag proc t)
     (should (equal t (process-inherit-coding-system-flag proc)))))

--- a/test/rust_src/src/process-tests.el
+++ b/test/rust_src/src/process-tests.el
@@ -5,7 +5,8 @@
 (require 'ert)
 
 (ert-deftest process-tests--process-inherit-coding-system-flag ()
-  (let ((proc (start-process "test" nil "ls")))
+  (let ((cmd) (if (eq system-type 'windows-nt) "dir" "ls")
+        (proc (start-process "test" nil command)))
     (should (not (process-inherit-coding-system-flag proc)))
     (set-process-inherit-coding-system-flag proc t)
     (should (equal t (process-inherit-coding-system-flag proc)))))

--- a/test/rust_src/src/process-tests.el
+++ b/test/rust_src/src/process-tests.el
@@ -6,7 +6,7 @@
 
 (ert-deftest process-tests--process-inherit-coding-system-flag ()
   (let* ((cmd (if (eq system-type 'windows-nt) "dir" "ls"))
-         (proc (start-process "test" nil command)))
+         (proc (start-process "test" nil cmd)))
     (should (not (process-inherit-coding-system-flag proc)))
     (set-process-inherit-coding-system-flag proc t)
     (should (equal t (process-inherit-coding-system-flag proc)))))

--- a/test/rust_src/src/process-tests.el
+++ b/test/rust_src/src/process-tests.el
@@ -1,0 +1,11 @@
+;;; process-tests.el --- Tests for process.rs
+
+;;; Code:
+
+(require 'ert)
+
+(ert-deftest process-tests--process-inherit-coding-system-flag ()
+  (let ((proc (start-process "test" nil "ls")))
+    (should (not (process-inherit-coding-system-flag proc)))
+    (set-process-inherit-coding-system-flag proc t)
+    (should (equal t (process-inherit-coding-system-flag proc)))))


### PR DESCRIPTION
# What changed?
I ported `process-inherit-coding-system-flag` to Rust. This addresses issue #644.

# How is it tested?
I ran the following code in Remacs:
```
(defvar myproc (start-process "test" nil "ls"))
(equal nil (process-inherit-coding-system-flag myproc)) ;; => t
(set-process-inherit-coding-system-flag myproc t)
(equal t (process-inherit-coding-system-flag myproc)) ;; => t
```

I can add this to a proper test in test/rust_src/src/process-tests.el if that's useful.