### PR TITLE
Make emacs-version report Remacs

### DIFF
--- a/lisp/version.el
+++ b/lisp/version.el
@@ -62,7 +62,7 @@ Don't use this function in programs to choose actions according
 to the system configuration; look at `system-configuration' instead."
   (interactive "P")
   (let ((version-string
-         (format "GNU Emacs %s (build %s, %s%s%s%s)%s"
+         (format "Remacs %s (build %s, %s%s%s%s)%s"
                  emacs-version
                  emacs-build-number
 		 system-configuration


### PR DESCRIPTION
I was going to file some bug reports and I realized the version information was inaccurate.

As an aside, how can I get Remacs to load this change? I made the change to `remacs/lisp/version.el`, but `emacs-version` is loaded from `remacs/nextstep/Remacs.app/Contents/Resources/lisp/version.el.gz`. Is there a fast and/or easy way to get the changed file to recompile or whatever?