### PR TITLE
Update syn (to 0.13.1) and quote (to 0.5), adjust macro definitions.

### DIFF
--- a/rust_src/Cargo.lock
+++ b/rust_src/Cargo.lock
@@ -293,6 +293,14 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "proc-macro2"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "pulldown-cmark"
 version = "0.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,6 +318,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "quote"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "quote"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "rand"
@@ -382,10 +398,10 @@ name = "remacs-macros"
 version = "0.1.0"
 dependencies = [
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "remacs-util 0.1.0",
- "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -487,6 +503,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "synom"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -543,6 +569,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "unicode-xid"
 version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-xid"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -623,9 +654,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
 "checksum num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e7de20f146db9d920c45ee8ed8f71681fd9ade71909b48c3acbd766aa504cf10"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
+"checksum proc-macro2 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "49b6a521dc81b643e9a51e0d1cf05df46d5a2f3c0280ea72bcb68276ba64a118"
 "checksum pulldown-cmark 0.0.15 (registry+https://github.com/rust-lang/crates.io-index)" = "378e941dbd392c101f2cb88097fa4d7167bc421d4b88de3ff7dbee503bc3233b"
 "checksum quine-mc_cluskey 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "07589615d719a60c8dd8a4622e7946465dfef20d1a428f969e3443e7386d5f45"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
+"checksum quote 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7b0ff51282f28dc1b53fd154298feaa2e77c5ea0dba68e1fd8b03b72fbe13d2a"
 "checksum rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)" = "6475140dfd8655aeb72e1fd4b7a1cc1c202be65d71669476e392fe62532b9edd"
 "checksum redox_syscall 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "ab105df655884ede59d45b7070c8a65002d921461ee813a024558ca16030eea0"
 "checksum regex 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "744554e01ccbd98fff8c457c3b092cd67af62a555a43bfe97ae8a0451f7799fa"
@@ -640,6 +673,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum sha1 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cc30b1e1e8c40c121ca33b86c23308a090d19974ef001b4bf6e61fd1a0fb095c"
 "checksum sha2 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "25405172e8d8325cbbb72af68adc28931dacd1482d067facc46ac808f48df55c"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
+"checksum syn 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "91b52877572087400e83d24b9178488541e3d535259e04ff17a63df1e5ceff59"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
 "checksum time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)" = "d5d788d3aa77bc0ef3e9621256885555368b47bd495c13dd2e7413c89f845520"
@@ -648,6 +682,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "51ccda9ef9efa3f7ef5d91e8f9b83bbe6955f9bf86aec89d5cce2c874625920f"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
+"checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 "checksum url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fa35e768d4daf1d85733418a49fb42e10d7f633e394fccab4ab7aba897053fe2"
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"

--- a/rust_src/remacs-macros/Cargo.toml
+++ b/rust_src/remacs-macros/Cargo.toml
@@ -8,14 +8,14 @@ path = "lib.rs"
 proc-macro = true
 
 [dependencies]
-quote = "0.3"
-syn = { version = "0.11.11", features = ["full"] }
+quote = "0.5"
+syn = { version = "0.13.1", features = ["full"] }
 remacs-util = { version = "0.1.0", path = "../remacs-util" }
 regex = "0.2"
 lazy_static = "1.0"
 
 [dev-dependencies]
-syn = { version = "0.11.11", features = ["full"] }
+syn = { version = "0.13.1", features = ["full"] }
 
 [profile.release]
 panic = "abort"

--- a/rust_src/remacs-macros/function.rs
+++ b/rust_src/remacs-macros/function.rs
@@ -30,13 +30,20 @@ pub struct Function {
 }
 
 pub fn parse(item: &syn::Item) -> Result<Function> {
-    match item.node {
-        syn::ItemKind::Fn(ref decl, unsafety, constness, ref abi, _, _) => {
-            if is_unsafe(unsafety) {
+    match *item {
+        syn::Item::Fn(syn::ItemFn {
+            ref decl,
+            ref unsafety,
+            ref constness,
+            ref abi,
+            ref ident,
+            ..
+        }) => {
+            if unsafety.is_some() {
                 return Err("lisp functions cannot be `unsafe`");
             }
 
-            if is_const(constness) {
+            if constness.is_some() {
                 return Err("lisp functions cannot be `const`");
             }
 
@@ -50,7 +57,7 @@ pub fn parse(item: &syn::Item) -> Result<Function> {
                 .collect::<Result<_>>()?;
 
             Ok(Function {
-                name: item.ident.clone(),
+                name: ident.clone(),
                 fntype: parse_function_type(&decl)?,
                 args: args,
             })
@@ -59,34 +66,30 @@ pub fn parse(item: &syn::Item) -> Result<Function> {
     }
 }
 
-fn is_unsafe(unsafety: syn::Unsafety) -> bool {
-    match unsafety {
-        syn::Unsafety::Unsafe => true,
-        syn::Unsafety::Normal => false,
-    }
-}
-
-fn is_const(constness: syn::Constness) -> bool {
-    match constness {
-        syn::Constness::Const => true,
-        syn::Constness::NotConst => false,
-    }
-}
-
 fn is_rust_abi(abi: &Option<syn::Abi>) -> bool {
     match *abi {
-        Some(ref abi) => match *abi {
-            syn::Abi::Named(_) => false,
-            syn::Abi::Rust => true,
-        },
+        Some(syn::Abi {
+            name: Some(_),
+            ..
+        }) => false,
+        Some(syn::Abi {
+            name: None,
+            ..
+        }) => true,
         None => true,
     }
 }
 
 fn get_fn_arg_ident_ty(fn_arg: &syn::FnArg) -> Result<syn::Ident> {
     match *fn_arg {
-        syn::FnArg::Captured(ref pat, _) => match *pat {
-            syn::Pat::Ident(_, ref ident, _) => Ok(ident.clone()),
+        syn::FnArg::Captured(syn::ArgCaptured {
+            ref pat,
+            ..
+        }) => match *pat {
+            syn::Pat::Ident(syn::PatIdent {
+                ref ident,
+                ..
+            }) => Ok(ident.clone()),
             _ => Err("invalid function argument"),
         },
         _ => Err("invalid function argument"),
@@ -97,7 +100,10 @@ fn parse_function_type(fndecl: &syn::FnDecl) -> Result<LispFnType> {
     let nargs = fndecl.inputs.len() as i16;
     for fnarg in &fndecl.inputs {
         match *fnarg {
-            syn::FnArg::Captured(_, ref ty) | syn::FnArg::Ignored(ref ty) => {
+            syn::FnArg::Captured(syn::ArgCaptured {
+                ref ty,
+                ..
+            }) | syn::FnArg::Ignored(ref ty) => {
                 match parse_arg_type(ty) {
                     ArgType::LispObject => {}
                     ArgType::LispObjectSlice => {
@@ -121,37 +127,53 @@ enum ArgType {
     Other,
 }
 
-fn parse_arg_type(fn_arg: &syn::Ty) -> ArgType {
+fn parse_arg_type(fn_arg: &syn::Type) -> ArgType {
     match *fn_arg {
-        syn::Ty::Path(ref qualification, ref path) => if qualification.is_some() {
+        syn::Type::Path(syn::TypePath {
+            qself: ref qualification,
+            ref path,
+        }) => if qualification.is_some() {
             ArgType::Other
         } else {
-            if is_lisp_object(path) {
+            if is_lisp_object(&path) {
                 ArgType::LispObject
             } else {
                 ArgType::Other
             }
         },
-        syn::Ty::Rptr(ref lifetime, ref mut_ty) => if lifetime.is_some() {
+        syn::Type::Reference(syn::TypeReference {
+            elem: ref ty,
+            ref lifetime,
+            ref mutability,
+            ..
+        }) => if lifetime.is_some() {
             ArgType::Other
         } else {
-            match mut_ty.mutability {
-                syn::Mutability::Immutable => ArgType::Other,
-                syn::Mutability::Mutable => match mut_ty.ty {
-                    syn::Ty::Slice(ref ty) => match **ty {
-                        syn::Ty::Path(ref qualification, ref path) => if qualification.is_some() {
-                            ArgType::Other
-                        } else {
-                            if is_lisp_object(path) {
-                                ArgType::LispObjectSlice
-                            } else {
+            match *mutability {
+                None => ArgType::Other,
+                Some(_) => match **ty {
+                    syn::Type::Slice(syn::TypeSlice {
+                        elem: ref ty,
+                        ..
+                    }) => {
+                        match **ty {
+                            syn::Type::Path(syn::TypePath {
+                                qself: ref qualification,
+                                ref path,
+                            }) => if qualification.is_some() {
                                 ArgType::Other
-                            }
-                        },
-                        _ => ArgType::Other,
+                            } else {
+                                if is_lisp_object(&path) {
+                                    ArgType::LispObjectSlice
+                                } else {
+                                    ArgType::Other
+                                }
+                            },
+                            _ => ArgType::Other,
+                        }
                     },
                     _ => ArgType::Other,
-                },
+                }
             }
         },
         _ => ArgType::Other,

--- a/rust_src/remacs-macros/lib.rs
+++ b/rust_src/remacs-macros/lib.rs
@@ -130,6 +130,10 @@ pub fn lisp_fn(attr_ts: TokenStream, fn_ts: TokenStream) -> TokenStream {
         }
     };
 
+    // we could put #fn_item into the quoted code above, but doing so
+    // drops all of the line numbers on the floor and causes the
+    // compiler to attribute any errors in the function to the macro
+    // invocation instead.
     tokens.append_all(fn_item.into_tokens());
     tokens.into()
 }

--- a/rust_src/remacs-macros/lib.rs
+++ b/rust_src/remacs-macros/lib.rs
@@ -13,8 +13,8 @@ extern crate remacs_util;
 extern crate syn;
 
 use proc_macro::TokenStream;
-use regex::Regex;
 use quote::ToTokens;
+use regex::Regex;
 
 mod function;
 
@@ -148,7 +148,11 @@ impl<'a> quote::ToTokens for CByteLiteral<'a> {
         let s = RE.replace_all(self.0, |caps: &regex::Captures| {
             format!("\\x{:x}", u32::from(caps[0].chars().next().unwrap()))
         });
-        tokens.append_all((syn::parse_str::<syn::Expr>(&format!(r#"b"{}\0""#, s))).unwrap().into_tokens());
+        tokens.append_all(
+            (syn::parse_str::<syn::Expr>(&format!(r#"b"{}\0""#, s)))
+                .unwrap()
+                .into_tokens(),
+        );
     }
 }
 

--- a/rust_src/remacs-macros/lib.rs
+++ b/rust_src/remacs-macros/lib.rs
@@ -14,12 +14,13 @@ extern crate syn;
 
 use proc_macro::TokenStream;
 use regex::Regex;
+use quote::ToTokens;
 
 mod function;
 
 #[proc_macro_attribute]
 pub fn lisp_fn(attr_ts: TokenStream, fn_ts: TokenStream) -> TokenStream {
-    let fn_item = syn::parse_item(&fn_ts.to_string()).unwrap();
+    let fn_item = syn::parse(fn_ts).unwrap();
     let function = function::parse(&fn_item).unwrap();
     let lisp_fn_args = match remacs_util::parse_lisp_fn(
         &attr_ts.to_string(),
@@ -44,17 +45,17 @@ pub fn lisp_fn(attr_ts: TokenStream, fn_ts: TokenStream) -> TokenStream {
     match function.fntype {
         function::LispFnType::Normal(_) => for ident in function.args {
             let arg = quote! { #ident: ::remacs_sys::Lisp_Object, };
-            cargs.append(arg);
+            cargs.append_all(arg);
 
             let arg = quote! { ::lisp::LispObject::from_raw(#ident).into(), };
-            rargs.append(arg);
+            rargs.append_all(arg);
         },
         function::LispFnType::Many => {
             let args = quote! {
                 nargs: ::libc::ptrdiff_t,
                 args: *mut ::remacs_sys::Lisp_Object,
             };
-            cargs.append(args);
+            cargs.append_all(args);
 
             let b = quote! {
                 let args = unsafe {
@@ -62,10 +63,10 @@ pub fn lisp_fn(attr_ts: TokenStream, fn_ts: TokenStream) -> TokenStream {
                         args, nargs as usize)
                 };
             };
-            body.append(b);
+            body.append_all(b);
 
             let arg = quote! { unsafe { ::std::mem::transmute(args) } };
-            rargs.append(arg);
+            rargs.append_all(arg);
         }
     }
 
@@ -92,7 +93,7 @@ pub fn lisp_fn(attr_ts: TokenStream, fn_ts: TokenStream) -> TokenStream {
         };
     }
 
-    let tokens = quote! {
+    let mut tokens = quote! {
         #[no_mangle]
         pub extern "C" fn #fname(#cargs) -> ::remacs_sys::Lisp_Object {
             #body
@@ -129,14 +130,8 @@ pub fn lisp_fn(attr_ts: TokenStream, fn_ts: TokenStream) -> TokenStream {
         }
     };
 
-    // we could put #fn_item into the quoted code above, but doing so
-    // drops all of the line numbers on the floor and causes the
-    // compiler to attribute any errors in the function to the macro
-    // invocation instead.
-    // Note: TokenStream has a FromIterator trait impl that converts
-    // an iterator over Token{Stream,Tree,Node}s into a single
-    // TokenStream; collect() calls that impl for us.
-    vec![tokens.parse().unwrap(), fn_ts].into_iter().collect()
+    tokens.append_all(fn_item.into_tokens());
+    tokens.into()
 }
 
 struct CByteLiteral<'a>(&'a str);
@@ -149,10 +144,10 @@ impl<'a> quote::ToTokens for CByteLiteral<'a> {
         let s = RE.replace_all(self.0, |caps: &regex::Captures| {
             format!("\\x{:x}", u32::from(caps[0].chars().next().unwrap()))
         });
-        tokens.append(&format!(r#"b"{}\0""#, s));
+        tokens.append_all((syn::parse_str::<syn::Expr>(&format!(r#"b"{}\0""#, s))).unwrap().into_tokens());
     }
 }
 
 fn concat_idents(lhs: &str, rhs: &str) -> syn::Ident {
-    syn::Ident::new(format!("{}{}", lhs, rhs))
+    syn::Ident::from(format!("{}{}", lhs, rhs))
 }


### PR DESCRIPTION
I'd like to play around with the metaprogramming bits, and I found it hard to find documentation for the old quote/syn versions we are using. So I upgraded, and tried to adjust the code accordingly.

My first real PR, so please be gentle :-). Totally willing to make adjustments, of course. (It would be nice to avoid the `syn::TypeFoo(syn::Type::Foo {` stuff, for starters.