### PR TITLE
Allow lisp_fn slice arguments to be immutable

### DIFF
--- a/rust_src/remacs-lib/docfile.rs
+++ b/rust_src/remacs-lib/docfile.rs
@@ -84,7 +84,7 @@ pub extern "C" fn scan_rust_file(
                 sig.extend(line_iter.next().unwrap());
             }
             let sig = sig.split(')').next().unwrap();
-            let has_many_args = sig.contains("&mut");
+            let has_many_args = sig.contains("&mut") || sig.contains("&[");
 
             // Split arg names and types
             let splitters = [':', ','];
@@ -106,7 +106,7 @@ pub extern "C" fn scan_rust_file(
                 if docstring_usage.is_empty() {
                     docstring_usage.push_str("(fn ");
                     for (i, chunk) in args.chunks(2).enumerate() {
-                        if chunk[1].contains("&mut") {
+                        if chunk[1].contains("&mut") || chunk[1].contains("&[") {
                             docstring_usage.push_str("&rest ");
                         } else if i == attr_props.min as usize {
                             docstring_usage.push_str("&optional ");

--- a/rust_src/remacs-macros/function.rs
+++ b/rust_src/remacs-macros/function.rs
@@ -125,18 +125,15 @@ fn parse_arg_type(fn_arg: &syn::Type) -> ArgType {
             }) => if lifetime.is_some() {
                 ArgType::Other
             } else {
-                match *mutability {
-                    None => ArgType::Other,
-                    Some(_) => match **ty {
-                        syn::Type::Slice(syn::TypeSlice { elem: ref ty, .. }) => {
-                            if is_lisp_object(&**ty) {
-                                ArgType::LispObjectSlice
-                            } else {
-                                ArgType::Other
-                            }
+                match **ty {
+                    syn::Type::Slice(syn::TypeSlice { elem: ref ty, .. }) => {
+                        if is_lisp_object(&**ty) {
+                            ArgType::LispObjectSlice
+                        } else {
+                            ArgType::Other
                         }
-                        _ => ArgType::Other,
-                    },
+                    }
+                    _ => ArgType::Other,
                 }
             },
             _ => ArgType::Other,

--- a/rust_src/src/editfns.rs
+++ b/rust_src/src/editfns.rs
@@ -352,7 +352,7 @@ pub fn char_after(mut pos: LispObject) -> Option<EmacsInt> {
 /// properties to add to the result.
 /// usage: (fn STRING &rest PROPERTIES)
 #[lisp_fn(min = "1")]
-pub fn propertize(args: &mut [LispObject]) -> LispObject {
+pub fn propertize(args: &[LispObject]) -> LispObject {
     /* Number of args must be odd. */
     if args.len() & 1 == 0 {
         error!("Wrong number of arguments");

--- a/rust_src/src/eval.rs
+++ b/rust_src/src/eval.rs
@@ -896,7 +896,7 @@ pub fn autoload_do_load(
 /// Instead, use `add-hook' and specify t for the LOCAL argument.
 /// usage: (run-hooks &rest HOOKS)
 #[lisp_fn]
-pub fn run_hooks(args: &mut [LispObject]) -> () {
+pub fn run_hooks(args: &[LispObject]) -> () {
     for item in args {
         run_hook(item.to_raw());
     }
@@ -916,7 +916,7 @@ pub fn run_hook_with_args(args: &mut [LispObject]) -> LispObject {
     run_hook_with_args_internal(args, funcall_nil)
 }
 
-fn funcall_nil(args: &mut [LispObject]) -> LispObject {
+fn funcall_nil(args: &[LispObject]) -> LispObject {
     let mut obj_array: Vec<Lisp_Object> = args.iter().map(|o| o.to_raw()).collect();
     unsafe { Ffuncall(obj_array.len() as isize, obj_array.as_mut_ptr()) };
     LispObject::constant_nil()
@@ -934,7 +934,7 @@ pub extern "C" fn run_hook(hook: Lisp_Object) -> () {
 /// FUNCALL specifies how to call each function on the hook.
 fn run_hook_with_args_internal(
     args: &mut [LispObject],
-    func: fn(&mut [LispObject]) -> LispObject,
+    func: fn(&[LispObject]) -> LispObject,
 ) -> LispObject {
     // If we are dying or still initializing,
     // don't do anything -- it would probably crash if we tried.

--- a/rust_src/src/hashtable.rs
+++ b/rust_src/src/hashtable.rs
@@ -325,7 +325,7 @@ pub fn clrhash(hash_table: LispHashTableRef) -> LispHashTableRef {
 #[lisp_fn]
 pub fn define_hash_table_test(name: LispObject, test: LispObject, hash: LispObject) -> LispObject {
     let sym = LispObject::from_raw(Qhash_table_test);
-    put(name, sym, list(&mut [test, hash]))
+    put(name, sym, list(&[test, hash]))
 }
 
 include!(concat!(env!("OUT_DIR"), "/hashtable_exports.rs"));

--- a/rust_src/src/lists.rs
+++ b/rust_src/src/lists.rs
@@ -402,7 +402,7 @@ pub fn put(symbol: LispObject, propname: LispObject, value: LispObject) -> LispO
 /// Any number of arguments, even zero arguments, are allowed.
 /// usage: (fn &rest OBJECTS)
 #[lisp_fn]
-pub fn list(args: &mut [LispObject]) -> LispObject {
+pub fn list(args: &[LispObject]) -> LispObject {
     args.iter()
         .rev()
         .fold(LispObject::constant_nil(), |list, &arg| {

--- a/rust_src/src/math.rs
+++ b/rust_src/src/math.rs
@@ -155,7 +155,7 @@ fn arith_driver(code: ArithOp, args: &[LispObject]) -> LispObject {
 /// Return sum of any number of arguments, which are numbers or markers.
 /// usage: (fn &rest NUMBERS-OR-MARKERS)
 #[lisp_fn(name = "+")]
-pub fn plus(args: &mut [LispObject]) -> LispObject {
+pub fn plus(args: &[LispObject]) -> LispObject {
     arith_driver(ArithOp::Add, args)
 }
 
@@ -164,14 +164,14 @@ pub fn plus(args: &mut [LispObject]) -> LispObject {
 /// subtracts all but the first from the first.
 /// usage: (fn &optional NUMBER-OR-MARKER &rest MORE-NUMBERS-OR-MARKERS)
 #[lisp_fn(name = "-")]
-pub fn minus(args: &mut [LispObject]) -> LispObject {
+pub fn minus(args: &[LispObject]) -> LispObject {
     arith_driver(ArithOp::Sub, args)
 }
 
 /// Return product of any number of arguments, which are numbers or markers.
 /// usage: (fn &rest NUMBER-OR-MARKERS)
 #[lisp_fn(name = "*")]
-pub fn times(args: &mut [LispObject]) -> LispObject {
+pub fn times(args: &[LispObject]) -> LispObject {
     arith_driver(ArithOp::Mult, args)
 }
 
@@ -181,7 +181,7 @@ pub fn times(args: &mut [LispObject]) -> LispObject {
 /// The arguments must be numbers or markers.
 /// usage: (fn NUMBER &rest DIVISORS)
 #[lisp_fn(name = "/", min = "1")]
-pub fn quo(args: &mut [LispObject]) -> LispObject {
+pub fn quo(args: &[LispObject]) -> LispObject {
     for argnum in 2..args.len() {
         let arg = args[argnum];
         if arg.is_float() {
@@ -195,7 +195,7 @@ pub fn quo(args: &mut [LispObject]) -> LispObject {
 /// Arguments may be integers, or markers, converted to integers.
 /// usage: (fn &rest INTS-OR-MARKERS)
 #[lisp_fn]
-pub fn logand(args: &mut [LispObject]) -> LispObject {
+pub fn logand(args: &[LispObject]) -> LispObject {
     arith_driver(ArithOp::Logand, args)
 }
 
@@ -203,7 +203,7 @@ pub fn logand(args: &mut [LispObject]) -> LispObject {
 /// Arguments may be integers, or markers converted to integers.
 /// usage: (fn &rest INTS-OR-MARKERS)
 #[lisp_fn]
-pub fn logior(args: &mut [LispObject]) -> LispObject {
+pub fn logior(args: &[LispObject]) -> LispObject {
     arith_driver(ArithOp::Logior, args)
 }
 
@@ -211,7 +211,7 @@ pub fn logior(args: &mut [LispObject]) -> LispObject {
 /// Arguments may be integers, or markers converted to integers.
 /// usage: (fn &rest INTS-OR-MARKERS)
 #[lisp_fn]
-pub fn logxor(args: &mut [LispObject]) -> LispObject {
+pub fn logxor(args: &[LispObject]) -> LispObject {
     arith_driver(ArithOp::Logxor, args)
 }
 
@@ -237,7 +237,7 @@ fn minmax_driver(args: &[LispObject], comparison: ArithComparison) -> LispObject
 /// The value is always a number; markers are converted to numbers.
 /// usage: (fn NUMBER-OR-MARKER &rest NUMBERS-OR-MARKERS)
 #[lisp_fn(min = "1")]
-pub fn max(args: &mut [LispObject]) -> LispObject {
+pub fn max(args: &[LispObject]) -> LispObject {
     minmax_driver(args, ArithComparison::Grtr)
 }
 
@@ -245,7 +245,7 @@ pub fn max(args: &mut [LispObject]) -> LispObject {
 /// The value is always a number; markers are converted to numbers.
 /// usage: (fn NUMBER-OR-MARKER &rest NUMBERS-OR-MARKERS)
 #[lisp_fn(min = "1")]
-pub fn min(args: &mut [LispObject]) -> LispObject {
+pub fn min(args: &[LispObject]) -> LispObject {
     minmax_driver(args, ArithComparison::Less)
 }
 
@@ -339,35 +339,35 @@ fn arithcompare_driver(args: &[LispObject], comparison: ArithComparison) -> bool
 /// Return t if args, all numbers or markers, are equal.
 /// usage: (fn NUMBER-OR-MARKER &rest NUMBERS-OR-MARKERS)
 #[lisp_fn(name = "=", min = "1")]
-pub fn eqlsign(args: &mut [LispObject]) -> bool {
+pub fn eqlsign(args: &[LispObject]) -> bool {
     arithcompare_driver(args, ArithComparison::Equal)
 }
 
 /// Return t if each arg (a number or marker), is less than the next arg.
 /// usage: (fn NUMBER-OR-MARKER &rest NUMBERS-OR-MARKERS)
 #[lisp_fn(name = "<", min = "1")]
-pub fn lss(args: &mut [LispObject]) -> bool {
+pub fn lss(args: &[LispObject]) -> bool {
     arithcompare_driver(args, ArithComparison::Less)
 }
 
 /// Return t if each arg (a number or marker) is greater than the next arg.
 /// usage: (fn NUMBER-OR-MARKER &rest NUMBERS-OR-MARKERS)
 #[lisp_fn(name = ">", min = "1")]
-pub fn gtr(args: &mut [LispObject]) -> bool {
+pub fn gtr(args: &[LispObject]) -> bool {
     arithcompare_driver(args, ArithComparison::Grtr)
 }
 
 /// Return t if each arg (a number or marker) is less than or equal to the next.
 /// usage: (fn NUMBER-OR-MARKER &rest NUMBERS-OR-MARKERS)
 #[lisp_fn(name = "<=", min = "1")]
-pub fn leq(args: &mut [LispObject]) -> bool {
+pub fn leq(args: &[LispObject]) -> bool {
     arithcompare_driver(args, ArithComparison::LessOrEqual)
 }
 
 /// Return t if each arg (a number or marker) is greater than or equal to the next.
 /// usage: (fn NUMBER-OR-MARKER &rest NUMBERS-OR-MARKERS)
 #[lisp_fn(name = ">=", min = "1")]
-pub fn geq(args: &mut [LispObject]) -> bool {
+pub fn geq(args: &[LispObject]) -> bool {
     arithcompare_driver(args, ArithComparison::GrtrOrEqual)
 }
 

--- a/rust_src/src/time.rs
+++ b/rust_src/src/time.rs
@@ -45,7 +45,7 @@ pub extern "C" fn make_lisp_time(t: c_timespec) -> Lisp_Object {
 fn make_lisp_time_1(t: c_timespec) -> LispObject {
     let s = t.tv_sec;
     let ns = t.tv_nsec;
-    list(&mut [
+    list(&[
         LispObject::from_fixnum(hi_time(s)),
         LispObject::from_fixnum(EmacsInt::from(lo_time(s))),
         LispObject::from_fixnum((ns / 1_000) as EmacsInt),


### PR DESCRIPTION
This allows slice references to be the sole argument for a lisp_fn function without requiring them to be mutable. I think there's a case to be made for banning mutable slice references entirely, but `run_hook_with_args_internal` actually does modify its argument array.