### PR TITLE
Restore proper line number attributions for lisp_fn errors

### DIFF
--- a/.travis-cerrors.sh
+++ b/.travis-cerrors.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# This is a standalone script so we terminate as soon as anything
+# errors. See https://github.com/travis-ci/travis-ci/issues/1066
+set -e
+set -x
+
+export PATH=$PATH:~/.cargo/bin
+
+RUSTFMT_CONFIG_DIR=$DIR/rust_src
+
+echo "Checking compile errors"
+cd "$DIR/rust_src"
+cargo build --features compile-errors 2> err.out || true
+cat err.out
+grep -q 'compile_error!("error 001");' err.out

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ rust:
 stages:
   - rustfmt
   - test
+  - cerrors
 
 jobs:
   include:
@@ -36,7 +37,7 @@ jobs:
       script:
         - ./autogen.sh && ./configure
         - make -j 3 && echo '==> Running tests' && make check
-    - 
+    -
       <<: *FULL_TEST
       os: osx
       env:
@@ -66,6 +67,15 @@ jobs:
       os: osx
       before_script:
         - travis_wait rustup install $(cat rust-toolchain)
+    - stage: cerrors
+      os: linux  # No need to run this everywhere
+      before_script:
+        - sudo apt install -y texinfo libgif-dev libxpm-dev
+        - travis_wait rustup install $(cat rust-toolchain)
+        - ./autogen.sh && ./configure --without-makeinfo --with-x=no --with-ns=no --without-gconf --without-gsettings --with-gif=no
+        - make -j 3
+      script:
+        - ./.travis-cerrors.sh
 
 notifications:
   fast_finish: true

--- a/rust_src/Cargo.toml
+++ b/rust_src/Cargo.toml
@@ -44,5 +44,6 @@ panic = "abort"
 panic = "abort"
 
 [features]
+compile-errors = []
 # Treat warnings as a build error on Travis.
 strict = []

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -100,3 +100,14 @@ include!(concat!(env!("OUT_DIR"), "/c_exports.rs"));
 
 #[cfg(test)]
 pub use functions::{lispsym, make_string, make_unibyte_string, Fcons, Fsignal};
+
+#[cfg(feature = "compile-errors")]
+mod compile_errors {
+    use lisp::LispObject;
+    use remacs_macros::lisp_fn;
+
+    #[lisp_fn]
+    fn dummy(x: LispObject) -> LispObject {
+        compile_error!("error 001");
+    }
+}


### PR DESCRIPTION
This is like #715, but includes testing code to make sure a `compile_error!` is attributed to itself rather than the macro.