### PR TITLE
Port minibuffer-depth and minibuffer-prompt #626

### DIFF
--- a/rust_src/src/minibuf.rs
+++ b/rust_src/src/minibuf.rs
@@ -1,7 +1,7 @@
 //! Minibuffer input and completion.
 
 use remacs_macros::lisp_fn;
-use remacs_sys::{minibuf_level, minibuf_window};
+use remacs_sys::{minibuf_level, minibuf_prompt, minibuf_window, EmacsInt, Fcopy_sequence};
 use remacs_sys::Vminibuffer_list;
 
 use buffers::{current_buffer, get_buffer};
@@ -49,6 +49,20 @@ pub fn set_minibuffer_window(window: LispObject) -> LispObject {
     }
 
     window
+}
+
+/// Return current depth of activations of minibuffer,
+/// a nonnegative integer.
+#[lisp_fn]
+pub fn minibuffer_depth() -> EmacsInt {
+    unsafe { minibuf_level }
+}
+
+/// Return the prompt string of the currently active
+/// minibuffer. If no minibuffer is active return nil.
+#[lisp_fn]
+pub fn minibuffer_prompt() -> LispObject {
+    unsafe { Fcopy_sequence(minibuf_prompt) }
 }
 
 include!(concat!(env!("OUT_DIR"), "/minibuf_exports.rs"));

--- a/rust_src/src/remacs_sys.rs
+++ b/rust_src/src/remacs_sys.rs
@@ -1369,6 +1369,7 @@ extern "C" {
     pub static mut last_per_buffer_idx: usize;
     pub static lispsym: Lisp_Symbol;
     pub static minibuf_level: EmacsInt;
+    pub static minibuf_prompt: LispObject;
     pub static minibuf_selected_window: LispObject;
     pub static mut minibuf_window: LispObject;
     pub static selected_frame: LispObject;

--- a/src/minibuf.c
+++ b/src/minibuf.c
@@ -55,7 +55,7 @@ Lisp_Object last_minibuf_string;
 
 /* Prompt to display in front of the mini-buffer contents.  */
 
-static Lisp_Object minibuf_prompt;
+Lisp_Object minibuf_prompt;
 
 /* Width of current mini-buffer prompt.  Only set after display_line
    of the line that contains the prompt.  */
@@ -1858,22 +1858,6 @@ single string, rather than a cons cell whose car is a string.  */)
 }
 
 
-DEFUN ("minibuffer-depth", Fminibuffer_depth, Sminibuffer_depth, 0, 0, 0,
-       doc: /* Return current depth of activations of minibuffer, a nonnegative integer.  */)
-  (void)
-{
-  return make_number (minibuf_level);
-}
-
-DEFUN ("minibuffer-prompt", Fminibuffer_prompt, Sminibuffer_prompt, 0, 0, 0,
-       doc: /* Return the prompt string of the currently-active minibuffer.
-If no minibuffer is active, return nil.  */)
-  (void)
-{
-  return Fcopy_sequence (minibuf_prompt);
-}
-
-
 void
 init_minibuf_once (void)
 {
@@ -2074,8 +2058,6 @@ characters.  This variable should never be set globally.  */);
   defsubr (&Sinternal_complete_buffer);
   defsubr (&Sread_buffer);
   defsubr (&Sread_no_blanks_input);
-  defsubr (&Sminibuffer_depth);
-  defsubr (&Sminibuffer_prompt);
 
   defsubr (&Sminibuffer_prompt_end);
   defsubr (&Sminibuffer_contents);


### PR DESCRIPTION
trying to find a way to return `static Lisp_Object minibuf_prompt`.

this is my first issue. i'm still exploring the project.