### PR TITLE
Update from upstream GNU Emacs

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,27 @@
+Language: Cpp
+BasedOnStyle: LLVM
+AlignEscapedNewlinesLeft: true
+AlwaysBreakAfterReturnType: TopLevelDefinitions
+BreakBeforeBinaryOperators: All
+BreakBeforeBraces: GNU
+ColumnLimit: 80
+ContinuationIndentWidth: 2
+ForEachMacros: [FOR_EACH_TAIL, FOR_EACH_TAIL_SAFE]
+IncludeCategories:
+  - Regex: '^<config\.h>$'
+    Priority: -1
+  - Regex: '^<'
+    Priority: 1
+  - Regex: '^"lisp\.h"$'
+    Priority: 2
+  - Regex: '.*'
+    Priority: 3
+KeepEmptyLinesAtTheStartOfBlocks: false
+MaxEmptyLinesToKeep: 1
+PenaltyBreakBeforeFirstCallParameter: 2000
+SpaceAfterCStyleCast: true
+SpaceBeforeParens: Always
+
+# Local Variables:
+# mode: yaml
+# End:

--- a/admin/gitmerge.el
+++ b/admin/gitmerge.el
@@ -67,7 +67,7 @@ re-?generate\\|bump version\\|from trunk\\|Auto-commit"
   '((t (:strike-through t)))
   "Face for skipped commits.")
 
-(defconst gitmerge-default-branch "origin/emacs-25"
+(defconst gitmerge-default-branch "origin/emacs-26"
   "Default for branch that should be merged.")
 
 (defconst gitmerge-buffer "*gitmerge*"

--- a/admin/make-tarball.txt
+++ b/admin/make-tarball.txt
@@ -5,7 +5,7 @@ Instructions to create pretest or release tarballs. -*- coding: utf-8 -*-
 
 Steps to take before starting on the first pretest in any release sequence:
 
-0.  The release branch (e.g. emacs-25) should already have been made
+0.  The release branch (e.g. emacs-26) should already have been made
     and you should use it for all that follows.  Diffs from this
     branch should be going to the emacs-diffs mailing list.
 

--- a/doc/lispref/files.texi
+++ b/doc/lispref/files.texi
@@ -2096,7 +2096,7 @@ Note that the @samp{.~3~} in the two last examples is the backup part,
 not an extension.
 @end defun
 
-@defun file-name-base &optional filename
+@defun file-name-base filename
 This function is the composition of @code{file-name-sans-extension}
 and @code{file-name-nondirectory}.  For example,
 
@@ -2104,8 +2104,6 @@ and @code{file-name-nondirectory}.  For example,
 (file-name-base "/my/home/foo.c")
     @result{} "foo"
 @end example
-
-The @var{filename} argument defaults to @code{buffer-file-name}.
 @end defun
 
 @node Relative File Names

--- a/etc/NEWS
+++ b/etc/NEWS
@@ -1216,6 +1216,10 @@ Programs that called it with multiple arguments before should pass
 them through 'format' first.  Even that is discouraged: for ElDoc
 support, you should set 'eldoc-documentation-function' instead of
 calling 'eldoc-message' directly.
+
+** The FILENAME argument to 'file-name-base' is now mandatory and no
+longer defaults to 'buffer-file-name'.
+
 
 * Lisp Changes in Emacs 26.1
 

--- a/lisp/autoinsert.el
+++ b/lisp/autoinsert.el
@@ -141,14 +141,14 @@ If this contains a %s, that will be replaced by the matching rule."
      "
 .\\\" You may distribute this file under the terms of the GNU Free
 .\\\" Documentation License.
-.TH " (file-name-base)
+.TH " (file-name-base (buffer-file-name))
      " " (file-name-extension (buffer-file-name))
      " " (format-time-string "%Y-%m-%d ")
      "\n.SH NAME\n"
-     (file-name-base)
+     (file-name-base (buffer-file-name))
      " \\- " str
      "\n.SH SYNOPSIS
-.B " (file-name-base)
+.B " (file-name-base (buffer-file-name))
      "\n"
      _
      "
@@ -211,7 +211,7 @@ If this contains a %s, that will be replaced by the matching rule."
 
 
 \(provide '"
-       (file-name-base)
+       (file-name-base (buffer-file-name))
        ")
 \;;; " (file-name-nondirectory (buffer-file-name)) " ends here\n")
     (("\\.texi\\(nfo\\)?\\'" . "Texinfo file skeleton")
@@ -219,7 +219,7 @@ If this contains a %s, that will be replaced by the matching rule."
      "\\input texinfo   @c -*-texinfo-*-
 @c %**start of header
 @setfilename "
-     (file-name-base) ".info\n"
+     (file-name-base (buffer-file-name)) ".info\n"
       "@settitle " str "
 @c %**end of header
 @copying\n"

--- a/lisp/files.el
+++ b/lisp/files.el
@@ -4484,8 +4484,8 @@ extension, the value is \"\"."
             "")))))
 
 (defun file-name-base (&optional filename)
-  "Return the base name of the FILENAME: no directory, no extension.
-FILENAME defaults to `buffer-file-name'."
+  "Return the base name of the FILENAME: no directory, no extension."
+  (declare (advertised-calling-convention (filename) "27.1"))
   (file-name-sans-extension
    (file-name-nondirectory (or filename (buffer-file-name)))))
 

--- a/lisp/mpc.el
+++ b/lisp/mpc.el
@@ -2403,10 +2403,38 @@ This is used so that they can be compared with `eq', which is needed for
   (interactive)
   (mpc-cmd-pause "0"))
 
+(defun mpc-read-seek (prompt)
+  "Read a seek time.
+Returns a string suitable for MPD \"seekcur\" protocol command."
+  (let* ((str (read-from-minibuffer prompt nil nil nil nil nil t))
+         (seconds "\\(?1:[[:digit:]]+\\(?:\\.[[:digit:]]*\\)?\\)")
+         (minsec (concat "\\(?2:[[:digit:]]+\\):" seconds "?"))
+         (hrminsec (concat "\\(?3:[[:digit:]]+\\):\\(?:" minsec "?\\|:\\)"))
+         time sign)
+    (setq str (string-trim str))
+    (when (memq (string-to-char str) '(?+ ?-))
+      (setq sign (string (string-to-char str)))
+      (setq str (substring str 1)))
+    (setq time
+          ;; `string-to-number' returns 0 on failure
+          (cond
+           ((string-match (concat "^" hrminsec "$") str)
+            (+ (* 3600 (string-to-number (match-string 3 str)))
+               (* 60 (string-to-number (or (match-string 2 str) "")))
+               (string-to-number (or (match-string 1 str) ""))))
+           ((string-match (concat "^" minsec "$") str)
+            (+ (* 60 (string-to-number (match-string 2 str)))
+               (string-to-number (match-string 1 str))))
+           ((string-match (concat "^" seconds "$") str)
+            (string-to-number (match-string 1 str)))
+           (t (user-error "Invalid time"))))
+    (setq time (number-to-string time))
+    (if (null sign) time (concat sign time))))
+
 (defun mpc-seek-current (pos)
   "Seek within current track."
   (interactive
-   (list (read-string "Position to go ([+-]seconds): ")))
+   (list (mpc-read-seek "Position to go ([+-][[H:]M:]seconds): ")))
   (mpc-cmd-seekcur pos))
 
 (defun mpc-toggle-play ()

--- a/lisp/newcomment.el
+++ b/lisp/newcomment.el
@@ -524,7 +524,7 @@ Ensure that `comment-normalize-vars' has been called before you use this."
   ;; comment-search-backward is only used to find the comment-column (in
   ;; comment-set-column) and to find the comment-start string (via
   ;; comment-beginning) in indent-new-comment-line, it should be harmless.
-  (if (not (re-search-backward comment-start-skip limit t))
+  (if (not (re-search-backward comment-start-skip limit 'move))
       (unless noerror (error "No comment"))
     (beginning-of-line)
     (let* ((end (match-end 0))

--- a/lisp/progmodes/cperl-mode.el
+++ b/lisp/progmodes/cperl-mode.el
@@ -2314,7 +2314,7 @@ to nil."
 						 nil t)))) ; Only one
 		     (progn
 		       (forward-word-strictly 1)
-		       (setq name (file-name-base)
+		       (setq name (file-name-base (buffer-file-name))
 			     p (point))
 		       (insert " NAME\n\n" name
 			       " - \n\n=head1 SYNOPSIS\n\n\n\n"

--- a/lisp/progmodes/idlwave.el
+++ b/lisp/progmodes/idlwave.el
@@ -5240,7 +5240,7 @@ Can run from `after-save-hook'."
 	  class
 	  (cond ((not (boundp 'idlwave-scanning-lib))
 		 (list  'buffer (buffer-file-name)))
-;		((string= (downcase (file-name-base))
+;		((string= (downcase (file-name-base (buffer-file-name))
 ;			  (downcase name))
 ;		 (list 'lib))
 ;		(t (cons 'lib (file-name-nondirectory (buffer-file-name))))

--- a/lisp/textmodes/reftex-ref.el
+++ b/lisp/textmodes/reftex-ref.el
@@ -314,7 +314,7 @@ also applies `reftex-translate-to-ascii-function' to the string."
               (save-match-data
                 (cond
                  ((equal letter "f")
-                  (file-name-base))
+                  (file-name-base (buffer-file-name)))
                  ((equal letter "F")
                   (let ((masterdir (file-name-directory (reftex-TeX-master-file)))
                         (file (file-name-sans-extension (buffer-file-name))))

--- a/nt/INSTALL.W64
+++ b/nt/INSTALL.W64
@@ -112,11 +112,11 @@ C:\emacs\emacs-24.5:
 ** From the Git repository
 
 To download the Git repository, do something like the following -- this will
-put the Emacs source into C:\emacs\emacs-25:
+put the Emacs source into C:\emacs\emacs-26:
 
   mkdir /c/emacs
   cd /c/emacs
-  git clone git://git.sv.gnu.org/emacs.git emacs-25
+  git clone git://git.sv.gnu.org/emacs.git emacs-26
 
 (We recommend using the command shown on Savannah Emacs project page.)
 
@@ -129,7 +129,7 @@ First we need to switch to the MinGW-w64 environment.  Exit the MSYS2 BASH
 console and run mingw64_shell.bat in the C:\msys64 folder, then cd back to
 your Emacs source directory, e.g.:
 
-  cd /c/emacs/emacs-25
+  cd /c/emacs/emacs-26
 
 ** Run autogen
 
@@ -146,7 +146,7 @@ that the example given here is just a simple one - for more information
 on the options available please see the INSTALL file in this directory.
 
 The '--prefix' option specifies a location for the resulting binary files,
-which 'make install' will use - in this example we set it to C:\emacs\emacs-25.
+which 'make install' will use - in this example we set it to C:\emacs\emacs-26.
 If a prefix is not specified the files will be put in the standard Unix
 directories located in your C:\msys64 directory, but this is not recommended.
 
@@ -154,7 +154,7 @@ Note also that we need to disable Imagemagick because Emacs does not yet
 support it on Windows.
 
   PKG_CONFIG_PATH=/mingw64/lib/pkgconfig \
-  ./configure --prefix=/c/emacs/emacs-25 --without-imagemagick
+  ./configure --prefix=/c/emacs/emacs-26 --without-imagemagick
 
 ** Run make
 

--- a/src/lcms.c
+++ b/src/lcms.c
@@ -589,6 +589,12 @@ DEFUN ("lcms2-available-p", Flcms2_available_p, Slcms2_available_p, 0, 0, 0,
 void
 syms_of_lcms2 (void)
 {
+  DEFVAR_LISP ("lcms-d65-xyz", Vlcms_d65_xyz,
+               doc: /* D65 illuminant as a CIE XYZ triple.  */);
+  Vlcms_d65_xyz = list3 (make_float (0.950455),
+                         make_float (1.0),
+                         make_float (1.088753));
+
   defsubr (&Slcms_cie_de2000);
   defsubr (&Slcms_xyz_to_jch);
   defsubr (&Slcms_jch_to_xyz);

--- a/test/src/lcms-tests.el
+++ b/test/src/lcms-tests.el
@@ -47,9 +47,9 @@ B is considered the exact value."
   "Like `lcms-approx-p' except for color triples."
   (pcase-let ((`(,a1 ,a2 ,a3) a)
               (`(,b1 ,b2 ,b3) b))
-   (and (lcms-approx-p a1 b1 delta)
-        (lcms-approx-p a2 b2 delta)
-        (lcms-approx-p a3 b3 delta))))
+    (and (lcms-approx-p a1 b1 delta)
+         (lcms-approx-p a2 b2 delta)
+         (lcms-approx-p a3 b3 delta))))
 
 (defun lcms-rgb255->xyz (rgb)
   "Return XYZ tristimulus values corresponding to RGB."


### PR DESCRIPTION
This brings a few commits over from upstream Emacs. The previous common commit:

```
$ git merge-base origin/master upstream/master    
c0af83b6ccf2dab9a515dd7f52eb9d4500275ae3
```

looks like it was previously on a branch that merged into master. I've tried to take a commit that was clearly on the `master` branch, to make things simpler in future. I think this is why I had a few merge conflicts in files that haven't changed in Remacs, such as lcms.c.

This only brings in a few extra commits, but I hope this makes future merges easier.