### PR TITLE
Merge Lisp_Object and LispObject into a new LispObject type.

### DIFF
--- a/rust_src/build.rs
+++ b/rust_src/build.rs
@@ -295,12 +295,6 @@ impl<'a> ModuleParser<'a> {
                 self.lineno,
                 "'no_mangle' functions exported for C need 'extern \"C\"' too.".to_string(),
             ))
-        } else if line.contains(": LispObject") || line.contains("-> LispObject") {
-            Err(LintMsg::new(
-                &self.info.name,
-                self.lineno,
-                "functions exported to C must use 'Lisp_Object' not 'LispObject'".to_string(),
-            ))
         } else {
             Ok(())
         }
@@ -562,6 +556,7 @@ fn generate_globals() {
                         match vtype {
                             "EMACS_INT" => "EmacsInt",
                             "bool_bf" => "BoolBF",
+                            "Lisp_Object" => "LispObject",
                             t => t,
                         }
                     ).expect("Write error!");
@@ -582,7 +577,7 @@ fn generate_globals() {
                     let value = parts.next().unwrap();
                     write!(
                         out_file,
-                        "pub const {}: Lisp_Object = Lisp_Object( \
+                        "pub const {}: LispObject = ::lisp::LispObject( \
                          {} * (::std::mem::size_of::<Lisp_Symbol>() as EmacsInt));\n",
                         symbol_name, value
                     ).expect("Write error in reading symbols stage");

--- a/rust_src/remacs-macros/lib.rs
+++ b/rust_src/remacs-macros/lib.rs
@@ -43,7 +43,7 @@ pub fn lisp_fn(attr_ts: TokenStream, fn_ts: TokenStream) -> TokenStream {
 
     match function.fntype {
         function::LispFnType::Normal(_) => for ident in function.args {
-            let arg = quote! { #ident: ::remacs_sys::Lisp_Object, };
+            let arg = quote! { #ident: ::lisp::LispObject, };
             cargs.append_all(arg);
 
             let arg = quote! { ::lisp::LispObject::from_raw(#ident).into(), };
@@ -52,13 +52,13 @@ pub fn lisp_fn(attr_ts: TokenStream, fn_ts: TokenStream) -> TokenStream {
         function::LispFnType::Many => {
             let args = quote! {
                 nargs: ::libc::ptrdiff_t,
-                args: *mut ::remacs_sys::Lisp_Object,
+                args: *mut ::lisp::LispObject,
             };
             cargs.append_all(args);
 
             let b = quote! {
                 let args = unsafe {
-                    ::std::slice::from_raw_parts_mut::<::remacs_sys::Lisp_Object>(
+                    ::std::slice::from_raw_parts_mut::<::lisp::LispObject>(
                         args, nargs as usize)
                 };
             };
@@ -94,7 +94,7 @@ pub fn lisp_fn(attr_ts: TokenStream, fn_ts: TokenStream) -> TokenStream {
 
     let tokens = quote! {
         #[no_mangle]
-        pub extern "C" fn #fname(#cargs) -> ::remacs_sys::Lisp_Object {
+        pub extern "C" fn #fname(#cargs) -> ::lisp::LispObject {
             #body
 
             let ret = #rname(#rargs);

--- a/rust_src/src/buffers.rs
+++ b/rust_src/src/buffers.rs
@@ -4,8 +4,8 @@ use libc::{self, c_int, c_uchar, c_void, ptrdiff_t};
 use std::{self, mem, ptr};
 
 use remacs_macros::lisp_fn;
-use remacs_sys::{EmacsInt, Lisp_Buffer, Lisp_Buffer_Local_Value, Lisp_Fwd, Lisp_Object,
-                 Lisp_Overlay, Lisp_Type, Vbuffer_alist, MOST_POSITIVE_FIXNUM};
+use remacs_sys::{EmacsInt, Lisp_Buffer, Lisp_Buffer_Local_Value, Lisp_Fwd, Lisp_Overlay,
+                 Lisp_Type, Vbuffer_alist, MOST_POSITIVE_FIXNUM};
 use remacs_sys::{Fcons, Fcopy_sequence, Fexpand_file_name, Ffind_file_name_handler,
                  Fget_text_property, Fnconc, Fnreverse};
 use remacs_sys::{Qbuffer_read_only, Qget_file_buffer, Qinhibit_read_only, Qnil, Qunbound,
@@ -392,7 +392,7 @@ impl LispBufferLocalValueRef {
 /// followed by the rest of the buffers.
 #[lisp_fn(min = "0")]
 pub fn buffer_list(frame: LispObject) -> LispObject {
-    let mut buffers: Vec<Lisp_Object> = LispObject::from_raw(unsafe { Vbuffer_alist })
+    let mut buffers: Vec<LispObject> = LispObject::from_raw(unsafe { Vbuffer_alist })
         .iter_cars_safe()
         .map(|o| cdr(o).to_raw())
         .collect();
@@ -545,7 +545,7 @@ pub fn overlay_properties(overlay: LispOverlayRef) -> LispObject {
 }
 
 #[no_mangle]
-pub extern "C" fn validate_region(b: *mut Lisp_Object, e: *mut Lisp_Object) {
+pub extern "C" fn validate_region(b: *mut LispObject, e: *mut LispObject) {
     let start = LispObject::from_raw(unsafe { *b });
     let stop = LispObject::from_raw(unsafe { *e });
 
@@ -611,7 +611,7 @@ pub fn barf_if_buffer_read_only(position: Option<EmacsInt>) -> () {
 
 /// No such buffer error.
 #[no_mangle]
-pub extern "C" fn nsberror(spec: Lisp_Object) -> ! {
+pub extern "C" fn nsberror(spec: LispObject) -> ! {
     let spec = LispObject::from_raw(spec);
     if let Some(s) = spec.as_string() {
         error!("No buffer named {}", s);
@@ -658,7 +658,7 @@ fn get_truename_buffer_1(filename: LispObject) -> LispObject {
 
 // to be removed once all references in C are ported
 #[no_mangle]
-pub extern "C" fn get_truename_buffer(filename: Lisp_Object) -> Lisp_Object {
+pub extern "C" fn get_truename_buffer(filename: LispObject) -> LispObject {
     get_truename_buffer_1(LispObject::from_raw(filename)).to_raw()
 }
 

--- a/rust_src/src/chartable.rs
+++ b/rust_src/src/chartable.rs
@@ -5,7 +5,7 @@ use std::ptr;
 use libc;
 
 use remacs_macros::lisp_fn;
-use remacs_sys::{ChartabSize, Lisp_Char_Table, Lisp_Object, Lisp_Sub_Char_Table, Lisp_Type};
+use remacs_sys::{ChartabSize, Lisp_Char_Table, Lisp_Sub_Char_Table, Lisp_Type};
 use remacs_sys::PSEUDOVECTOR_SIZE_MASK;
 use remacs_sys::Qchar_code_property_table;
 use remacs_sys::uniprop_table_uncompress;
@@ -100,7 +100,7 @@ impl LispSubCharTableAsciiRef {
     }
 
     fn _get(self, idx: isize) -> LispObject {
-        let tmp = &self.0.contents as *const [Lisp_Object; 1] as *const LispObject;
+        let tmp = &self.0.contents as *const [LispObject; 1] as *const LispObject;
         unsafe { ptr::read(tmp.offset(idx)) }
     }
 
@@ -115,7 +115,7 @@ impl LispSubCharTableRef {
     }
 
     fn _get(self, idx: isize) -> LispObject {
-        let tmp = &self.contents as *const [Lisp_Object; 1] as *const LispObject;
+        let tmp = &self.contents as *const [LispObject; 1] as *const LispObject;
         unsafe { ptr::read(tmp.offset(idx)) }
     }
 

--- a/rust_src/src/editfns.rs
+++ b/rust_src/src/editfns.rs
@@ -366,8 +366,6 @@ pub fn propertize(args: &[LispObject]) -> LispObject {
 
     let copy = LispObject::from_raw(unsafe { Fcopy_sequence(first.to_raw()) });
 
-    // this is a C style Lisp_Object because that is what Fcons expects and returns.
-    // Once Fcons is ported to Rust this can be migrated to a LispObject.
     let mut properties = Qnil;
 
     while let Some(a) = it.next() {

--- a/rust_src/src/eval.rs
+++ b/rust_src/src/eval.rs
@@ -1,7 +1,7 @@
 //! Generic Lisp eval functions
 
 use remacs_macros::lisp_fn;
-use remacs_sys::{EmacsInt, Lisp_Object, PseudovecType};
+use remacs_sys::{EmacsInt, PseudovecType};
 use remacs_sys::{Fapply, Fcons, Fdefault_value, Ffset, Ffuncall, Fload, Fpurecopy, Fset,
                  Fset_default};
 use remacs_sys::{QCdocumentation, Qautoload, Qclosure, Qerror, Qfunction, Qinteractive,
@@ -122,7 +122,7 @@ pub fn progn(body: LispObject) -> LispObject {
 
 /// Evaluate BODY sequentially, discarding its value.
 #[no_mangle]
-pub extern "C" fn prog_ignore(body: Lisp_Object) {
+pub extern "C" fn prog_ignore(body: LispObject) {
     progn(LispObject::from_raw(body));
 }
 
@@ -341,7 +341,7 @@ pub fn defconst(args: LispObject) -> LispSymbolRef {
 // ((a 1)) -> (a, 1)
 // ((a)) -> (a, nil)
 // ((a (* 5 (+ 2 1)))) -> (a, 15)
-fn let_binding_value(obj: LispObject) -> (LispObject, Lisp_Object) {
+fn let_binding_value(obj: LispObject) -> (LispObject, LispObject) {
     if obj.is_symbol() {
         (obj, Qnil)
     } else {
@@ -589,7 +589,7 @@ pub fn eval(form: LispObject, lexical: LispObject) -> LispObject {
 
 /// Apply fn to arg.
 #[no_mangle]
-pub extern "C" fn apply1(mut func: Lisp_Object, arg: Lisp_Object) -> Lisp_Object {
+pub extern "C" fn apply1(mut func: LispObject, arg: LispObject) -> LispObject {
     if arg == Qnil {
         unsafe { Ffuncall(1, &mut func) }
     } else {
@@ -737,7 +737,7 @@ pub fn functionp_lisp(object: LispObject) -> bool {
 }
 
 #[no_mangle]
-pub extern "C" fn FUNCTIONP(object: Lisp_Object) -> bool {
+pub extern "C" fn FUNCTIONP(object: LispObject) -> bool {
     let mut obj = LispObject::from_raw(object);
 
     if let Some(sym) = obj.as_symbol() {
@@ -776,7 +776,7 @@ pub extern "C" fn FUNCTIONP(object: Lisp_Object) -> bool {
     }
 }
 
-pub unsafe extern "C" fn un_autoload(oldqueue: Lisp_Object) {
+pub unsafe extern "C" fn un_autoload(oldqueue: LispObject) {
     // Queue to unwind is current value of Vautoload_queue.
     // oldqueue is the shadowed value to leave in Vautoload_queue.
     let queue = Vautoload_queue;
@@ -917,14 +917,14 @@ pub fn run_hook_with_args(args: &mut [LispObject]) -> LispObject {
 }
 
 fn funcall_nil(args: &[LispObject]) -> LispObject {
-    let mut obj_array: Vec<Lisp_Object> = args.iter().map(|o| o.to_raw()).collect();
+    let mut obj_array: Vec<LispObject> = args.iter().map(|o| o.to_raw()).collect();
     unsafe { Ffuncall(obj_array.len() as isize, obj_array.as_mut_ptr()) };
     LispObject::constant_nil()
 }
 
 /// Run the hook HOOK, giving each function no args.
 #[no_mangle]
-pub extern "C" fn run_hook(hook: Lisp_Object) -> () {
+pub extern "C" fn run_hook(hook: LispObject) -> () {
     run_hook_with_args(&mut [LispObject::from_raw(hook)]);
 }
 

--- a/rust_src/src/eval_macros.rs
+++ b/rust_src/src/eval_macros.rs
@@ -132,7 +132,7 @@ macro_rules! def_lisp_sym {
 #[allow(unused_macros)]
 macro_rules! declare_GC_protected_static {
     ($var: ident, $value: expr) => {
-        static mut $var: Lisp_Object = $value;
+        static mut $var: LispObject = $value;
     }
 }
 

--- a/rust_src/src/ffi.rs
+++ b/rust_src/src/ffi.rs
@@ -1,5 +1,5 @@
 //! Module that is used for FFI exports.These calls should NOT be used in Rust directly.
-use remacs_sys::{Lisp_Object, Lisp_Window};
+use remacs_sys::Lisp_Window;
 
 use data;
 use keyboard;
@@ -9,12 +9,12 @@ use math;
 use windows;
 
 #[no_mangle]
-pub extern "C" fn circular_list(obj: Lisp_Object) -> ! {
+pub extern "C" fn circular_list(obj: LispObject) -> ! {
     lists::circular_list(LispObject::from_raw(obj))
 }
 
 #[no_mangle]
-pub extern "C" fn merge(l1: Lisp_Object, l2: Lisp_Object, pred: Lisp_Object) -> Lisp_Object {
+pub extern "C" fn merge(l1: LispObject, l2: LispObject, pred: LispObject) -> LispObject {
     let result = lists::merge(
         LispObject::from_raw(l1),
         LispObject::from_raw(l2),
@@ -24,17 +24,17 @@ pub extern "C" fn merge(l1: Lisp_Object, l2: Lisp_Object, pred: Lisp_Object) -> 
 }
 
 #[no_mangle]
-pub extern "C" fn indirect_function(object: Lisp_Object) -> Lisp_Object {
+pub extern "C" fn indirect_function(object: LispObject) -> LispObject {
     let result = data::indirect_function(LispObject::from_raw(object));
     result.to_raw()
 }
 
 #[no_mangle]
 pub extern "C" fn arithcompare(
-    obj1: Lisp_Object,
-    obj2: Lisp_Object,
+    obj1: LispObject,
+    obj2: LispObject,
     comparison: math::ArithComparison,
-) -> Lisp_Object {
+) -> LispObject {
     let result = math::arithcompare(
         LispObject::from_raw(obj1),
         LispObject::from_raw(obj2),
@@ -44,7 +44,7 @@ pub extern "C" fn arithcompare(
 }
 
 #[no_mangle]
-pub extern "C" fn lucid_event_type_list_p(event: Lisp_Object) -> bool {
+pub extern "C" fn lucid_event_type_list_p(event: LispObject) -> bool {
     keyboard::lucid_event_type_list_p(LispObject::from_raw(event).as_cons())
 }
 

--- a/rust_src/src/floatfns.rs
+++ b/rust_src/src/floatfns.rs
@@ -7,8 +7,7 @@ use libc;
 
 use libm;
 use remacs_macros::lisp_fn;
-use remacs_sys::{EmacsDouble, EmacsInt, EmacsUint, Lisp_Object, MOST_NEGATIVE_FIXNUM,
-                 MOST_POSITIVE_FIXNUM};
+use remacs_sys::{EmacsDouble, EmacsInt, EmacsUint, MOST_NEGATIVE_FIXNUM, MOST_POSITIVE_FIXNUM};
 use remacs_sys::{Qarith_error, Qinteger_or_marker_p, Qnumberp, Qrange_error};
 
 use lisp::{LispNumber, LispObject};
@@ -18,8 +17,7 @@ use math::ArithOp;
 /// Either extracts a floating point number from a lisp number (of any kind) or throws an error
 /// TODO this is used from C in a few places; remove afterwards.
 #[no_mangle]
-pub extern "C" fn extract_float(f: Lisp_Object) -> EmacsDouble {
-    let f = LispObject::from_raw(f);
+pub extern "C" fn extract_float(f: LispObject) -> EmacsDouble {
     f.any_to_float_or_error()
 }
 

--- a/rust_src/src/fns.rs
+++ b/rust_src/src/fns.rs
@@ -282,7 +282,7 @@ pub fn concat(args: &mut [LispObject]) -> LispObject {
     LispObject::from_raw(unsafe {
         lisp_concat(
             args.len() as isize,
-            args.as_mut_ptr() as *mut Lisp_Object,
+            args.as_mut_ptr() as *mut LispObject,
             Lisp_Type::Lisp_String,
             false,
         )

--- a/rust_src/src/fns.rs
+++ b/rust_src/src/fns.rs
@@ -2,7 +2,7 @@
 
 use remacs_macros::lisp_fn;
 use remacs_sys::{Fcons, Fload, Fmapc};
-use remacs_sys::{Lisp_Object, Lisp_Type};
+use remacs_sys::{LispObject, Lisp_Type};
 use remacs_sys::{Qfuncall, Qlistp, Qnil, Qprovide, Qquote, Qrequire, Qsubfeatures, Qt,
                  Qwrong_number_of_arguments};
 use remacs_sys::{concat as lisp_concat, globals, record_unwind_protect, unbind_to};
@@ -266,7 +266,7 @@ pub fn append(args: &mut [LispObject]) -> LispObject {
     LispObject::from_raw(unsafe {
         lisp_concat(
             args.len() as isize,
-            args.as_mut_ptr() as *mut Lisp_Object,
+            args.as_mut_ptr() as *mut LispObject,
             Lisp_Type::Lisp_Cons,
             true,
         )

--- a/rust_src/src/fns.rs
+++ b/rust_src/src/fns.rs
@@ -2,10 +2,10 @@
 
 use remacs_macros::lisp_fn;
 use remacs_sys::{Fcons, Fload, Fmapc};
-use remacs_sys::{LispObject, Lisp_Type};
 use remacs_sys::{Qfuncall, Qlistp, Qnil, Qprovide, Qquote, Qrequire, Qsubfeatures, Qt,
                  Qwrong_number_of_arguments};
 use remacs_sys::{concat as lisp_concat, globals, record_unwind_protect, unbind_to};
+use remacs_sys::Lisp_Type;
 use remacs_sys::Vautoload_queue;
 
 use eval::un_autoload;

--- a/rust_src/src/fns.rs
+++ b/rust_src/src/fns.rs
@@ -9,7 +9,8 @@ use remacs_sys::{concat as lisp_concat, globals, record_unwind_protect, unbind_t
 use remacs_sys::Vautoload_queue;
 
 use eval::un_autoload;
-use lisp::{LispCons, LispObject};
+use lisp::LispCons;
+use lisp::LispObject;
 use lisp::defsubr;
 use lists::{assq, car, get, member, memq, put};
 use obarray::loadhist_attach;
@@ -115,7 +116,7 @@ pub fn quote(args: LispCons) -> LispObject {
 
 declare_GC_protected_static!(require_nesting_list, Qnil);
 
-unsafe extern "C" fn require_unwind(old_value: Lisp_Object) {
+unsafe extern "C" fn require_unwind(old_value: LispObject) {
     require_nesting_list = old_value;
 }
 

--- a/rust_src/src/functions.rs
+++ b/rust_src/src/functions.rs
@@ -19,10 +19,10 @@ pub static mut lispsym: EmacsInt = 0;
 
 #[mock]
 extern "C" {
-    pub fn Fcons(car: Lisp_Object, cdr: Lisp_Object) -> Lisp_Object;
-    pub fn Fsignal(error_symbol: Lisp_Object, data: Lisp_Object);
-    pub fn make_string(s: *const c_char, length: ptrdiff_t) -> Lisp_Object;
-    pub fn make_unibyte_string(s: *const c_char, length: ptrdiff_t) -> Lisp_Object;
+    pub fn Fcons(car: LispObject, cdr: LispObject) -> LispObject;
+    pub fn Fsignal(error_symbol: LispObject, data: LispObject);
+    pub fn make_string(s: *const c_char, length: ptrdiff_t) -> LispObject;
+    pub fn make_unibyte_string(s: *const c_char, length: ptrdiff_t) -> LispObject;
 }
 
 macro_rules! mock_float {

--- a/rust_src/src/functions.rs
+++ b/rust_src/src/functions.rs
@@ -9,8 +9,11 @@
 /// This module is only for testing, and you should add all
 /// definitions to remacs-sys first and foremost.
 use libc::*;
+
 use mock_derive::mock;
 use remacs_sys::*;
+
+use lisp::LispObject;
 
 // The linker needs the symbol "lispsym" to exist, since certain
 // codepaths lead to it's usage.

--- a/rust_src/src/keymap.rs
+++ b/rust_src/src/keymap.rs
@@ -6,8 +6,7 @@ use std::ptr;
 use libc::c_void;
 
 use remacs_macros::lisp_fn;
-use remacs_sys::{current_global_map as _current_global_map, globals, EmacsInt, Lisp_Object,
-                 CHAR_META};
+use remacs_sys::{current_global_map as _current_global_map, globals, EmacsInt, CHAR_META};
 use remacs_sys::{Fcons, Fevent_convert_list, Ffset, Fmake_char_table, Fpurecopy, Fset};
 use remacs_sys::{Qautoload, Qkeymap, Qkeymapp, Qnil, Qt};
 use remacs_sys::{access_keymap, make_save_funcptr_ptr_obj, map_char_table, map_keymap_call,
@@ -31,13 +30,13 @@ declare_GC_protected_static!(where_is_cache, Qnil);
 
 /// Allows the C code to get the value of `where_is_cache`
 #[no_mangle]
-pub extern "C" fn get_where_is_cache() -> Lisp_Object {
+pub extern "C" fn get_where_is_cache() -> LispObject {
     unsafe { where_is_cache }
 }
 
 /// Allows the C code to set the value of `where_is_cache`
 #[no_mangle]
-pub extern "C" fn set_where_is_cache(val: Lisp_Object) {
+pub extern "C" fn set_where_is_cache(val: LispObject) {
     unsafe {
         where_is_cache = val;
     }
@@ -48,13 +47,13 @@ declare_GC_protected_static!(where_is_cache_keymaps, Qt);
 
 /// Allows the C code to get the value of `where_is_cache_keymaps`
 #[no_mangle]
-pub extern "C" fn get_where_is_cache_keymaps() -> Lisp_Object {
+pub extern "C" fn get_where_is_cache_keymaps() -> LispObject {
     unsafe { where_is_cache_keymaps }
 }
 
 /// Allows the C code to set the value of `where_is_cache_keymaps`
 #[no_mangle]
-pub extern "C" fn set_where_is_cache_keymaps(val: Lisp_Object) {
+pub extern "C" fn set_where_is_cache_keymaps(val: LispObject) {
     unsafe {
         where_is_cache_keymaps = val;
     }
@@ -81,10 +80,10 @@ pub extern "C" fn set_where_is_cache_keymaps(val: Lisp_Object) {
 /// `Fautoload_do_load` which can GC.
 #[no_mangle]
 pub extern "C" fn get_keymap(
-    object: Lisp_Object,
+    object: LispObject,
     error_if_not_keymap: bool,
     autoload: bool,
-) -> Lisp_Object {
+) -> LispObject {
     let object = LispObject::from_raw(object);
 
     let mut autoload_retry = true;
@@ -168,7 +167,7 @@ pub fn keymapp(object: LispObject) -> bool {
 /// Return the parent map of KEYMAP, or nil if it has none.
 /// We assume that KEYMAP is a valid keymap.
 #[no_mangle]
-pub extern "C" fn keymap_parent(keymap: Lisp_Object, autoload: bool) -> Lisp_Object {
+pub extern "C" fn keymap_parent(keymap: LispObject, autoload: bool) -> LispObject {
     let map = LispObject::from_raw(get_keymap(keymap, true, autoload));
     let mut current = LispObject::constant_nil();
     for elt in map.iter_tails_safe() {
@@ -189,7 +188,7 @@ pub fn keymap_parent_lisp(keymap: LispObject) -> LispObject {
 
 /// Check whether MAP is one of MAPS parents.
 #[no_mangle]
-pub extern "C" fn keymap_memberp(map: Lisp_Object, maps: Lisp_Object) -> bool {
+pub extern "C" fn keymap_memberp(map: LispObject, maps: LispObject) -> bool {
     let map = LispObject::from_raw(map);
     let mut maps = LispObject::from_raw(maps);
     if map.is_nil() {
@@ -269,9 +268,9 @@ pub fn keymap_prompt(map: LispObject) -> LispObject {
 /// AUTOLOAD indicates that autoloaded keymaps should be loaded.
 #[no_mangle]
 pub extern "C" fn map_keymap(
-    map: Lisp_Object,
+    map: LispObject,
     fun: map_keymap_function_t,
-    args: Lisp_Object,
+    args: LispObject,
     data: *const c_void,
     autoload: bool,
 ) {
@@ -320,11 +319,11 @@ pub fn map_keymap_lisp(function: LispObject, keymap: LispObject, sort_first: boo
 /// FUN is called with 4 arguments: FUN (KEY, BINDING, ARGS, DATA).
 #[no_mangle]
 pub extern "C" fn map_keymap_internal(
-    map: Lisp_Object,
+    map: LispObject,
     fun: map_keymap_function_t,
-    args: Lisp_Object,
+    args: LispObject,
     data: *const c_void,
-) -> Lisp_Object {
+) -> LispObject {
     let map = LispObject::from_raw(map);
     let tail = match map.as_cons() {
         None => LispObject::constant_nil(),

--- a/rust_src/src/marker.rs
+++ b/rust_src/src/marker.rs
@@ -5,7 +5,7 @@ use std::mem;
 use std::ptr;
 
 use remacs_macros::lisp_fn;
-use remacs_sys::{BoolBF, EmacsInt, Lisp_Buffer, Lisp_Marker, Lisp_Object};
+use remacs_sys::{BoolBF, EmacsInt, Lisp_Buffer, Lisp_Marker};
 use remacs_sys::{buf_charpos_to_bytepos, mget_buffer, mget_bytepos, mget_charpos,
                  mget_insertion_type, mget_next_marker, mset_buffer, mset_insertion_type,
                  mset_next_marker, set_marker_internal, set_point_both, unchain_marker,
@@ -134,7 +134,7 @@ pub fn marker_buffer(marker: LispMarkerRef) -> Option<LispBufferRef> {
 
 /// Set PT from MARKER's clipped position.
 #[no_mangle]
-pub extern "C" fn set_point_from_marker(marker: Lisp_Object) {
+pub extern "C" fn set_point_from_marker(marker: LispObject) {
     let marker = LispObject::from_raw(marker).as_marker_or_error();
     let cur_buf = ThreadState::current_buffer();
     let charpos = clip_to_bounds(
@@ -270,10 +270,10 @@ pub extern "C" fn attach_marker(
 /// Like set-marker, but won't let the position be outside the visible part.
 #[no_mangle]
 pub extern "C" fn set_marker_restricted(
-    marker: Lisp_Object,
-    position: Lisp_Object,
-    buffer: Lisp_Object,
-) -> Lisp_Object {
+    marker: LispObject,
+    position: LispObject,
+    buffer: LispObject,
+) -> LispObject {
     unsafe { set_marker_internal(marker, position, buffer, true) }
 }
 
@@ -281,11 +281,11 @@ pub extern "C" fn set_marker_restricted(
 /// character position and the corresponding byte position.
 #[no_mangle]
 pub extern "C" fn set_marker_both(
-    marker: Lisp_Object,
-    buffer: Lisp_Object,
+    marker: LispObject,
+    buffer: LispObject,
     charpos: ptrdiff_t,
     bytepos: ptrdiff_t,
-) -> Lisp_Object {
+) -> LispObject {
     let mut m = LispObject::from_raw(marker).as_marker_or_error();
     let b = live_buffer(buffer);
     if !b.is_null() {
@@ -299,11 +299,11 @@ pub extern "C" fn set_marker_both(
 /// Like set_marker_both, but won't let the position be outside the visible part.
 #[no_mangle]
 pub extern "C" fn set_marker_restricted_both(
-    marker: Lisp_Object,
-    buffer: Lisp_Object,
+    marker: LispObject,
+    buffer: LispObject,
     charpos: ptrdiff_t,
     bytepos: ptrdiff_t,
-) -> Lisp_Object {
+) -> LispObject {
     let mut m = LispObject::from_raw(marker).as_marker_or_error();
     let b = live_buffer(buffer);
 
@@ -325,14 +325,14 @@ pub extern "C" fn set_marker_restricted_both(
 // use charpos_or_error and bytepos_or_error in rust.
 /// Return the char position of marker MARKER, as a C integer.
 #[no_mangle]
-pub extern "C" fn marker_position(marker: Lisp_Object) -> ptrdiff_t {
+pub extern "C" fn marker_position(marker: LispObject) -> ptrdiff_t {
     let m = LispObject::from_raw(marker).as_marker_or_error();
     m.charpos_or_error()
 }
 
 /// Return the byte position of marker MARKER, as a C integer.
 #[no_mangle]
-pub extern "C" fn marker_byte_position(marker: Lisp_Object) -> ptrdiff_t {
+pub extern "C" fn marker_byte_position(marker: LispObject) -> ptrdiff_t {
     let m = LispObject::from_raw(marker).as_marker_or_error();
     m.bytepos_or_error()
 }
@@ -341,7 +341,7 @@ pub extern "C" fn marker_byte_position(marker: Lisp_Object) -> ptrdiff_t {
 /// whether BUFFER is a buffer object and return buffer pointer
 /// corresponding to BUFFER if BUFFER is live, or NULL otherwise.
 #[no_mangle]
-pub extern "C" fn live_buffer(buffer: Lisp_Object) -> *mut Lisp_Buffer {
+pub extern "C" fn live_buffer(buffer: LispObject) -> *mut Lisp_Buffer {
     let mut b = LispObject::from_raw(buffer).as_buffer_or_current_buffer();
     if b.is_live() {
         b.as_mut()

--- a/rust_src/src/obarray.rs
+++ b/rust_src/src/obarray.rs
@@ -5,7 +5,6 @@ use remacs_macros::lisp_fn;
 use remacs_sys::{Fcons, Fmake_symbol, Fpurecopy};
 use remacs_sys::{fatal_error_in_progress, globals, initial_obarray, initialized, intern_sym,
                  make_pure_c_string, make_unibyte_string, oblookup};
-use remacs_sys::Lisp_Object;
 use remacs_sys::Qvectorp;
 
 use lisp::LispObject;
@@ -79,7 +78,7 @@ pub fn intern<T: AsRef<str>>(string: T) -> LispObject {
 }
 
 #[no_mangle]
-pub extern "C" fn loadhist_attach(x: Lisp_Object) {
+pub extern "C" fn loadhist_attach(x: LispObject) {
     unsafe {
         if initialized {
             globals.f_Vcurrent_load_list = Fcons(x, globals.f_Vcurrent_load_list);
@@ -90,7 +89,7 @@ pub extern "C" fn loadhist_attach(x: Lisp_Object) {
 /// Get an error if OBARRAY is not an obarray.
 /// If it is one, return it.
 #[no_mangle]
-pub extern "C" fn check_obarray(obarray: Lisp_Object) -> Lisp_Object {
+pub extern "C" fn check_obarray(obarray: LispObject) -> LispObject {
     // We don't want to signal a wrong-type error when we are shutting
     // down due to a fatal error and we don't want to hit assertions
     // if the fatal error was during GC.
@@ -113,9 +112,9 @@ pub extern "C" fn check_obarray(obarray: Lisp_Object) -> Lisp_Object {
 
 #[no_mangle]
 pub extern "C" fn map_obarray(
-    obarray: Lisp_Object,
-    func: extern "C" fn(Lisp_Object, Lisp_Object),
-    arg: Lisp_Object,
+    obarray: LispObject,
+    func: extern "C" fn(LispObject, LispObject),
+    arg: LispObject,
 ) {
     let v = LispObject::from_raw(obarray).as_vector_or_error();
     for item in v.iter().rev() {
@@ -130,7 +129,7 @@ pub extern "C" fn map_obarray(
 /// Intern the C string `s`: return a symbol with that name, interned in the
 /// current obarray.
 #[no_mangle]
-pub extern "C" fn intern_1(s: *const libc::c_char, len: libc::ptrdiff_t) -> Lisp_Object {
+pub extern "C" fn intern_1(s: *const libc::c_char, len: libc::ptrdiff_t) -> LispObject {
     let obarray = LispObarrayRef::global().as_lisp_obj().to_raw();
     let tem = LispObject::from_raw(unsafe { oblookup(obarray, s, len, len) });
 
@@ -150,7 +149,7 @@ pub extern "C" fn intern_1(s: *const libc::c_char, len: libc::ptrdiff_t) -> Lisp
 /// Intern the C string STR: return a symbol with that name,
 /// interned in the current obarray.
 #[no_mangle]
-pub extern "C" fn intern_c_string_1(s: *const libc::c_char, len: libc::ptrdiff_t) -> Lisp_Object {
+pub extern "C" fn intern_c_string_1(s: *const libc::c_char, len: libc::ptrdiff_t) -> LispObject {
     let obarray = LispObarrayRef::global().as_lisp_obj().to_raw();
     let tem = LispObject::from_raw(unsafe { oblookup(obarray, s, len, len) });
 
@@ -167,10 +166,10 @@ pub extern "C" fn intern_c_string_1(s: *const libc::c_char, len: libc::ptrdiff_t
 /// Intern a symbol with name STRING in OBARRAY using bucket INDEX.
 #[no_mangle]
 pub extern "C" fn intern_driver(
-    string: Lisp_Object,
-    obarray: Lisp_Object,
-    index: Lisp_Object,
-) -> Lisp_Object {
+    string: LispObject,
+    obarray: LispObject,
+    index: LispObject,
+) -> LispObject {
     unsafe { intern_sym(Fmake_symbol(string), obarray, index) }
 }
 
@@ -201,7 +200,7 @@ pub fn lisp_intern(string: LispObject, obarray: Option<LispObarrayRef>) -> LispO
     obarray.intern(string)
 }
 
-extern "C" fn mapatoms_1(sym: Lisp_Object, function: Lisp_Object) {
+extern "C" fn mapatoms_1(sym: LispObject, function: LispObject) {
     call_raw!(function, sym);
 }
 

--- a/rust_src/src/remacs_sys.rs
+++ b/rust_src/src/remacs_sys.rs
@@ -20,32 +20,11 @@ extern crate std;
 
 use libc::{c_char, c_double, c_float, c_int, c_short, c_uchar, c_void, intmax_t, off_t, ptrdiff_t,
            size_t, time_t, timespec};
+use lisp::LispObject;
 
 // libc prefers not to merge pid_t as an alias for c_int in Windows, so we will not use libc::pid_t
 // and alias it ourselves.
 pub type pid_t = libc::c_int;
-
-#[repr(transparent)]
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub struct Lisp_Object(EmacsInt);
-
-impl Lisp_Object {
-    pub fn from_C(n: EmacsInt) -> Lisp_Object {
-        Lisp_Object(n)
-    }
-
-    pub fn from_C_unsigned(n: EmacsUint) -> Lisp_Object {
-        Self::from_C(n as EmacsInt)
-    }
-
-    pub fn to_C(self) -> EmacsInt {
-        self.0
-    }
-
-    pub fn to_C_unsigned(self) -> EmacsUint {
-        self.0 as EmacsUint
-    }
-}
 
 include!(concat!(env!("OUT_DIR"), "/definitions.rs"));
 include!(concat!(env!("OUT_DIR"), "/globals.rs"));
@@ -70,7 +49,7 @@ pub const PSEUDOVECTOR_REST_MASK: ptrdiff_t =
 pub const PSEUDOVECTOR_AREA_BITS: ptrdiff_t = PSEUDOVECTOR_SIZE_BITS + PSEUDOVECTOR_REST_BITS;
 pub const PVEC_TYPE_MASK: ptrdiff_t = 0x3f << PSEUDOVECTOR_AREA_BITS;
 
-// Number of bits in a Lisp_Object tag.
+// Number of bits in a LispObject tag.
 pub const VALBITS: EmacsInt = EMACS_INT_SIZE * 8 - GCTYPEBITS;
 pub const INTTYPEBITS: EmacsInt = GCTYPEBITS - 1;
 pub const FIXNUM_BITS: EmacsInt = VALBITS + 1;
@@ -253,7 +232,7 @@ pub const SYMBOL_FORWARDED: symbol_redirect = 3;
 
 #[repr(C)]
 pub union SymbolUnion {
-    pub value: Lisp_Object,
+    pub value: LispObject,
     pub alias: *mut Lisp_Symbol,
     pub blv: *mut Lisp_Buffer_Local_Value,
     pub fwd: *mut Lisp_Fwd,
@@ -265,10 +244,10 @@ pub union SymbolUnion {
 #[repr(C)]
 pub struct Lisp_Symbol {
     _padding: BitfieldPadding,
-    pub name: Lisp_Object,
+    pub name: LispObject,
     pub val: SymbolUnion,
-    pub function: Lisp_Object,
-    pub plist: Lisp_Object,
+    pub function: LispObject,
+    pub plist: LispObject,
     pub next: *mut Lisp_Symbol,
 }
 
@@ -287,17 +266,17 @@ extern "C" {
   of slots) of the vector.
 - If PSEUDOVECTOR_FLAG is 1, the rest is subdivided into three fields:
   - a) pseudovector subtype held in PVEC_TYPE_MASK field;
-  - b) number of Lisp_Objects slots at the beginning of the object
+  - b) number of LispObjects slots at the beginning of the object
     held in PSEUDOVECTOR_SIZE_MASK field.  These objects are always
     traced by the GC;
   - c) size of the rest fields held in PSEUDOVECTOR_REST_MASK and
     measured in word_size units.  Rest fields may also include
-    Lisp_Objects, but these objects usually needs some special treatment
+    LispObjects, but these objects usually needs some special treatment
     during GC.
   There are some exceptions.  For PVEC_FREE, b) is always zero.  For
   PVEC_BOOL_VECTOR and PVEC_SUBR, both b) and c) are always zero.
   Current layout limits the pseudovectors to 63 PVEC_xxx subtypes,
-  4095 Lisp_Objects in GC-ed area and 4095 word-sized other slots.  */
+  4095 LispObjects in GC-ed area and 4095 word-sized other slots.  */
 
 #[repr(C)]
 pub struct Lisp_Vectorlike_Header {
@@ -314,7 +293,7 @@ pub struct Lisp_Vectorlike {
 pub struct Lisp_Vector {
     pub header: Lisp_Vectorlike_Header,
     // actually any number of items... not sure how to express this
-    pub contents: [Lisp_Object; 1],
+    pub contents: [LispObject; 1],
 }
 
 // No C equivalent.  Generic type for a vectorlike with one or more
@@ -323,7 +302,7 @@ pub struct Lisp_Vector {
 pub struct Lisp_Vectorlike_With_Slots {
     pub header: Lisp_Vectorlike_Header,
     // actually any number of items... not sure how to express this
-    pub contents: [Lisp_Object; 1],
+    pub contents: [LispObject; 1],
 }
 
 #[repr(C)]
@@ -362,9 +341,9 @@ pub struct Lisp_Misc_Any {
 pub type Lisp_Fwd_Type = u32;
 pub const Lisp_Fwd_Int: Lisp_Fwd_Type = 0; // Fwd to a C `int' variable.
 pub const Lisp_Fwd_Bool: Lisp_Fwd_Type = 1; // Fwd to a C boolean var.
-pub const Lisp_Fwd_Obj: Lisp_Fwd_Type = 2; // Fwd to a C Lisp_Object variable.
-pub const Lisp_Fwd_Buffer_Obj: Lisp_Fwd_Type = 3; // Fwd to a Lisp_Object field of buffers.
-pub const Lisp_Fwd_Kboard_Obj: Lisp_Fwd_Type = 4; // Fwd to a Lisp_Object field of kboards.
+pub const Lisp_Fwd_Obj: Lisp_Fwd_Type = 2; // Fwd to a C LispObject variable.
+pub const Lisp_Fwd_Buffer_Obj: Lisp_Fwd_Type = 3; // Fwd to a LispObject field of buffers.
+pub const Lisp_Fwd_Kboard_Obj: Lisp_Fwd_Type = 4; // Fwd to a LispObject field of kboards.
 
 // TODO: write a docstring based on the docs in lisp.h.
 #[repr(C)]
@@ -393,9 +372,9 @@ extern "C" {
 pub struct Lisp_Overlay {
     _padding: BitfieldPadding,
     pub next: *const Lisp_Overlay,
-    pub start: Lisp_Object,
-    pub end: Lisp_Object,
-    pub plist: Lisp_Object,
+    pub start: LispObject,
+    pub end: LispObject,
+    pub plist: LispObject,
 }
 
 /// Represents the cursor position within an Emacs window. For
@@ -433,7 +412,7 @@ pub struct glyph {
     /// a buffer or a string; or nil if the glyph was inserted by
     /// redisplay for its own purposes, such as padding, truncation, or
     /// continuation glyphs, or the overlay-arrow glyphs on TTYs.
-    object: Lisp_Object,
+    object: LispObject,
 
     /// Width in pixels.
     pixel_width: i16,
@@ -531,33 +510,33 @@ pub const BASIC_FACE_ID_SENTINEL: face_id = 16;
 #[repr(C)]
 pub struct Lisp_Window {
     pub header: Lisp_Vectorlike_Header,
-    pub frame: Lisp_Object,
-    pub next: Lisp_Object,
-    pub prev: Lisp_Object,
-    pub parent: Lisp_Object,
-    pub normal_lines: Lisp_Object,
-    pub normal_cols: Lisp_Object,
-    pub new_total: Lisp_Object,
-    pub new_normal: Lisp_Object,
-    pub new_pixel: Lisp_Object,
-    pub contents: Lisp_Object,
-    pub start: Lisp_Object,
-    pub pointm: Lisp_Object,
-    pub old_pointm: Lisp_Object,
-    pub temslot: Lisp_Object,
-    pub vertical_scroll_bar: Lisp_Object,
-    pub vertical_scroll_bar_type: Lisp_Object,
-    pub horizontal_scroll_bar: Lisp_Object,
-    pub horizontal_scroll_bar_type: Lisp_Object,
-    pub display_table: Lisp_Object,
-    pub dedicated: Lisp_Object,
-    pub redisplay_end_trigger: Lisp_Object,
-    pub combination_limit: Lisp_Object,
-    pub window_parameters: Lisp_Object,
+    pub frame: LispObject,
+    pub next: LispObject,
+    pub prev: LispObject,
+    pub parent: LispObject,
+    pub normal_lines: LispObject,
+    pub normal_cols: LispObject,
+    pub new_total: LispObject,
+    pub new_normal: LispObject,
+    pub new_pixel: LispObject,
+    pub contents: LispObject,
+    pub start: LispObject,
+    pub pointm: LispObject,
+    pub old_pointm: LispObject,
+    pub temslot: LispObject,
+    pub vertical_scroll_bar: LispObject,
+    pub vertical_scroll_bar_type: LispObject,
+    pub horizontal_scroll_bar: LispObject,
+    pub horizontal_scroll_bar_type: LispObject,
+    pub display_table: LispObject,
+    pub dedicated: LispObject,
+    pub redisplay_end_trigger: LispObject,
+    pub combination_limit: LispObject,
+    pub window_parameters: LispObject,
     pub current_matrix: *mut c_void,
     pub desired_matrix: *mut c_void,
-    pub prev_buffers: Lisp_Object,
-    pub next_buffers: Lisp_Object,
+    pub prev_buffers: LispObject,
+    pub next_buffers: LispObject,
     pub use_time: EmacsInt,
     pub sequence_number: EmacsInt,
     pub pixel_left: c_int,
@@ -608,13 +587,13 @@ pub struct Lisp_Window {
 extern "C" {
     pub fn wget_current_matrix(w: *const Lisp_Window) -> *mut glyph_matrix;
     pub fn wget_mode_line_height(w: *const Lisp_Window) -> c_int;
-    pub fn wget_parent(w: *const Lisp_Window) -> Lisp_Object;
+    pub fn wget_parent(w: *const Lisp_Window) -> LispObject;
     pub fn wget_pixel_height(w: *const Lisp_Window) -> c_int;
     pub fn wget_pseudo_window_p(w: *const Lisp_Window) -> bool;
 
     pub fn wset_mode_line_height(w: *mut Lisp_Window, height: c_int);
 
-    pub fn window_parameter(w: *const Lisp_Window, parameter: Lisp_Object) -> Lisp_Object;
+    pub fn window_parameter(w: *const Lisp_Window, parameter: LispObject) -> LispObject;
 }
 
 /// Area in window glyph matrix.  If values are added or removed,
@@ -631,79 +610,79 @@ pub const LAST_AREA: glyph_row_area = 3;
 #[repr(C)]
 pub struct Lisp_Buffer {
     pub header: Lisp_Vectorlike_Header,
-    pub name: Lisp_Object,
-    pub filename: Lisp_Object,
-    pub directory: Lisp_Object,
-    pub backed_up: Lisp_Object,
-    pub save_length: Lisp_Object,
-    pub auto_save_file_name: Lisp_Object,
-    pub read_only: Lisp_Object,
-    pub mark: Lisp_Object,
-    pub local_var_alist: Lisp_Object,
-    pub major_mode: Lisp_Object,
-    pub mode_name: Lisp_Object,
-    pub mode_line_format: Lisp_Object,
-    pub header_line_format: Lisp_Object,
-    pub keymap: Lisp_Object,
-    pub abbrev_table: Lisp_Object,
-    pub syntax_table: Lisp_Object,
-    pub category_table: Lisp_Object,
-    pub case_fold_search: Lisp_Object,
-    pub tab_width: Lisp_Object,
-    pub fill_column: Lisp_Object,
-    pub left_margin: Lisp_Object,
-    pub auto_fill_function: Lisp_Object,
-    pub downcase_table: Lisp_Object,
-    pub upcase_table: Lisp_Object,
-    pub case_canon_table: Lisp_Object,
-    pub case_eqv_table: Lisp_Object,
-    pub truncate_lines: Lisp_Object,
-    pub word_wrap: Lisp_Object,
-    pub ctl_arrow: Lisp_Object,
-    pub bidi_display_reordering: Lisp_Object,
-    pub bidi_paragraph_direction: Lisp_Object,
-    pub bidi_paragraph_separate_re: Lisp_Object,
-    pub bidi_paragraph_start_re: Lisp_Object,
-    pub selective_display: Lisp_Object,
-    pub selective_display_ellipses: Lisp_Object,
-    pub minor_modes: Lisp_Object,
-    pub overwrite_mode: Lisp_Object,
-    pub abbrev_mode: Lisp_Object,
-    pub display_table: Lisp_Object,
-    pub mark_active: Lisp_Object,
-    pub enable_multibyte_characters: Lisp_Object,
-    pub buffer_file_coding_system: Lisp_Object,
-    pub file_format: Lisp_Object,
-    pub auto_save_file_format: Lisp_Object,
-    pub cache_long_scans: Lisp_Object,
-    pub width_table: Lisp_Object,
-    pub pt_marker: Lisp_Object,
-    pub begv_marker: Lisp_Object,
-    pub zv_marker: Lisp_Object,
-    pub point_before_scroll: Lisp_Object,
-    pub file_truename: Lisp_Object,
-    pub invisibility_spec: Lisp_Object,
-    pub last_selected_window: Lisp_Object,
-    pub display_count: Lisp_Object,
-    pub left_margin_cols: Lisp_Object,
-    pub right_margin_cols: Lisp_Object,
-    pub left_fringe_width: Lisp_Object,
-    pub right_fringe_width: Lisp_Object,
-    pub fringes_outside_margins: Lisp_Object,
-    pub scroll_bar_width: Lisp_Object,
-    pub scroll_bar_height: Lisp_Object,
-    pub vertical_scroll_bar_type: Lisp_Object,
-    pub horizontal_scroll_bar_type: Lisp_Object,
-    pub indicate_empty_lines: Lisp_Object,
-    pub indicate_buffer_boundaries: Lisp_Object,
-    pub fringe_indicator_alist: Lisp_Object,
-    pub fringe_cursor_alist: Lisp_Object,
-    pub display_time: Lisp_Object,
-    pub scroll_up_aggressively: Lisp_Object,
-    pub scroll_down_aggressively: Lisp_Object,
-    pub cursor_type: Lisp_Object,
-    pub extra_line_spacing: Lisp_Object,
-    pub cursor_in_non_selected_windows: Lisp_Object,
+    pub name: LispObject,
+    pub filename: LispObject,
+    pub directory: LispObject,
+    pub backed_up: LispObject,
+    pub save_length: LispObject,
+    pub auto_save_file_name: LispObject,
+    pub read_only: LispObject,
+    pub mark: LispObject,
+    pub local_var_alist: LispObject,
+    pub major_mode: LispObject,
+    pub mode_name: LispObject,
+    pub mode_line_format: LispObject,
+    pub header_line_format: LispObject,
+    pub keymap: LispObject,
+    pub abbrev_table: LispObject,
+    pub syntax_table: LispObject,
+    pub category_table: LispObject,
+    pub case_fold_search: LispObject,
+    pub tab_width: LispObject,
+    pub fill_column: LispObject,
+    pub left_margin: LispObject,
+    pub auto_fill_function: LispObject,
+    pub downcase_table: LispObject,
+    pub upcase_table: LispObject,
+    pub case_canon_table: LispObject,
+    pub case_eqv_table: LispObject,
+    pub truncate_lines: LispObject,
+    pub word_wrap: LispObject,
+    pub ctl_arrow: LispObject,
+    pub bidi_display_reordering: LispObject,
+    pub bidi_paragraph_direction: LispObject,
+    pub bidi_paragraph_separate_re: LispObject,
+    pub bidi_paragraph_start_re: LispObject,
+    pub selective_display: LispObject,
+    pub selective_display_ellipses: LispObject,
+    pub minor_modes: LispObject,
+    pub overwrite_mode: LispObject,
+    pub abbrev_mode: LispObject,
+    pub display_table: LispObject,
+    pub mark_active: LispObject,
+    pub enable_multibyte_characters: LispObject,
+    pub buffer_file_coding_system: LispObject,
+    pub file_format: LispObject,
+    pub auto_save_file_format: LispObject,
+    pub cache_long_scans: LispObject,
+    pub width_table: LispObject,
+    pub pt_marker: LispObject,
+    pub begv_marker: LispObject,
+    pub zv_marker: LispObject,
+    pub point_before_scroll: LispObject,
+    pub file_truename: LispObject,
+    pub invisibility_spec: LispObject,
+    pub last_selected_window: LispObject,
+    pub display_count: LispObject,
+    pub left_margin_cols: LispObject,
+    pub right_margin_cols: LispObject,
+    pub left_fringe_width: LispObject,
+    pub right_fringe_width: LispObject,
+    pub fringes_outside_margins: LispObject,
+    pub scroll_bar_width: LispObject,
+    pub scroll_bar_height: LispObject,
+    pub vertical_scroll_bar_type: LispObject,
+    pub horizontal_scroll_bar_type: LispObject,
+    pub indicate_empty_lines: LispObject,
+    pub indicate_buffer_boundaries: LispObject,
+    pub fringe_indicator_alist: LispObject,
+    pub fringe_cursor_alist: LispObject,
+    pub display_time: LispObject,
+    pub scroll_up_aggressively: LispObject,
+    pub scroll_down_aggressively: LispObject,
+    pub cursor_type: LispObject,
+    pub extra_line_spacing: LispObject,
+    pub cursor_in_non_selected_windows: LispObject,
 
     pub own_text: Lisp_Buffer_Text,
     pub text: *mut Lisp_Buffer_Text,
@@ -739,7 +718,7 @@ pub struct Lisp_Buffer {
     overlays_after: *mut c_void,
     overlay_center: ptrdiff_t,
 
-    undo_list: Lisp_Object,
+    undo_list: LispObject,
 }
 
 extern "C" {
@@ -781,21 +760,21 @@ pub struct Lisp_Buffer_Local_Value {
     /// If non-NULL, a forwarding to the C var where it should also be set.
     pub fwd: *mut Lisp_Fwd, // Should never be (Buffer|Kboard)_Objfwd.
     /// The buffer or frame for which the loaded binding was found.
-    pub where_: Lisp_Object,
+    pub where_: LispObject,
     /// A cons cell that holds the default value.  It has the form
     /// (SYMBOL . DEFAULT-VALUE).
-    pub defcell: Lisp_Object,
+    pub defcell: LispObject,
     /// The cons cell from `where's parameter alist.
     /// It always has the form (SYMBOL . VALUE)
     /// Note that if `forward' is non-nil, VALUE may be out of date.
     /// Also if the currently loaded binding is the default binding, then
     /// this is `eq'ual to defcell.
-    valcell: Lisp_Object,
+    valcell: LispObject,
 }
 
 extern "C" {
     pub fn get_blv_fwd(blv: *const Lisp_Buffer_Local_Value) -> *const Lisp_Fwd;
-    pub fn get_blv_value(blv: *const Lisp_Buffer_Local_Value) -> Lisp_Object;
+    pub fn get_blv_value(blv: *const Lisp_Buffer_Local_Value) -> LispObject;
 }
 
 #[repr(C)]
@@ -829,7 +808,7 @@ pub struct Lisp_Boolfwd {
     pub boolvar: *mut bool,
 }
 
-/// Forwarding pointer to a Lisp_Object variable.
+/// Forwarding pointer to a LispObject variable.
 /// This is allowed only in the value cell of a symbol,
 /// and it means that the symbol's value really lives in the
 /// specified variable.
@@ -837,7 +816,7 @@ pub struct Lisp_Boolfwd {
 #[derive(Clone, Copy)]
 pub struct Lisp_Objfwd {
     pub ty: Lisp_Fwd_Type, // = Lisp_Fwd_Obj
-    pub objvar: *mut Lisp_Object,
+    pub objvar: *mut LispObject,
 }
 
 /// Like Lisp_Objfwd except that value lives in a slot in the
@@ -848,7 +827,7 @@ pub struct Lisp_Buffer_Objfwd {
     pub ty: Lisp_Fwd_Type, // = Lisp_Fwd_Buffer_Obj
     pub offset: i32,
     // One of Qnil, Qintegerp, Qsymbolp, Qstringp, Qfloatp or Qnumberp.
-    pub predicate: Lisp_Object,
+    pub predicate: LispObject,
 }
 
 /// Like Lisp_Objfwd except that value lives in a slot in the
@@ -918,9 +897,9 @@ pub struct Lisp_Float {
 #[repr(C)]
 pub struct Lisp_Cons {
     /// Car of this cons cell.
-    pub car: Lisp_Object,
+    pub car: LispObject,
     /// Cdr of this cons cell, or the chain used for the free list.
-    pub cdr: Lisp_Object,
+    pub cdr: LispObject,
 }
 
 /// Type of comparison for `internal_equal()`.
@@ -944,22 +923,22 @@ pub struct thread_state {
     /// The buffer in which the last search was performed, or
     /// Qt if the last search was done in a string;
     /// Qnil if no searching has been done yet.
-    pub m_last_thing_searched: Lisp_Object,
+    pub m_last_thing_searched: LispObject,
 
-    pub m_saved_last_thing_searched: Lisp_Object,
+    pub m_saved_last_thing_searched: LispObject,
     /// The thread's name.
-    pub name: Lisp_Object,
+    pub name: LispObject,
 
     /// The thread's function.
-    pub function: Lisp_Object,
+    pub function: LispObject,
 
     /// If non-nil, this thread has been signaled.
-    pub error_symbol: Lisp_Object,
-    pub error_data: Lisp_Object,
+    pub error_symbol: LispObject,
+    pub error_data: LispObject,
 
     /// If we are waiting for some event, this holds the object we are
     /// waiting on.
-    pub event_object: Lisp_Object,
+    pub event_object: LispObject,
 
     /// m_stack_bottom must be the first non-Lisp field.
     /// An address near the bottom of the stack.
@@ -1017,7 +996,7 @@ pub struct thread_state {
     /// If the value is a Lisp string object, we are matching text in that
     /// string; if it's nil, we are matching text in the current buffer; if
     /// it's t, we are matching text in a C string.
-    pub m_re_match_object: Lisp_Object,
+    pub m_re_match_object: LispObject,
     /// This member is different from waiting_for_input.
     /// It is used to communicate to a lisp process-filter/sentinel (via the
     /// function Fwaiting_for_user_input_p) whether Emacs was waiting
@@ -1059,26 +1038,26 @@ pub struct Lisp_Char_Table {
 
     /// This holds a default value,
     /// which is used whenever the value for a specific character is nil.
-    pub default: Lisp_Object,
+    pub default: LispObject,
 
     /// This points to another char table, which we inherit from when the
     /// value for a specific character is nil.  The `defalt' slot takes
     /// precedence over this.
-    pub parent: Lisp_Object,
+    pub parent: LispObject,
 
     /// This is a symbol which says what kind of use this char-table is
     /// meant for.
-    pub purpose: Lisp_Object,
+    pub purpose: LispObject,
 
     /// The bottom sub char-table for characters of the range 0..127.  It
     /// is nil if none of ASCII character has a specific value.
-    pub ascii: Lisp_Object,
+    pub ascii: LispObject,
 
-    pub contents: [Lisp_Object; 1 << ChartabSize::Bits0 as u8],
+    pub contents: [LispObject; 1 << ChartabSize::Bits0 as u8],
 
     /// These hold additional data.  It is a vector.
     // actually any number of items
-    pub extras: [Lisp_Object; 1],
+    pub extras: [LispObject; 1],
 }
 
 #[repr(C)]
@@ -1099,11 +1078,11 @@ pub struct Lisp_Sub_Char_Table {
     pub min_char: libc::c_int,
 
     /// Use set_sub_char_table_contents to set this.
-    pub contents: [Lisp_Object; 1],
+    pub contents: [LispObject; 1],
 }
 
 extern "C" {
-    pub fn uniprop_table_uncompress(table: Lisp_Object, idx: libc::c_int) -> Lisp_Object;
+    pub fn uniprop_table_uncompress(table: LispObject, idx: libc::c_int) -> LispObject;
 }
 
 #[repr(C)]
@@ -1111,42 +1090,42 @@ pub struct Lisp_Process {
     pub header: Lisp_Vectorlike_Header,
 
     /// Name of subprocess terminal.
-    pub tty_name: Lisp_Object,
+    pub tty_name: LispObject,
 
     /// Name of this process.
-    pub name: Lisp_Object,
+    pub name: LispObject,
 
     /// List of command arguments that this process was run with.
     /// Is set to t for a stopped network process; nil otherwise.
-    pub command: Lisp_Object,
+    pub command: LispObject,
 
     /// (funcall FILTER PROC STRING)  (if FILTER is non-nil)
     /// to dispose of a bunch of chars from the process all at once.
-    pub filter: Lisp_Object,
+    pub filter: LispObject,
 
     /// (funcall SENTINEL PROCESS) when process state changes.
-    pub sentinel: Lisp_Object,
+    pub sentinel: LispObject,
 
     /// (funcall LOG SERVER CLIENT MESSAGE) when a server process
     /// accepts a connection from a client.
-    pub log: Lisp_Object,
+    pub log: LispObject,
 
     /// Buffer that output is going to.
-    pub buffer: Lisp_Object,
+    pub buffer: LispObject,
 
     /// t if this is a real child process.  For a network or serial
     /// connection, it is a plist based on the arguments to
     /// make-network-process or make-serial-process.
-    pub childp: Lisp_Object,
+    pub childp: LispObject,
 
     /// Plist for programs to keep per-process state information, parameters, etc.
-    pub plist: Lisp_Object,
+    pub plist: LispObject,
 
     /// Symbol indicating the type of process: real, network, serial.
-    pub process_type: Lisp_Object,
+    pub process_type: LispObject,
 
     /// Marker set to end of last buffer-inserted output from this process.
-    pub mark: Lisp_Object,
+    pub mark: LispObject,
 
     /// Symbol indicating status of process.
     /// This may be a symbol: run, open, closed, listen, or failed.
@@ -1156,22 +1135,22 @@ pub struct Lisp_Process {
     /// Or it may be a list, whose car is stop, exit or signal
     /// and whose cdr is a pair (EXIT_CODE . COREDUMP_FLAG)
     /// or (SIGNAL_NUMBER . COREDUMP_FLAG).
-    pub status: Lisp_Object,
+    pub status: LispObject,
 
     /// Coding-system for decoding the input from this process.
-    pub decode_coding_system: Lisp_Object,
+    pub decode_coding_system: LispObject,
 
     /// Working buffer for decoding.
-    pub decoding_buf: Lisp_Object,
+    pub decoding_buf: LispObject,
 
     /// Coding-system for encoding the output to this process.
-    pub encode_coding_system: Lisp_Object,
+    pub encode_coding_system: LispObject,
 
     /// Working buffer for encoding.
-    pub encoding_buf: Lisp_Object,
+    pub encoding_buf: LispObject,
 
     /// Queue for storing waiting writes.
-    pub write_queue: Lisp_Object,
+    pub write_queue: LispObject,
     // This struct is incomplete.
     // To access remaining fields use access functions written in
     // src/process.c and export them here for use in Rust.
@@ -1193,20 +1172,20 @@ extern "C" {
 pub struct Lisp_Frame {
     pub header: Lisp_Vectorlike_Header,
 
-    /// All Lisp_Object components must come first.
+    /// All LispObject components must come first.
     /// That ensures they are all aligned normally.
 
     /// Name of this frame: a Lisp string.  It is used for looking up resources,
     /// as well as for the title in some cases.
-    pub name: Lisp_Object,
+    pub name: LispObject,
 
     /// The name to use for the icon, the last time
     /// it was refreshed.  nil means not explicitly specified.
-    pub icon_name: Lisp_Object,
+    pub icon_name: LispObject,
 
     /// This is the frame title specified explicitly, if any.
     /// Usually it is nil.
-    pub title: Lisp_Object,
+    pub title: LispObject,
 
     // This struct is incomplete.
     // It is difficult, if not impossible, to import the rest of this struct.
@@ -1218,7 +1197,7 @@ pub struct Lisp_Frame {
     // exported here for use in Rust. This means that instead of
     // frame.foo the proper method is fget_foo(frame).
     /// This frame's parent frame, if it has one.
-    parent_frame: Lisp_Object,
+    parent_frame: LispObject,
 
     ///  The frame which should receive keystrokes that occur in this
     /// frame, or nil if they should go to the frame itself.  This is
@@ -1231,29 +1210,29 @@ pub struct Lisp_Frame {
     /// to shift from one frame to the other, any redirections to the
     /// original frame are shifted to the newly selected frame; if
     /// focus_frame is nil, Fselect_frame will leave it alone.
-    focus_frame: Lisp_Object,
+    focus_frame: LispObject,
 
     /// This frame's root window.  Every frame has one.
     /// If the frame has only a minibuffer window, this is it.
     /// Otherwise, if the frame has a minibuffer window, this is its sibling.
-    root_window: Lisp_Object,
+    root_window: LispObject,
 
     /// This frame's selected window.
     /// Each frame has its own window hierarchy
     /// and one of the windows in it is selected within the frame.
     /// The selected window of the selected frame is Emacs's selected window.
-    selected_window: Lisp_Object,
+    selected_window: LispObject,
 
     /// This frame's minibuffer window.
     /// Most frames have their own minibuffer windows,
     /// but only the selected frame's minibuffer window
     /// can actually appear to exist.
-    minibuffer_window: Lisp_Object,
+    minibuffer_window: LispObject,
 
     /// Parameter alist of this frame.
     /// These are the parameters specified when creating the frame
     /// or modified with modify-frame-parameters.
-    param_alist: Lisp_Object,
+    param_alist: LispObject,
 
     /// List of scroll bars on this frame.
     /// Actually, we don't specify exactly what is stored here at all; the
@@ -1262,41 +1241,41 @@ pub struct Lisp_Frame {
     /// instead of in the `device' structure so that the garbage
     /// collector doesn't need to look inside the window-system-dependent
     /// structure.
-    scroll_bars: Lisp_Object,
-    condemned_scroll_bars: Lisp_Object,
+    scroll_bars: LispObject,
+    condemned_scroll_bars: LispObject,
 
     /// Vector describing the items to display in the menu bar.
     /// Each item has four elements in this vector.
     /// They are KEY, STRING, SUBMAP, and HPOS.
     /// (HPOS is not used in when the X toolkit is in use.)
     /// There are four additional elements of nil at the end, to terminate.
-    menu_bar_items: Lisp_Object,
+    menu_bar_items: LispObject,
 
     /// Alist of elements (FACE-NAME . FACE-VECTOR-DATA).
-    face_alist: Lisp_Object,
+    face_alist: LispObject,
 
     /// A vector that records the entire structure of this frame's menu bar.
     /// For the format of the data, see extensive comments in xmenu.c.
     /// Only the X toolkit version uses this.
-    menu_bar_vector: Lisp_Object,
+    menu_bar_vector: LispObject,
 
     /// Predicate for selecting buffers for other-buffer.
-    buffer_predicate: Lisp_Object,
+    buffer_predicate: LispObject,
 
     /// List of buffers viewed in this frame, for other-buffer.
-    buffer_list: Lisp_Object,
+    buffer_list: LispObject,
 
     /// List of buffers that were viewed, then buried in this frame.  The
     /// most recently buried buffer is first.  For last-buffer.
-    buried_buffer_list: Lisp_Object,
+    buried_buffer_list: LispObject,
 }
 
 extern "C" {
-    pub fn fget_buffer_list(frame: *const Lisp_Frame) -> Lisp_Object;
-    pub fn fget_buried_buffer_list(frame: *const Lisp_Frame) -> Lisp_Object;
+    pub fn fget_buffer_list(frame: *const Lisp_Frame) -> LispObject;
+    pub fn fget_buried_buffer_list(frame: *const Lisp_Frame) -> LispObject;
     pub fn fget_internal_border_width(frame: *const Lisp_Frame) -> c_int;
-    pub fn fget_selected_window(frame: *const Lisp_Frame) -> Lisp_Object;
-    pub fn fset_selected_window(frame: *mut Lisp_Frame, window: Lisp_Object);
+    pub fn fget_selected_window(frame: *const Lisp_Frame) -> LispObject;
+    pub fn fset_selected_window(frame: *mut Lisp_Frame, window: LispObject);
 }
 
 #[repr(C)]
@@ -1308,8 +1287,8 @@ pub struct terminal {
 extern "C" {
     pub fn fget_column_width(f: *const Lisp_Frame) -> c_int;
     pub fn fget_line_height(f: *const Lisp_Frame) -> c_int;
-    pub fn fget_minibuffer_window(f: *const Lisp_Frame) -> Lisp_Object;
-    pub fn fget_root_window(f: *const Lisp_Frame) -> Lisp_Object;
+    pub fn fget_minibuffer_window(f: *const Lisp_Frame) -> LispObject;
+    pub fn fget_root_window(f: *const Lisp_Frame) -> LispObject;
     pub fn fget_terminal(f: *const Lisp_Frame) -> *const terminal;
     pub fn fget_output_method(f: *const Lisp_Frame) -> c_int;
     pub fn fget_visible(f: *const Lisp_Frame) -> bool;
@@ -1327,26 +1306,26 @@ extern "C" {
 
 #[repr(C)]
 pub struct hash_table_test {
-    pub name: Lisp_Object,
-    pub user_hash_function: Lisp_Object,
-    pub user_cmp_function: Lisp_Object,
-    pub cmpfn: extern "C" fn(t: *mut hash_table_test, a: Lisp_Object, b: Lisp_Object) -> bool,
-    pub hashfn: extern "C" fn(t: *mut hash_table_test, a: Lisp_Object) -> EmacsUint,
+    pub name: LispObject,
+    pub user_hash_function: LispObject,
+    pub user_cmp_function: LispObject,
+    pub cmpfn: extern "C" fn(t: *mut hash_table_test, a: LispObject, b: LispObject) -> bool,
+    pub hashfn: extern "C" fn(t: *mut hash_table_test, a: LispObject) -> EmacsUint,
 }
 
 #[repr(C)]
 pub struct Lisp_Hash_Table {
     pub header: Lisp_Vectorlike_Header,
-    pub weak: Lisp_Object,
-    pub hash: Lisp_Object,
-    pub next: Lisp_Object,
-    pub index: Lisp_Object,
+    pub weak: LispObject,
+    pub hash: LispObject,
+    pub next: LispObject,
+    pub index: LispObject,
     pub count: ptrdiff_t,
     pub next_free: ptrdiff_t,
     pub pure_: bool, // pure is a reserved keyword in Rust
     pub rehash_threshold: c_float,
     pub rehash_size: c_float,
-    pub key_and_value: Lisp_Object,
+    pub key_and_value: LispObject,
     pub test: hash_table_test,
     pub next_weak: *mut Lisp_Hash_Table,
 }
@@ -1364,102 +1343,101 @@ pub struct lisp_time {
 }
 
 pub type map_keymap_function_t =
-    unsafe extern "C" fn(Lisp_Object, Lisp_Object, Lisp_Object, *const c_void);
+    unsafe extern "C" fn(LispObject, LispObject, LispObject, *const c_void);
 pub type voidfuncptr = unsafe extern "C" fn();
 
 extern "C" {
     pub static initialized: bool;
-    pub static mut current_global_map: Lisp_Object;
+    pub static mut current_global_map: LispObject;
     pub static current_thread: *mut thread_state;
-    pub static empty_unibyte_string: Lisp_Object;
+    pub static empty_unibyte_string: LispObject;
     pub static fatal_error_in_progress: bool;
     pub static mut globals: emacs_globals;
-    pub static initial_obarray: Lisp_Object;
+    pub static initial_obarray: LispObject;
     pub static lispsym: Lisp_Symbol;
     pub static minibuf_level: EmacsInt;
-    pub static minibuf_selected_window: Lisp_Object;
-    pub static mut minibuf_window: Lisp_Object;
-    pub static selected_frame: Lisp_Object;
-    pub static selected_window: Lisp_Object;
+    pub static minibuf_selected_window: LispObject;
+    pub static mut minibuf_window: LispObject;
+    pub static selected_frame: LispObject;
+    pub static selected_window: LispObject;
 
-    pub static mut Vautoload_queue: Lisp_Object;
-    pub static Vbuffer_alist: Lisp_Object;
-    pub static Vminibuffer_list: Lisp_Object;
-    pub static Vprocess_alist: Lisp_Object;
-    pub static Vrun_hooks: Lisp_Object;
+    pub static mut Vautoload_queue: LispObject;
+    pub static Vbuffer_alist: LispObject;
+    pub static Vminibuffer_list: LispObject;
+    pub static Vprocess_alist: LispObject;
+    pub static Vrun_hooks: LispObject;
 
-    pub fn staticpro(varaddress: *const Lisp_Object);
+    pub fn staticpro(varaddress: *const LispObject);
 
     // Use LispObject::tag_ptr instead of make_lisp_ptr
-    pub fn make_lisp_ptr(ptr: *const c_void, ty: Lisp_Type) -> Lisp_Object;
-    pub fn Fmake_char_table(purpose: Lisp_Object, init: Lisp_Object) -> Lisp_Object;
+    pub fn make_lisp_ptr(ptr: *const c_void, ty: Lisp_Type) -> LispObject;
+    pub fn Fmake_char_table(purpose: LispObject, init: LispObject) -> LispObject;
     pub fn map_char_table(
-        c_function: unsafe extern "C" fn(Lisp_Object, Lisp_Object, Lisp_Object),
-        function: Lisp_Object,
-        table: Lisp_Object,
-        arg: Lisp_Object,
+        c_function: unsafe extern "C" fn(LispObject, LispObject, LispObject),
+        function: LispObject,
+        table: LispObject,
+        arg: LispObject,
     );
-    pub fn CHAR_TABLE_SET(ct: Lisp_Object, idx: c_int, val: Lisp_Object);
+    pub fn CHAR_TABLE_SET(ct: LispObject, idx: c_int, val: LispObject);
 
-    pub fn aset_multibyte_string(array: Lisp_Object, idxval: EmacsInt, c: c_int);
-    pub fn Fcons(car: Lisp_Object, cdr: Lisp_Object) -> Lisp_Object;
-    pub fn Fsignal(error_symbol: Lisp_Object, data: Lisp_Object) -> !;
-    pub fn Fcopy_sequence(seq: Lisp_Object) -> Lisp_Object;
-    pub fn Ffind_operation_coding_system(nargs: ptrdiff_t, args: *mut Lisp_Object) -> Lisp_Object;
-    pub fn Flocal_variable_p(variable: Lisp_Object, buffer: Lisp_Object) -> Lisp_Object;
-    pub fn Ffuncall(nargs: ptrdiff_t, args: *mut Lisp_Object) -> Lisp_Object;
-    pub fn Fpurecopy(string: Lisp_Object) -> Lisp_Object;
-    pub fn Fmapcar(function: Lisp_Object, sequence: Lisp_Object) -> Lisp_Object;
-    pub fn Fset(symbol: Lisp_Object, newval: Lisp_Object) -> Lisp_Object;
-    pub fn Fset_default(symbol: Lisp_Object, value: Lisp_Object) -> Lisp_Object;
-    pub fn Fconcat(nargs: ptrdiff_t, args: *mut Lisp_Object) -> Lisp_Object;
-    pub fn Fnconc(nargs: ptrdiff_t, args: *mut Lisp_Object) -> Lisp_Object;
+    pub fn aset_multibyte_string(array: LispObject, idxval: EmacsInt, c: c_int);
+    pub fn Fcons(car: LispObject, cdr: LispObject) -> LispObject;
+    pub fn Fsignal(error_symbol: LispObject, data: LispObject) -> !;
+    pub fn Fcopy_sequence(seq: LispObject) -> LispObject;
+    pub fn Ffind_operation_coding_system(nargs: ptrdiff_t, args: *mut LispObject) -> LispObject;
+    pub fn Flocal_variable_p(variable: LispObject, buffer: LispObject) -> LispObject;
+    pub fn Ffuncall(nargs: ptrdiff_t, args: *mut LispObject) -> LispObject;
+    pub fn Fpurecopy(string: LispObject) -> LispObject;
+    pub fn Fmapcar(function: LispObject, sequence: LispObject) -> LispObject;
+    pub fn Fset(symbol: LispObject, newval: LispObject) -> LispObject;
+    pub fn Fset_default(symbol: LispObject, value: LispObject) -> LispObject;
+    pub fn Fconcat(nargs: ptrdiff_t, args: *mut LispObject) -> LispObject;
+    pub fn Fnconc(nargs: ptrdiff_t, args: *mut LispObject) -> LispObject;
 
-    pub fn make_float(float_value: c_double) -> Lisp_Object;
-    pub fn make_string(s: *const c_char, length: ptrdiff_t) -> Lisp_Object;
+    pub fn make_float(float_value: c_double) -> LispObject;
+    pub fn make_string(s: *const c_char, length: ptrdiff_t) -> LispObject;
     pub fn make_string_from_bytes(
         contents: *const c_char,
         nchars: ptrdiff_t,
         nbytes: ptrdiff_t,
-    ) -> Lisp_Object;
-    pub fn make_pure_c_string(data: *const c_char, nchars: ptrdiff_t) -> Lisp_Object;
+    ) -> LispObject;
+    pub fn make_pure_c_string(data: *const c_char, nchars: ptrdiff_t) -> LispObject;
 
-    pub fn make_lisp_symbol(ptr: *mut Lisp_Symbol) -> Lisp_Object;
-    pub fn build_string(s: *const c_char) -> Lisp_Object;
-    pub fn make_unibyte_string(s: *const c_char, length: ptrdiff_t) -> Lisp_Object;
-    pub fn make_uninit_string(length: EmacsInt) -> Lisp_Object;
-    pub fn make_uninit_multibyte_string(nchars: EmacsInt, nbytes: EmacsInt) -> Lisp_Object;
+    pub fn make_lisp_symbol(ptr: *mut Lisp_Symbol) -> LispObject;
+    pub fn build_string(s: *const c_char) -> LispObject;
+    pub fn make_unibyte_string(s: *const c_char, length: ptrdiff_t) -> LispObject;
+    pub fn make_uninit_string(length: EmacsInt) -> LispObject;
+    pub fn make_uninit_multibyte_string(nchars: EmacsInt, nbytes: EmacsInt) -> LispObject;
     pub fn make_specified_string(
         contents: *const c_char,
         nchars: ptrdiff_t,
         nbytes: ptrdiff_t,
         multibyte: bool,
-    ) -> Lisp_Object;
-    pub fn string_to_multibyte(string: Lisp_Object) -> Lisp_Object;
-    pub fn initial_define_key(keymap: Lisp_Object, key: c_int, defname: *const c_char);
+    ) -> LispObject;
+    pub fn string_to_multibyte(string: LispObject) -> LispObject;
+    pub fn initial_define_key(keymap: LispObject, key: c_int, defname: *const c_char);
 
-    pub fn eval_sub(form: Lisp_Object) -> Lisp_Object;
+    pub fn eval_sub(form: LispObject) -> LispObject;
 
-    pub fn preferred_coding_system() -> Lisp_Object;
-    pub fn Fcoding_system_p(o: Lisp_Object) -> Lisp_Object;
+    pub fn preferred_coding_system() -> LispObject;
+    pub fn Fcoding_system_p(o: LispObject) -> LispObject;
     pub fn code_convert_string(
-        string: Lisp_Object,
-        coding_system: Lisp_Object,
-        dst_object: Lisp_Object,
+        string: LispObject,
+        coding_system: LispObject,
+        dst_object: LispObject,
         encodep: bool,
         nocopy: bool,
         norecord: bool,
-    ) -> Lisp_Object;
+    ) -> LispObject;
     pub fn validate_subarray(
-        array: Lisp_Object,
-        from: Lisp_Object,
-        to: Lisp_Object,
+        array: LispObject,
+        from: LispObject,
+        to: LispObject,
         size: libc::ptrdiff_t,
         ifrom: &mut libc::ptrdiff_t,
         ito: &mut libc::ptrdiff_t,
     );
-    pub fn string_char_to_byte(string: Lisp_Object, char_index: libc::ptrdiff_t)
-        -> libc::ptrdiff_t;
+    pub fn string_char_to_byte(string: LispObject, char_index: libc::ptrdiff_t) -> libc::ptrdiff_t;
 
     pub fn record_unwind_current_buffer();
     pub fn set_buffer_internal(buffer: *mut Lisp_Buffer);
@@ -1467,23 +1445,23 @@ extern "C" {
         start: libc::ptrdiff_t,
         end: libc::ptrdiff_t,
         props: bool,
-    ) -> Lisp_Object;
+    ) -> LispObject;
 
-    pub fn intern_sym(sym: Lisp_Object, obarray: Lisp_Object, index: Lisp_Object) -> Lisp_Object;
+    pub fn intern_sym(sym: LispObject, obarray: LispObject, index: LispObject) -> LispObject;
     pub fn oblookup(
-        obarray: Lisp_Object,
+        obarray: LispObject,
         s: *const c_char,
         size: ptrdiff_t,
         size_bytes: ptrdiff_t,
-    ) -> Lisp_Object;
+    ) -> LispObject;
 
-    pub fn CHECK_IMPURE(obj: Lisp_Object, ptr: *const c_void);
+    pub fn CHECK_IMPURE(obj: LispObject, ptr: *const c_void);
     pub fn internal_equal(
-        o1: Lisp_Object,
-        o2: Lisp_Object,
+        o1: LispObject,
+        o2: LispObject,
         kind: EqualKind,
         depth: c_int,
-        ht: Lisp_Object,
+        ht: LispObject,
     ) -> bool;
 
     pub fn emacs_abort() -> !;
@@ -1511,34 +1489,31 @@ extern "C" {
     ) -> *mut Lisp_Vector;
 
     pub fn extract_data_from_object(
-        spec: Lisp_Object,
+        spec: LispObject,
         start_byte: *mut ptrdiff_t,
         end_byte: *mut ptrdiff_t,
     ) -> *mut c_char;
 
-    pub fn hash_lookup(
-        h: *mut Lisp_Hash_Table,
-        key: Lisp_Object,
-        hash: *mut EmacsUint,
-    ) -> ptrdiff_t;
+    pub fn hash_lookup(h: *mut Lisp_Hash_Table, key: LispObject, hash: *mut EmacsUint)
+        -> ptrdiff_t;
 
     pub fn hash_put(
         h: *mut Lisp_Hash_Table,
-        key: Lisp_Object,
-        value: Lisp_Object,
+        key: LispObject,
+        value: LispObject,
         hash: EmacsUint,
     ) -> ptrdiff_t;
     pub fn hash_clear(h: *mut Lisp_Hash_Table);
 
-    pub fn gc_aset(array: Lisp_Object, idx: ptrdiff_t, val: Lisp_Object);
+    pub fn gc_aset(array: LispObject, idx: ptrdiff_t, val: LispObject);
 
-    pub fn hash_remove_from_table(h: *mut Lisp_Hash_Table, key: Lisp_Object);
+    pub fn hash_remove_from_table(h: *mut Lisp_Hash_Table, key: LispObject);
     pub fn set_point_both(charpos: ptrdiff_t, bytepos: ptrdiff_t);
     pub fn set_point(charpos: ptrdiff_t);
     pub fn buf_charpos_to_bytepos(buffer: *const Lisp_Buffer, charpos: ptrdiff_t) -> ptrdiff_t;
 
-    pub fn insert(string: *const c_char, nbytes: ptrdiff_t) -> Lisp_Object;
-    pub fn insert_and_inherit(string: *const c_char, nbytes: ptrdiff_t) -> Lisp_Object;
+    pub fn insert(string: *const c_char, nbytes: ptrdiff_t) -> LispObject;
+    pub fn insert_and_inherit(string: *const c_char, nbytes: ptrdiff_t) -> LispObject;
     pub fn buffer_overflow();
 
     pub fn wait_reading_process_output(
@@ -1546,7 +1521,7 @@ extern "C" {
         nsecs: c_int,
         read_kbd: c_int,
         do_display: bool,
-        wait_for_cell: Lisp_Object,
+        wait_for_cell: LispObject,
         wait_proc: *const Lisp_Process,
         just_wait_proc: c_int,
     ) -> c_int;
@@ -1558,14 +1533,14 @@ extern "C" {
     pub fn current_column() -> ptrdiff_t;
 
     pub fn Fadd_text_properties(
-        start: Lisp_Object,
-        end: Lisp_Object,
-        properties: Lisp_Object,
-        object: Lisp_Object,
-    ) -> Lisp_Object;
+        start: LispObject,
+        end: LispObject,
+        properties: LispObject,
+        object: LispObject,
+    ) -> LispObject;
 
-    pub fn Fmake_symbol(name: Lisp_Object) -> Lisp_Object;
-    pub fn find_symbol_value(symbol: Lisp_Object) -> Lisp_Object;
+    pub fn Fmake_symbol(name: LispObject) -> LispObject;
+    pub fn find_symbol_value(symbol: LispObject) -> LispObject;
     pub fn symbol_is_interned(symbol: *const Lisp_Symbol) -> bool;
     pub fn symbol_is_alias(symbol: *const Lisp_Symbol) -> bool;
     pub fn symbol_is_constant(symbol: *const Lisp_Symbol) -> bool;
@@ -1573,69 +1548,61 @@ extern "C" {
     pub fn is_minibuffer(w: *const Lisp_Window) -> bool;
     pub fn xmalloc(size: size_t) -> *mut c_void;
 
-    pub fn Fmapc(function: Lisp_Object, sequence: Lisp_Object) -> Lisp_Object;
+    pub fn Fmapc(function: LispObject, sequence: LispObject) -> LispObject;
 
     pub fn Fpos_visible_in_window_p(
-        pos: Lisp_Object,
-        window: Lisp_Object,
-        partially: Lisp_Object,
-    ) -> Lisp_Object;
+        pos: LispObject,
+        window: LispObject,
+        partially: LispObject,
+    ) -> LispObject;
     pub fn find_before_next_newline(
         from: ptrdiff_t,
         to: ptrdiff_t,
         cnt: ptrdiff_t,
         bytepos: *mut ptrdiff_t,
     ) -> ptrdiff_t;
-    pub fn get_process(name: Lisp_Object) -> Lisp_Object;
+    pub fn get_process(name: LispObject) -> LispObject;
     pub fn update_status(p: *const Lisp_Process);
-    pub fn setup_process_coding_systems(process: Lisp_Object);
+    pub fn setup_process_coding_systems(process: LispObject);
     pub fn send_process(
-        process: Lisp_Object,
+        process: LispObject,
         buf: *const c_char,
         len: ptrdiff_t,
-        object: Lisp_Object,
+        object: LispObject,
     );
     pub fn STRING_BYTES(s: *const Lisp_String) -> ptrdiff_t;
-    pub fn Fevent_convert_list(event_desc: Lisp_Object) -> Lisp_Object;
+    pub fn Fevent_convert_list(event_desc: LispObject) -> LispObject;
     pub fn map_keymap_item(
         fun: map_keymap_function_t,
-        args: Lisp_Object,
-        key: Lisp_Object,
-        val: Lisp_Object,
+        args: LispObject,
+        key: LispObject,
+        val: LispObject,
         data: *const c_void,
     );
-    pub fn map_keymap_char_table_item(args: Lisp_Object, key: Lisp_Object, val: Lisp_Object);
-    pub fn map_keymap_call(
-        key: Lisp_Object,
-        val: Lisp_Object,
-        fun: Lisp_Object,
-        void: *const c_void,
-    );
+    pub fn map_keymap_char_table_item(args: LispObject, key: LispObject, val: LispObject);
+    pub fn map_keymap_call(key: LispObject, val: LispObject, fun: LispObject, void: *const c_void);
     pub fn access_keymap(
-        map: Lisp_Object,
-        idx: Lisp_Object,
+        map: LispObject,
+        idx: LispObject,
         ok: bool,
         noinherit: bool,
         autoload: bool,
-    ) -> Lisp_Object;
-    pub fn message_with_string(m: *const c_char, string: Lisp_Object, log: bool);
+    ) -> LispObject;
+    pub fn message_with_string(m: *const c_char, string: LispObject, log: bool);
     pub fn maybe_quit();
     pub fn make_lispy_position(
         f: *const Lisp_Frame,
-        x: Lisp_Object,
-        y: Lisp_Object,
+        x: LispObject,
+        y: LispObject,
         t: Time,
-    ) -> Lisp_Object;
+    ) -> LispObject;
 
-    pub fn make_save_funcptr_ptr_obj(
-        a: voidfuncptr,
-        b: *const c_void,
-        c: Lisp_Object,
-    ) -> Lisp_Object;
+    pub fn make_save_funcptr_ptr_obj(a: voidfuncptr, b: *const c_void, c: LispObject)
+        -> LispObject;
 
-    pub fn Fselect_window(window: Lisp_Object, norecord: Lisp_Object) -> Lisp_Object;
+    pub fn Fselect_window(window: LispObject, norecord: LispObject) -> LispObject;
 
-    pub fn Ffset(symbol: Lisp_Object, definition: Lisp_Object) -> Lisp_Object;
+    pub fn Ffset(symbol: LispObject, definition: LispObject) -> LispObject;
 
     pub fn frame_dimension(x: c_int) -> c_int;
     pub fn window_box_left_offset(w: *const Lisp_Window, area: glyph_row_area) -> c_int;
@@ -1648,19 +1615,19 @@ extern "C" {
     ) -> ptrdiff_t;
 
     pub fn set_marker_internal(
-        marker: Lisp_Object,
-        position: Lisp_Object,
-        buffer: Lisp_Object,
+        marker: LispObject,
+        position: LispObject,
+        buffer: LispObject,
         restricted: bool,
-    ) -> Lisp_Object;
-    pub fn Fmake_marker() -> Lisp_Object;
+    ) -> LispObject;
+    pub fn Fmake_marker() -> LispObject;
 
     pub fn find_field(
-        pos: Lisp_Object,
-        merge_at_boundary: Lisp_Object,
-        beg_limit: Lisp_Object,
+        pos: LispObject,
+        merge_at_boundary: LispObject,
+        beg_limit: LispObject,
         beg: *mut ptrdiff_t,
-        end_limit: Lisp_Object,
+        end_limit: LispObject,
         end: *mut ptrdiff_t,
     );
     pub fn find_newline(
@@ -1675,55 +1642,55 @@ extern "C" {
     ) -> ptrdiff_t;
 
     pub fn Fget_pos_property(
-        position: Lisp_Object,
-        prop: Lisp_Object,
-        object: Lisp_Object,
-    ) -> Lisp_Object;
+        position: LispObject,
+        prop: LispObject,
+        object: LispObject,
+    ) -> LispObject;
     pub fn Fget_text_property(
-        position: Lisp_Object,
-        prop: Lisp_Object,
-        object: Lisp_Object,
-    ) -> Lisp_Object;
+        position: LispObject,
+        prop: LispObject,
+        object: LispObject,
+    ) -> LispObject;
 
     pub fn get_char_property_and_overlay(
-        position: Lisp_Object,
-        prop: Lisp_Object,
-        object: Lisp_Object,
-        overlay: *mut Lisp_Object,
-    ) -> Lisp_Object;
-    pub fn specbind(symbol: Lisp_Object, value: Lisp_Object);
-    pub fn unbind_to(count: ptrdiff_t, value: Lisp_Object) -> Lisp_Object;
-    pub fn Fapply(nargs: ptrdiff_t, args: *const Lisp_Object) -> Lisp_Object;
+        position: LispObject,
+        prop: LispObject,
+        object: LispObject,
+        overlay: *mut LispObject,
+    ) -> LispObject;
+    pub fn specbind(symbol: LispObject, value: LispObject);
+    pub fn unbind_to(count: ptrdiff_t, value: LispObject) -> LispObject;
+    pub fn Fapply(nargs: ptrdiff_t, args: *const LispObject) -> LispObject;
 
-    pub fn wset_window_parameters(w: *const Lisp_Window, val: Lisp_Object);
-    pub fn wget_window_parameters(w: *const Lisp_Window) -> Lisp_Object;
+    pub fn wset_window_parameters(w: *const Lisp_Window, val: LispObject);
+    pub fn wget_window_parameters(w: *const Lisp_Window) -> LispObject;
 
-    pub fn Fnreverse(seq: Lisp_Object) -> Lisp_Object;
+    pub fn Fnreverse(seq: LispObject) -> LispObject;
 
     pub fn Fload(
-        file: Lisp_Object,
-        noerror: Lisp_Object,
-        nomessage: Lisp_Object,
-        nosuffix: Lisp_Object,
-        must_suffix: Lisp_Object,
-    ) -> Lisp_Object;
-    pub fn record_unwind_protect(function: unsafe extern "C" fn(Lisp_Object), arg: Lisp_Object);
+        file: LispObject,
+        noerror: LispObject,
+        nomessage: LispObject,
+        nosuffix: LispObject,
+        must_suffix: LispObject,
+    ) -> LispObject;
+    pub fn record_unwind_protect(function: unsafe extern "C" fn(LispObject), arg: LispObject);
     pub fn record_unwind_save_match_data();
-    pub fn un_autoload(oldqueue: Lisp_Object);
+    pub fn un_autoload(oldqueue: LispObject);
 
     pub fn unchain_marker(marker: *mut Lisp_Marker);
     pub fn del_range(from: ptrdiff_t, to: ptrdiff_t);
     pub fn buf_bytepos_to_charpos(b: *mut Lisp_Buffer, bytepos: ptrdiff_t) -> ptrdiff_t;
-    pub fn Fdefault_value(symbol: Lisp_Object) -> Lisp_Object;
+    pub fn Fdefault_value(symbol: LispObject) -> LispObject;
     pub fn swap_in_symval_forwarding(sym: *mut Lisp_Symbol, blv: *mut Lisp_Buffer_Local_Value);
-    pub fn Fexpand_file_name(filename: Lisp_Object, default_directory: Lisp_Object) -> Lisp_Object;
-    pub fn Ffind_file_name_handler(filename: Lisp_Object, operation: Lisp_Object) -> Lisp_Object;
+    pub fn Fexpand_file_name(filename: LispObject, default_directory: LispObject) -> LispObject;
+    pub fn Ffind_file_name_handler(filename: LispObject, operation: LispObject) -> LispObject;
     pub fn window_list_1(
-        window: Lisp_Object,
-        minibuf: Lisp_Object,
-        all_frames: Lisp_Object,
-    ) -> Lisp_Object;
-    pub fn buffer_local_value(variable: Lisp_Object, buffer: Lisp_Object) -> Lisp_Object;
+        window: LispObject,
+        minibuf: LispObject,
+        all_frames: LispObject,
+    ) -> LispObject;
+    pub fn buffer_local_value(variable: LispObject, buffer: LispObject) -> LispObject;
     pub fn downcase(c: c_int) -> c_int;
 
 }
@@ -1785,7 +1752,7 @@ fn basic_size_and_align() {
     assert!(::std::mem::size_of::<Lisp_Symbol>() == 56);
     assert!(::std::mem::size_of::<Lisp_Marker>() == 48);
     assert!(::std::mem::size_of::<Lisp_Overlay>() == 48);
-    assert!(::std::mem::size_of::<SymbolUnion>() == ::std::mem::size_of::<Lisp_Object>());
+    assert!(::std::mem::size_of::<SymbolUnion>() == ::std::mem::size_of::<LispObject>());
     assert!(offset_of!(Lisp_Symbol, name) == 16);
     assert!(offset_of!(Lisp_Symbol, next) == 48);
     assert!(offset_of!(Lisp_Symbol, function) == 32);
@@ -1800,13 +1767,13 @@ fn basic_size_and_align() {
 extern "C" {
     pub fn frame_make_pointer_invisible(frame: *mut Lisp_Frame);
     pub fn bitch_at_user() -> !;
-    pub fn translate_char(table: Lisp_Object, c: EmacsInt) -> EmacsInt;
+    pub fn translate_char(table: LispObject, c: EmacsInt) -> EmacsInt;
     pub fn concat(
         nargs: ptrdiff_t,
-        args: *mut Lisp_Object,
+        args: *mut LispObject,
         target_type: Lisp_Type,
         last_special: bool,
-    ) -> Lisp_Object;
+    ) -> LispObject;
 }
 
 #[repr(u8)]

--- a/rust_src/src/remacs_sys.rs
+++ b/rust_src/src/remacs_sys.rs
@@ -1800,20 +1800,20 @@ pub enum syntaxcode {
 
 extern "C" {
     pub fn syntax_property(c: libc::c_int, via_property: bool) -> syntaxcode;
-    pub fn concat2(s1: Lisp_Object, s2: Lisp_Object) -> Lisp_Object;
+    pub fn concat2(s1: LispObject, s2: LispObject) -> LispObject;
     pub fn replace_range(
         from: ptrdiff_t,
         to: ptrdiff_t,
-        new: Lisp_Object,
+        new: LispObject,
         prepare: bool,
         inherit: bool,
         markers: bool,
         adjust_match_data: bool,
     );
     pub fn memory_full(nbytes: libc::size_t) -> !;
-    pub fn run_hook(symbol: Lisp_Object);
-    pub fn Fchar_width(ch: Lisp_Object) -> Lisp_Object;
-    pub fn Fget(symbol: Lisp_Object, propname: Lisp_Object) -> Lisp_Object;
-    pub fn Fmove_to_column(column: Lisp_Object, force: Lisp_Object) -> Lisp_Object;
-    pub fn Fmake_string(length: Lisp_Object, init: Lisp_Object) -> Lisp_Object;
+    pub fn run_hook(symbol: LispObject);
+    pub fn Fchar_width(ch: LispObject) -> LispObject;
+    pub fn Fget(symbol: LispObject, propname: LispObject) -> LispObject;
+    pub fn Fmove_to_column(column: LispObject, force: LispObject) -> LispObject;
+    pub fn Fmake_string(length: LispObject, init: LispObject) -> LispObject;
 }

--- a/rust_src/src/time.rs
+++ b/rust_src/src/time.rs
@@ -7,7 +7,7 @@ use libc::timespec as c_timespec;
 
 use remacs_lib::current_timespec;
 use remacs_macros::lisp_fn;
-use remacs_sys::{lisp_time, EmacsInt, Lisp_Object};
+use remacs_sys::{lisp_time, EmacsInt};
 use remacs_sys::MOST_NEGATIVE_FIXNUM;
 
 use lisp::LispObject;
@@ -38,7 +38,7 @@ pub extern "C" fn lo_time(t: time_t) -> i32 {
 /// `UNKNOWN_MODTIME_NSECS`; in that case, the Lisp list contains a
 /// correspondingly negative picosecond count.
 #[no_mangle]
-pub extern "C" fn make_lisp_time(t: c_timespec) -> Lisp_Object {
+pub extern "C" fn make_lisp_time(t: c_timespec) -> LispObject {
     make_lisp_time_1(t).to_raw()
 }
 
@@ -59,11 +59,11 @@ fn make_lisp_time_1(t: c_timespec) -> LispObject {
 /// if successful, 0 if unsuccessful.
 #[no_mangle]
 pub extern "C" fn disassemble_lisp_time(
-    specified_time: Lisp_Object,
-    phigh: *mut Lisp_Object,
-    plow: *mut Lisp_Object,
-    pusec: *mut Lisp_Object,
-    ppsec: *mut Lisp_Object,
+    specified_time: LispObject,
+    phigh: *mut LispObject,
+    plow: *mut LispObject,
+    pusec: *mut LispObject,
+    ppsec: *mut LispObject,
 ) -> c_int {
     let specified_time = LispObject::from_raw(specified_time);
 
@@ -129,10 +129,10 @@ pub extern "C" fn disassemble_lisp_time(
 /// wrong type, and -1 if the time is out of range.
 #[no_mangle]
 pub extern "C" fn decode_time_components(
-    high: Lisp_Object,
-    low: Lisp_Object,
-    usec: Lisp_Object,
-    psec: Lisp_Object,
+    high: LispObject,
+    low: LispObject,
+    usec: LispObject,
+    psec: LispObject,
     result: *mut lisp_time,
     dresult: *mut f64,
 ) -> c_int {
@@ -292,11 +292,11 @@ pub extern "C" fn lisp_to_timespec(t: lisp_time) -> c_timespec {
 /// If `SPECIFIED_TIME` is nil, use the current time.
 /// Signal an error if `SPECIFIED_TIME` does not represent a time.
 #[no_mangle]
-pub extern "C" fn lisp_time_struct(specified_time: Lisp_Object, plen: *mut c_int) -> lisp_time {
-    let mut high = Lisp_Object::from_C(0);
-    let mut low = Lisp_Object::from_C(0);
-    let mut usec = Lisp_Object::from_C(0);
-    let mut psec = Lisp_Object::from_C(0);
+pub extern "C" fn lisp_time_struct(specified_time: LispObject, plen: *mut c_int) -> lisp_time {
+    let mut high = LispObject::from_C(0);
+    let mut low = LispObject::from_C(0);
+    let mut usec = LispObject::from_C(0);
+    let mut psec = LispObject::from_C(0);
 
     let len = disassemble_lisp_time(specified_time, &mut high, &mut low, &mut usec, &mut psec);
     if len == 0 {
@@ -358,10 +358,10 @@ pub fn current_time() -> LispObject {
 /// or (if you need time as a string) `format-time-string'.
 #[lisp_fn(min = "0")]
 pub fn float_time(time: LispObject) -> LispObject {
-    let mut high = Lisp_Object::from_C(0);
-    let mut low = Lisp_Object::from_C(0);
-    let mut usec = Lisp_Object::from_C(0);
-    let mut psec = Lisp_Object::from_C(0);
+    let mut high = LispObject::from_C(0);
+    let mut low = LispObject::from_C(0);
+    let mut usec = LispObject::from_C(0);
+    let mut psec = LispObject::from_C(0);
 
     let mut t = 0.0;
 

--- a/rust_src/src/vectors.rs
+++ b/rust_src/src/vectors.rs
@@ -190,7 +190,7 @@ macro_rules! impl_vectorlike_ref {
             pub fn as_slice(&self) -> &[LispObject] {
                 unsafe {
                     slice::from_raw_parts(
-                        &self.contents as *const [::remacs_sys::Lisp_Object; 1]
+                        &self.contents as *const [::lisp::LispObject; 1]
                             as *const LispObject,
                         self.len(),
                     )
@@ -201,7 +201,7 @@ macro_rules! impl_vectorlike_ref {
             pub fn as_mut_slice(&mut self) -> &mut [LispObject] {
                 unsafe {
                     slice::from_raw_parts_mut(
-                        &mut self.contents as *mut [::remacs_sys::Lisp_Object; 1]
+                        &mut self.contents as *mut [::lisp::LispObject; 1]
                             as *mut LispObject,
                         self.len(),
                     )
@@ -217,7 +217,7 @@ macro_rules! impl_vectorlike_ref {
             #[inline]
             pub unsafe fn get_unchecked(&self, idx: ptrdiff_t) -> LispObject {
                 ptr::read(
-                    (&self.contents as *const [::remacs_sys::Lisp_Object; 1]
+                    (&self.contents as *const [::lisp::LispObject; 1]
                      as *const LispObject).offset(idx),
                 )
             }
@@ -239,7 +239,7 @@ macro_rules! impl_vectorlike_ref {
             #[inline]
             pub unsafe fn set_unchecked(&mut self, idx: ptrdiff_t, item: LispObject) {
                 ptr::write(
-                    (&mut self.contents as *mut [::remacs_sys::Lisp_Object; 1]
+                    (&mut self.contents as *mut [::lisp::LispObject; 1]
                      as *mut LispObject).offset(idx),
                     item,
                 )
@@ -564,7 +564,7 @@ lazy_static! {
         unsafe { offset_of!(::remacs_sys::Lisp_Vector, contents) }
     };
     pub static ref WORD_SIZE: usize = {
-        ::std::mem::size_of::<::remacs_sys::Lisp_Object>()
+        ::std::mem::size_of::<::lisp::LispObject>()
     };
 }
 


### PR DESCRIPTION
Closes #706.

This is the mechanical rename part of the change, leaving out the significant clean-up that's possible once `Lisp_Object` is removed.