### PR TITLE
Rust dired systemusers v2

### DIFF
--- a/rust_src/src/dired.rs
+++ b/rust_src/src/dired.rs
@@ -1,12 +1,14 @@
 //! Lisp functions for making directory listings.
 
+use std::ffi::CStr;
+
 use libc;
-use lisp::LispObject;
-use lisp::defsubr;
-use lists::list;
+
 use remacs_macros::lisp_fn;
 use remacs_sys::Fuser_real_login_name;
-use std::ffi::CStr;
+
+use lisp::{defsubr, LispObject};
+use lists::list;
 
 /// Return a list of user names currently registered in the system.
 /// If we don't know how to determine that on this platform, just

--- a/rust_src/src/dired.rs
+++ b/rust_src/src/dired.rs
@@ -1,0 +1,39 @@
+//! Lisp functions for making directory listings.
+
+use libc;
+use lisp::LispObject;
+use lisp::defsubr;
+use lists::list;
+use remacs_macros::lisp_fn;
+use remacs_sys::Fuser_real_login_name;
+use std::ffi::CStr;
+
+/// Return a list of user names currently registered in the system.
+/// If we don't know how to determine that on this platform, just
+/// return a list with one element, taken from `user-real-login-name'.
+#[lisp_fn]
+pub fn system_users() -> LispObject {
+    let mut done = false;
+    let mut unames = Vec::new();
+
+    while !done {
+        let pw: *mut libc::passwd = unsafe { libc::getpwent() };
+        if pw.is_null() {
+            done = true;
+        } else {
+            let pwnam_string =
+                unsafe { CStr::from_ptr((*pw).pw_name).to_string_lossy().into_owned() };
+            let pwnam_str = &*pwnam_string;
+            unames.push(LispObject::from(pwnam_str));
+        }
+    }
+    unsafe { libc::endpwent() };
+
+    if unames.len() < 1 {
+        unames.push(LispObject::from_raw(unsafe { Fuser_real_login_name() }));
+    }
+
+    list(&mut unames)
+}
+
+include!(concat!(env!("OUT_DIR"), "/dired_exports.rs"));

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -55,6 +55,7 @@ mod chartable;
 mod cmds;
 mod crypto;
 mod data;
+mod dired;
 mod dispnew;
 mod editfns;
 mod eval;

--- a/rust_src/src/remacs_sys.rs
+++ b/rust_src/src/remacs_sys.rs
@@ -1724,7 +1724,7 @@ extern "C" {
         all_frames: Lisp_Object,
     ) -> Lisp_Object;
     pub fn buffer_local_value(variable: Lisp_Object, buffer: Lisp_Object) -> Lisp_Object;
-
+    pub fn Fuser_real_login_name() -> Lisp_Object;
 }
 
 /// Contains C definitions from the font.h header.

--- a/src/dired.c
+++ b/src/dired.c
@@ -1038,27 +1038,6 @@ Comparison is in lexicographic order and case is significant.  */)
 }
 
 
-DEFUN ("system-users", Fsystem_users, Ssystem_users, 0, 0, 0,
-       doc: /* Return a list of user names currently registered in the system.
-If we don't know how to determine that on this platform, just
-return a list with one element, taken from `user-real-login-name'.  */)
-     (void)
-{
-  Lisp_Object users = Qnil;
-#if defined HAVE_GETPWENT && defined HAVE_ENDPWENT
-  struct passwd *pw;
-
-  while ((pw = getpwent ()))
-    users = Fcons (DECODE_SYSTEM (build_string (pw->pw_name)), users);
-
-  endpwent ();
-#endif
-  if (EQ (users, Qnil))
-    /* At least current user is always known. */
-    users = list1 (Vuser_real_login_name);
-  return users;
-}
-
 DEFUN ("system-groups", Fsystem_groups, Ssystem_groups, 0, 0, 0,
        doc: /* Return a list of user group names currently registered in the system.
 The value may be nil if not supported on this platform.  */)
@@ -1094,7 +1073,6 @@ syms_of_dired (void)
   defsubr (&Sfile_name_all_completions);
   defsubr (&Sfile_attributes);
   defsubr (&Sfile_attributes_lessp);
-  defsubr (&Ssystem_users);
   defsubr (&Ssystem_groups);
 
   DEFVAR_LISP ("completion-ignored-extensions", Vcompletion_ignored_extensions,


### PR DESCRIPTION
Here's the first (of 3 probably) split-up of PR #348 ...

It's make/check and rustfmt clean and the lisp function and docstring tested by hand on Linux. Also the Fuser_real_login_name fallback block was tested (temp commented out prev block).

The prev version -- a few months ago -- was tested on MacOS too. This code is pretty simple so likely will build/work on MacOS (Windows we'll see too).