### PR TITLE
Rust's ranges are exclusive of the last value

### DIFF
--- a/rust_src/src/cmds.rs
+++ b/rust_src/src/cmds.rs
@@ -505,10 +505,10 @@ pub extern "C" fn keys_of_cmds() {
     unsafe {
         let sic = CString::new("self-insert-command").unwrap();
         initial_define_key(global_map, Ctl('I'), sic.as_ptr());
-        for n in 0x20..0x7e {
+        for n in 0x20..0x7f {
             initial_define_key(global_map, n, sic.as_ptr());
         }
-        for n in 0xa0..0xff {
+        for n in 0xa0..0x100 {
             initial_define_key(global_map, n, sic.as_ptr());
         }
 


### PR DESCRIPTION
Just like the C code we ported it from.

In my defense, I just blindly copied this code from Sean, and didn't
double-check it. Fixes #742