### PR TITLE
run-hooks should accept a symbol evaluating to a function

### DIFF
--- a/rust_src/src/eval.rs
+++ b/rust_src/src/eval.rs
@@ -948,7 +948,7 @@ fn run_hook_with_args_internal(
 
     if val.eq_raw(Qunbound) || val.is_nil() {
         LispObject::constant_nil()
-    } else if !val.is_cons() || val.is_module_function() {
+    } else if !val.is_cons() || FUNCTIONP(val) {
         args[0] = val;
         func(args)
     } else {

--- a/test/rust_src/src/eval-tests.el
+++ b/test/rust_src/src/eval-tests.el
@@ -236,4 +236,15 @@
   (let ((f (lambda () nil)))
     (should (functionp f))))
 
+(ert-deftest eval-tests--run-hooks-base ()
+  ;; We can't use let construct here because run-hooks takes a symbol
+  ;; as an argument and because of lexical binding, that symbol's
+  ;; value will always be nil
+  (setq function-hook '(lambda () (+ 1 1)))
+  (setq list-of-functions '((lambda () (+ 2 2))
+                            (lambda () (+ 3 3))))
+  (run-hooks 'function-hook 'list-of-functions)
+  (makunbound 'function-hook)
+  (makunbound 'list-of-functions))
+
 ;;; eval-tests.el ends here


### PR DESCRIPTION
Addresses #758.

Cause of the issue:

When a hook's value is a single function, C behaviour is to call that function. To check if the value is a function, C code uses `FUNCTIONP`. There was a mistake at this part in ported Rust code and because of that `'(lambda () (+ 1 1))` is treated as a list of functions and this leads to the error `Invalid function: lambda`

Since `run-hooks` takes a symbol as an argument, I couldn't use `let` construct in tests. I used `setq` and `makunbound`. Is this an acceptable usage?
