### PR TITLE
Temporary fix for MacOS re-builder freeze

### DIFF
--- a/rust_src/src/windows.rs
+++ b/rust_src/src/windows.rs
@@ -70,7 +70,7 @@ impl LispWindowRef {
 
         if mode_line_height >= 0 {
             mode_line_height
-        } else if matrix_mode_line_height != 0 {
+        } else if matrix_mode_line_height > 1 {
             unsafe { wset_mode_line_height(self.as_mut(), matrix_mode_line_height) };
             matrix_mode_line_height
         } else {


### PR DESCRIPTION
Resolves [#717](https://github.com/Wilfred/remacs/issues/717) even though this solution is not optimal. The original GNU Emacs C-code has the != 0 logic but for some reason it doesn't work in remacs, the glyph matrix seems to hold invalid values. This bug that seems to happen when a small window is being opened, like when launching re-builder.

(I moved these changes to from master to a separate branch in my forked repository, that's why I closed the old pull request and created a identical one.)