### PR TITLE
Add checks for eassert and emacs_abort in pre-commit hook

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,8 @@ Thank you for contributing to Remacs!
   you have the correct version by using rustup (it will use the
   correct version based on our [toolchain
   file](https://github.com/rust-lang-nursery/rustup.rs#the-toolchain-file))
-  and running `rustup component add rustfmt-preview`
+  and running `rustup component add rustfmt-preview`. See
+  [Helpful Hooks](#helpful-hooks) for help to automatate this verification.
 * Add docstrings to your Rust functions `/// This function does ...`
 * _Really_ great PRs include tests. See
   [Writing Tests](#writing-tests) for more information.
@@ -51,6 +52,20 @@ if you ported a function from keyboard.c to keyboard.rs the tests
 would belong in `test/rust_src/src/keyboard-tests.el`. If you wrote
 the tests in `test/src/` while porting just copy the code over to the
 equivalent file in `test/rust_src/src` before submitting the PR.
+
+## Helpful Hooks
+
+The script `rust_src/src/admin/pre-commit` performs some basic checks
+to see if any style rule is violated. To run it automatically before
+every commit, go to the git root level and run the following commands:
+
+```sh
+cd .git/hooks
+ln -s ../../rust_src/admin/pre-commit pre-commit
+```
+
+Among other things, the script will ensure that the code is formatted
+properly in line with the project's guidelines.
 
 ## Getting your PRs merged
 

--- a/rust_src/admin/pre-commit
+++ b/rust_src/admin/pre-commit
@@ -43,17 +43,18 @@ if [ -z "$stripped_diff" ]; then
 	echo -e "success."
 else
 	echo -e "FAIL!"
-	echo "$diff"
+	echo -e "Following code is not formatted with rustfmt. Make sure to run 'make rustfmt' from git root.\n"
+	echo -e "$diff\n"
 	errors=1
 fi
 
-OVERRIDE_TEXT="To commit anyway, pass --no-verify to git commit."
 
 # Check if emacs_abort is used
 EMACS_ABORT_PATTERN='\+.*emacs_abort'
 if [ "$(git diff --cached --diff-filter=ACM | grep $EMACS_ABORT_PATTERN)" != "" ]; then
     cat <<EOF
-Some files use emacs_abort. Use panic! with a string explaining cause instead. See $GIT_ROOT/rust_src/src/buffers.rs for examples.
+Some files use emacs_abort. Use panic! with a string explaining cause instead. See $GIT_TOPLEVEL/rust_src/src/buffers.rs for examples.
+
 EOF
     errors=1
 fi
@@ -63,7 +64,8 @@ EASSERT_PATTERN='\+.*eassert'
 # Check for eassert
 if [ "$(git diff --cached --diff-filter=ACM | grep $EASSERT_PATTERN)" != "" ]; then
     cat <<EOF
-Some files use eassert. Use debug_assert! instead. See $GIT_ROOT/rust_src/lisp.rs for examples.
+Some files use eassert. Use debug_assert! instead. See $GIT_TOPLEVEL/rust_src/lisp.rs for examples.
+
 EOF
     errors=1
 fi
@@ -71,7 +73,7 @@ fi
 
 if [ "$errors" != 0 ]; then
     echo "pre-commit checks failed"
-    echo $OVERRIDE_TEXT
+    echo "To commit anyway, pass --no-verify to git commit."
     exit 1
 else
 	echo "OK"

--- a/rust_src/admin/pre-commit
+++ b/rust_src/admin/pre-commit
@@ -47,9 +47,32 @@ else
 	errors=1
 fi
 
+OVERRIDE_TEXT="To commit anyway, pass --no-verify to git commit."
+
+# Check if emacs_abort is used
+EMACS_ABORT_PATTERN='\+.*emacs_abort'
+if [ "$(git diff --cached --diff-filter=ACM | grep $EMACS_ABORT_PATTERN)" != "" ]; then
+    cat <<EOF
+Some files use emacs_abort. Use panic! with a string explaining cause instead. See $GIT_ROOT/rust_src/src/buffers.rs for examples.
+EOF
+    errors=1
+fi
+
+# Check if eassert is used
+EASSERT_PATTERN='\+.*eassert'
+# Check for eassert
+if [ "$(git diff --cached --diff-filter=ACM | grep $EASSERT_PATTERN)" != "" ]; then
+    cat <<EOF
+Some files use eassert. Use debug_assert! instead. See $GIT_ROOT/rust_src/lisp.rs for examples.
+EOF
+    errors=1
+fi
+
+
 if [ "$errors" != 0 ]; then
-	echo "Failed"
-	exit 1
+    echo "pre-commit checks failed"
+    echo $OVERRIDE_TEXT
+    exit 1
 else
 	echo "OK"
 fi


### PR DESCRIPTION
I guess not formatting code with `rustfmt` is a common beginner mistake. Hence added some explanatory text.