### PR TITLE
Remove LispObject::from_raw

### DIFF
--- a/rust_src/remacs-macros/lib.rs
+++ b/rust_src/remacs-macros/lib.rs
@@ -46,7 +46,7 @@ pub fn lisp_fn(attr_ts: TokenStream, fn_ts: TokenStream) -> TokenStream {
             let arg = quote! { #ident: ::lisp::LispObject, };
             cargs.append_all(arg);
 
-            let arg = quote! { ::lisp::LispObject::from_raw(#ident).into(), };
+            let arg = quote! { (#ident).into(), };
             rargs.append_all(arg);
         },
         function::LispFnType::Many => {

--- a/rust_src/src/base64.rs
+++ b/rust_src/src/base64.rs
@@ -360,7 +360,7 @@ pub fn base64_encode_string(mut string: LispStringRef, no_line_break: bool) -> L
         error!("Multibyte character in data for base64 encoding");
     }
 
-    unsafe { LispObject::from_raw(make_unibyte_string(encoded, encoded_length)) }
+    unsafe { make_unibyte_string(encoded, encoded_length) }
 }
 
 /// Base64-decode STRING and return the result.
@@ -384,7 +384,7 @@ pub fn base64_decode_string(mut string: LispStringRef) -> LispObject {
     }
     unsafe {
         buffer.set_len(decoded_length as usize);
-        LispObject::from_raw(make_unibyte_string(decoded, decoded_length))
+        make_unibyte_string(decoded, decoded_length)
     }
 }
 

--- a/rust_src/src/buffers.rs
+++ b/rust_src/src/buffers.rs
@@ -72,7 +72,7 @@ impl LispBufferRef {
     }
 
     pub fn is_read_only(&self) -> bool {
-        LispObject::from_raw(self.read_only).into()
+        self.read_only.into()
     }
 
     #[inline]
@@ -188,38 +188,38 @@ impl LispBufferRef {
 
     #[inline]
     pub fn mark_active(self) -> LispObject {
-        LispObject::from_raw(self.mark_active)
+        self.mark_active
     }
 
     #[inline]
     pub fn pt_marker(self) -> LispObject {
-        LispObject::from_raw(self.pt_marker)
+        self.pt_marker
     }
 
     #[inline]
     pub fn begv_marker(self) -> LispObject {
-        LispObject::from_raw(self.begv_marker)
+        self.begv_marker
     }
 
     #[inline]
     pub fn zv_marker(self) -> LispObject {
-        LispObject::from_raw(self.zv_marker)
+        self.zv_marker
     }
 
     #[inline]
     pub fn mark(self) -> LispObject {
-        LispObject::from_raw(self.mark)
+        self.mark
     }
 
     #[allow(dead_code)]
     #[inline]
     pub fn name(self) -> LispObject {
-        LispObject::from_raw(self.name)
+        self.name
     }
 
     #[inline]
     pub fn filename(self) -> LispObject {
-        LispObject::from_raw(self.filename)
+        self.filename
     }
 
     #[inline]
@@ -229,17 +229,17 @@ impl LispBufferRef {
 
     #[inline]
     pub fn truename(self) -> LispObject {
-        LispObject::from_raw(self.file_truename)
+        self.file_truename
     }
 
     pub fn case_fold_search(self) -> LispObject {
-        LispObject::from_raw(self.case_fold_search)
+        self.case_fold_search
     }
 
     // Check if buffer is live
     #[inline]
     pub fn is_live(self) -> bool {
-        LispObject::from_raw(self.name).is_not_nil()
+        self.name.is_not_nil()
     }
 
     #[inline]
@@ -281,7 +281,7 @@ impl LispBufferRef {
 
     #[inline]
     pub fn multibyte_characters_enabled(self) -> bool {
-        LispObject::from_raw(self.enable_multibyte_characters).is_not_nil()
+        self.enable_multibyte_characters.is_not_nil()
     }
 
     #[inline]
@@ -345,17 +345,17 @@ impl LispOverlayRef {
 
     #[inline]
     pub fn start(self) -> LispObject {
-        LispObject::from_raw(self.start)
+        self.start
     }
 
     #[inline]
     pub fn end(self) -> LispObject {
-        LispObject::from_raw(self.end)
+        self.end
     }
 
     #[inline]
     pub fn plist(self) -> LispObject {
-        LispObject::from_raw(self.plist)
+        self.plist
     }
 
     pub fn iter(self) -> LispOverlayIter {
@@ -405,7 +405,7 @@ impl LispBufferLocalValueRef {
     }
 
     pub fn get_value(self) -> LispObject {
-        LispObject::from_raw(unsafe { get_blv_value(self.as_ptr()) })
+        unsafe { get_blv_value(self.as_ptr()) }
     }
 }
 
@@ -415,13 +415,13 @@ impl LispBufferLocalValueRef {
 /// followed by the rest of the buffers.
 #[lisp_fn(min = "0")]
 pub fn buffer_list(frame: LispObject) -> LispObject {
-    let mut buffers: Vec<LispObject> = LispObject::from_raw(unsafe { Vbuffer_alist })
+    let mut buffers: Vec<LispObject> = unsafe { Vbuffer_alist }
         .iter_cars_safe()
         .map(|o| cdr(o).to_raw())
         .collect();
 
     match frame.as_frame() {
-        None => LispObject::from_raw(Flist(buffers.len() as isize, buffers.as_mut_ptr())),
+        None => Flist(buffers.len() as isize, buffers.as_mut_ptr()),
 
         Some(frame) => unsafe {
             let framelist = Fcopy_sequence(fget_buffer_list(frame.as_ptr()));
@@ -476,10 +476,9 @@ pub fn get_buffer(buffer_or_name: LispObject) -> LispObject {
         buffer_or_name
     } else {
         buffer_or_name.as_string_or_error();
-        cdr(assoc_ignore_text_properties(
-            buffer_or_name,
-            LispObject::from_raw(unsafe { Vbuffer_alist }),
-        ))
+        cdr(assoc_ignore_text_properties(buffer_or_name, unsafe {
+            Vbuffer_alist
+        }))
     }
 }
 
@@ -499,7 +498,7 @@ pub fn buffer_file_name(buffer: LispObject) -> LispObject {
         buffer.as_buffer_or_error()
     };
 
-    LispObject::from_raw(buf.filename)
+    buf.filename
 }
 
 /// Return t if BUFFER was modified since its file was last read or saved.
@@ -515,7 +514,7 @@ pub fn buffer_modified_p(buffer: LispObject) -> bool {
 /// Return nil if BUFFER has been killed.
 #[lisp_fn(min = "0")]
 pub fn buffer_name(buffer: LispObject) -> LispObject {
-    LispObject::from_raw(buffer.as_buffer_or_current_buffer().name)
+    buffer.as_buffer_or_current_buffer().name
 }
 
 /// Return BUFFER's tick counter, incremented for each change in text.
@@ -564,13 +563,13 @@ pub fn overlay_buffer(overlay: LispOverlayRef) -> Option<LispBufferRef> {
 /// effect on OVERLAY.
 #[lisp_fn]
 pub fn overlay_properties(overlay: LispOverlayRef) -> LispObject {
-    LispObject::from_raw(unsafe { Fcopy_sequence(overlay.plist) })
+    unsafe { Fcopy_sequence(overlay.plist) }
 }
 
 #[no_mangle]
 pub extern "C" fn validate_region(b: *mut LispObject, e: *mut LispObject) {
-    let start = LispObject::from_raw(unsafe { *b });
-    let stop = LispObject::from_raw(unsafe { *e });
+    let start = unsafe { *b };
+    let stop = unsafe { *e };
 
     let mut beg = start.as_fixnum_coerce_marker_or_error();
     let mut end = stop.as_fixnum_coerce_marker_or_error();
@@ -621,11 +620,9 @@ pub fn set_buffer(buffer_or_name: LispObject) -> LispObject {
 pub fn barf_if_buffer_read_only(position: Option<EmacsInt>) -> () {
     let pos = position.unwrap_or_else(point);
 
-    let inhibit_read_only: bool =
-        unsafe { LispObject::from_raw(globals.f_Vinhibit_read_only).into() };
-    let prop = LispObject::from_raw(unsafe {
-        Fget_text_property(LispObject::from(pos).to_raw(), Qinhibit_read_only, Qnil)
-    });
+    let inhibit_read_only: bool = unsafe { globals.f_Vinhibit_read_only.into() };
+    let prop =
+        unsafe { Fget_text_property(LispObject::from(pos).to_raw(), Qinhibit_read_only, Qnil) };
 
     if ThreadState::current_buffer().is_read_only() && !inhibit_read_only && prop.is_nil() {
         xsignal!(Qbuffer_read_only, current_buffer())
@@ -635,7 +632,7 @@ pub fn barf_if_buffer_read_only(position: Option<EmacsInt>) -> () {
 /// No such buffer error.
 #[no_mangle]
 pub extern "C" fn nsberror(spec: LispObject) -> ! {
-    let spec = LispObject::from_raw(spec);
+    let spec = spec;
     if let Some(s) = spec.as_string() {
         error!("No buffer named {}", s);
     } else {
@@ -657,7 +654,7 @@ pub fn overlay_lists() -> LispObject {
         let ol_list = ol.iter().fold(Qnil, |accum, n| unsafe {
             Fcons(n.as_lisp_obj().to_raw(), accum)
         });
-        LispObject::from_raw(ol_list)
+        ol_list
     };
 
     let cur_buf = ThreadState::current_buffer();
@@ -667,7 +664,7 @@ pub fn overlay_lists() -> LispObject {
     let after = cur_buf
         .overlays_after()
         .map_or_else(LispObject::constant_nil, &list_overlays);
-    unsafe { LispObject::from_raw(Fcons(Fnreverse(before.to_raw()), Fnreverse(after.to_raw()))) }
+    unsafe { Fcons(Fnreverse(before.to_raw()), Fnreverse(after.to_raw())) }
 }
 
 fn get_truename_buffer_1(filename: LispObject) -> LispObject {
@@ -682,7 +679,7 @@ fn get_truename_buffer_1(filename: LispObject) -> LispObject {
 // to be removed once all references in C are ported
 #[no_mangle]
 pub extern "C" fn get_truename_buffer(filename: LispObject) -> LispObject {
-    get_truename_buffer_1(LispObject::from_raw(filename)).to_raw()
+    get_truename_buffer_1(filename).to_raw()
 }
 
 /// If buffer B has markers to record PT, BEGV and ZV when it is not
@@ -753,13 +750,11 @@ pub extern "C" fn fetch_buffer_markers(buffer: *mut Lisp_Buffer) {
 #[lisp_fn]
 pub fn get_file_buffer(filename: LispObject) -> Option<LispBufferRef> {
     verify_lisp_type!(filename, Qstringp);
-    let filename = unsafe { LispObject::from_raw(Fexpand_file_name(filename.to_raw(), Qnil)) };
+    let filename = unsafe { Fexpand_file_name(filename.to_raw(), Qnil) };
 
     // If the file name has special constructs in it,
     // call the corresponding file handler.
-    let handler = unsafe {
-        LispObject::from_raw(Ffind_file_name_handler(filename.to_raw(), Qget_file_buffer))
-    };
+    let handler = unsafe { Ffind_file_name_handler(filename.to_raw(), Qget_file_buffer) };
 
     if handler.is_not_nil() {
         let handled_buf = call_raw!(handler.to_raw(), Qget_file_buffer, filename.to_raw());
@@ -777,8 +772,7 @@ pub fn get_file_buffer(filename: LispObject) -> Option<LispBufferRef> {
 /// is the default binding of the variable.
 #[lisp_fn(name = "buffer-local-value", c_name = "buffer_local_value")]
 pub fn buffer_local_value_lisp(variable: LispObject, buffer: LispObject) -> LispObject {
-    let result =
-        LispObject::from_raw(unsafe { buffer_local_value(variable.to_raw(), buffer.to_raw()) });
+    let result = unsafe { buffer_local_value(variable.to_raw(), buffer.to_raw()) };
 
     if result.eq_raw(Qunbound) {
         xsignal!(Qvoid_variable, variable);

--- a/rust_src/src/category.rs
+++ b/rust_src/src/category.rs
@@ -10,9 +10,8 @@ use threads::ThreadState;
 /// Return t if ARG is a category table.
 #[lisp_fn]
 pub fn category_table_p(arg: LispObject) -> bool {
-    arg.as_char_table().map_or(false, |table| {
-        LispObject::from_raw(table.purpose).eq(LispObject::from_raw(Qcategory_table))
-    })
+    arg.as_char_table()
+        .map_or(false, |table| table.purpose.eq(Qcategory_table))
 }
 
 /// Return the current category table.
@@ -20,7 +19,7 @@ pub fn category_table_p(arg: LispObject) -> bool {
 #[lisp_fn]
 pub fn category_table() -> LispObject {
     let buffer_ref = ThreadState::current_buffer();
-    LispObject::from_raw(buffer_ref.category_table)
+    buffer_ref.category_table
 }
 
 include!(concat!(env!("OUT_DIR"), "/category_exports.rs"));

--- a/rust_src/src/chartable.rs
+++ b/rust_src/src/chartable.rs
@@ -61,7 +61,7 @@ impl LispCharTableRef {
 
     pub fn get(self, c: isize) -> LispObject {
         let mut val = if is_ascii(c) {
-            let tmp = LispObject::from_raw(self.ascii);
+            let tmp = self.ascii;
             if let Some(sub) = tmp.as_sub_char_table_ascii() {
                 sub.get(c)
             } else {
@@ -70,10 +70,7 @@ impl LispCharTableRef {
         } else {
             let tmp = self.contents
                 .get(chartab_idx(c, 0, 0) as usize)
-                .map_or_else(
-                    || error!("Index out of range"),
-                    |tmp| LispObject::from_raw(*tmp),
-                );
+                .map_or_else(|| error!("Index out of range"), |tmp| *tmp);
             if let Some(sub) = tmp.as_sub_char_table() {
                 sub.get(c, self.is_uniprop())
             } else {
@@ -82,9 +79,9 @@ impl LispCharTableRef {
         };
 
         if val.is_nil() {
-            val = LispObject::from_raw(self.default);
+            val = self.default;
             if val.is_nil() {
-                if let Some(parent) = LispObject::from_raw(self.parent).as_char_table() {
+                if let Some(parent) = self.parent.as_char_table() {
                     val = parent.get(c);
                 }
             }
@@ -125,9 +122,9 @@ impl LispSubCharTableRef {
         let mut val = self._get(idx);
 
         if is_uniprop && uniprop_compressed_form_p(val) {
-            val = LispObject::from_raw(unsafe {
+            val = unsafe {
                 uniprop_table_uncompress(self.as_lisp_obj().to_raw(), idx as libc::c_int)
-            });
+            };
         }
 
         if let Some(sub) = val.as_sub_char_table() {
@@ -145,7 +142,7 @@ fn is_ascii(c: isize) -> bool {
 /// Return the subtype of char-table CHARTABLE.  The value is a symbol.
 #[lisp_fn]
 pub fn char_table_subtype(chartable: LispCharTableRef) -> LispObject {
-    LispObject::from_raw(chartable.purpose)
+    chartable.purpose
 }
 
 /// Return the parent char-table of CHARTABLE.
@@ -155,7 +152,7 @@ pub fn char_table_subtype(chartable: LispCharTableRef) -> LispObject {
 /// (or from its parents, if necessary).
 #[lisp_fn]
 pub fn char_table_parent(chartable: LispCharTableRef) -> Option<LispCharTableRef> {
-    LispObject::from_raw(chartable.parent).as_char_table()
+    chartable.parent.as_char_table()
 }
 
 /// Set the parent char-table of CHARTABLE to PARENT.

--- a/rust_src/src/crypto/mod.rs
+++ b/rust_src/src/crypto/mod.rs
@@ -62,10 +62,10 @@ fn hash_alg(algorithm: LispObject) -> HashAlg {
 }
 
 fn check_coding_system_or_error(coding_system: LispObject, noerror: LispObject) -> LispObject {
-    if LispObject::from_raw(unsafe { Fcoding_system_p(coding_system.to_raw()) }).is_nil() {
+    if unsafe { Fcoding_system_p(coding_system.to_raw()) }.is_nil() {
         /* Invalid coding system. */
         if noerror.is_not_nil() {
-            LispObject::from_raw(Qraw_text)
+            Qraw_text
         } else {
             xsignal!(Qcoding_system_error, coding_system);
         }
@@ -79,9 +79,9 @@ fn get_coding_system_for_string(string: LispStringRef, coding_system: LispObject
         /* Decide the coding-system to encode the data with. */
         if string.is_multibyte() {
             /* use default, we can't guess correct value */
-            LispObject::from_raw(unsafe { preferred_coding_system() })
+            unsafe { preferred_coding_system() }
         } else {
-            LispObject::from_raw(Qraw_text)
+            Qraw_text
         }
     } else {
         coding_system
@@ -102,18 +102,17 @@ fn get_coding_system_for_buffer(
     if coding_system.is_not_nil() {
         return coding_system;
     }
-    if LispObject::from_raw(unsafe { globals.f_Vcoding_system_for_write }).is_not_nil() {
-        return LispObject::from_raw(unsafe { globals.f_Vcoding_system_for_write });
+    if unsafe { globals.f_Vcoding_system_for_write }.is_not_nil() {
+        return unsafe { globals.f_Vcoding_system_for_write };
     }
-    if (LispObject::from_raw(buffer.buffer_file_coding_system).is_nil()
-        || LispObject::from_raw(unsafe {
-            Flocal_variable_p(
-                Qbuffer_file_coding_system,
-                LispObject::constant_nil().to_raw(),
-            )
-        }).is_nil()) && !buffer.multibyte_characters_enabled()
+    if (buffer.buffer_file_coding_system.is_nil() || unsafe {
+        Flocal_variable_p(
+            Qbuffer_file_coding_system,
+            LispObject::constant_nil().to_raw(),
+        )
+    }.is_nil()) && !buffer.multibyte_characters_enabled()
     {
-        return LispObject::from_raw(Qraw_text);
+        return Qraw_text;
     }
     if buffer_file_name(object).is_not_nil() {
         /* Check file-coding-system-alist. */
@@ -123,18 +122,17 @@ fn get_coding_system_for_buffer(
             end.to_raw(),
             buffer_file_name(object).to_raw(),
         ];
-        let val =
-            LispObject::from_raw(unsafe { Ffind_operation_coding_system(4, args.as_mut_ptr()) });
+        let val = unsafe { Ffind_operation_coding_system(4, args.as_mut_ptr()) };
         if val.is_cons() && val.as_cons_or_error().cdr().is_not_nil() {
             return val.as_cons_or_error().cdr();
         }
     }
-    if LispObject::from_raw(buffer.buffer_file_coding_system).is_not_nil() {
+    if buffer.buffer_file_coding_system.is_not_nil() {
         /* If we still have not decided a coding system, use the
            default value of buffer-file-coding-system. */
-        return LispObject::from_raw(buffer.buffer_file_coding_system);
+        return buffer.buffer_file_coding_system;
     }
-    let sscsf = LispObject::from_raw(unsafe { globals.f_Vselect_safe_coding_system_function });
+    let sscsf = unsafe { globals.f_Vselect_safe_coding_system_function };
     if fboundp(sscsf.as_symbol_or_error()) {
         /* Confirm that VAL can surely encode the current region. */
         return call!(
@@ -184,14 +182,14 @@ fn get_input_from_string(
     if start_byte == 0 && end_byte == size {
         object
     } else {
-        LispObject::from_raw(unsafe {
+        unsafe {
             make_specified_string(
                 string.const_sdata_ptr().offset(start_byte),
                 -1 as ptrdiff_t,
                 end_byte - start_byte,
                 string.is_multibyte(),
             )
-        })
+        }
     }
 }
 
@@ -227,7 +225,7 @@ fn get_input_from_buffer(
     if !(buffer.begv <= *start_byte && *end_byte <= buffer.zv) {
         args_out_of_range!(start, end);
     }
-    let string = LispObject::from_raw(unsafe { make_buffer_string(*start_byte, *end_byte, false) });
+    let string = unsafe { make_buffer_string(*start_byte, *end_byte, false) };
     unsafe { set_buffer_internal(prev_buffer) };
     // TODO: this needs to be std::mem::size_of<specbinding>()
     unsafe { (*current_thread).m_specpdl_ptr = (*current_thread).m_specpdl_ptr.offset(-40) };
@@ -250,7 +248,7 @@ fn get_input(
                 noerror,
             );
             *string = Some(
-                LispObject::from_raw(unsafe {
+                unsafe {
                     code_convert_string(
                         object.to_raw(),
                         coding_system.to_raw(),
@@ -259,7 +257,7 @@ fn get_input(
                         false,
                         true,
                     )
-                }).as_string_or_error(),
+                }.as_string_or_error(),
             )
         }
         get_input_from_string(object, string.unwrap(), start, end).as_string_or_error()
@@ -281,7 +279,7 @@ fn get_input(
                 ),
                 noerror,
             );
-            LispObject::from_raw(unsafe {
+            unsafe {
                 code_convert_string(
                     s.to_raw(),
                     coding_system.to_raw(),
@@ -290,7 +288,7 @@ fn get_input(
                     false,
                     false,
                 )
-            }).as_string_or_error()
+            }.as_string_or_error()
         } else {
             ss
         }
@@ -414,7 +412,7 @@ fn _secure_hash(
     } else {
         digest_size as EmacsInt
     };
-    let digest = LispObject::from_raw(unsafe { make_uninit_string(buffer_size as EmacsInt) });
+    let digest = unsafe { make_uninit_string(buffer_size as EmacsInt) };
     let mut digest_str = digest.as_string_or_error();
     hash_func(input_slice, digest_str.as_mut_slice());
     if binary.is_nil() {
@@ -515,7 +513,7 @@ pub fn buffer_hash(buffer_or_name: LispObject) -> LispObject {
     }
 
     let formatted = ctx.digest().to_string();
-    let digest = LispObject::from_raw(unsafe { make_uninit_string(formatted.len() as EmacsInt) });
+    let digest = unsafe { make_uninit_string(formatted.len() as EmacsInt) };
     digest
         .as_string()
         .unwrap()

--- a/rust_src/src/data.rs
+++ b/rust_src/src/data.rs
@@ -127,7 +127,7 @@ pub fn type_of(object: LispObject) -> LispObject {
             }
         }
     };
-    LispObject::from_raw(ty)
+    ty
 }
 
 #[lisp_fn]
@@ -249,7 +249,7 @@ pub fn defalias(sym: LispObject, mut definition: LispObject, docstring: LispObje
             // If `definition' is a keymap, immutable (and copying) is wrong.
             && get_keymap(definition.to_raw(), false, false) == Qnil
         {
-            definition = LispObject::from_raw(Fpurecopy(definition.to_raw()));
+            definition = Fpurecopy(definition.to_raw());
         }
     }
 
@@ -258,7 +258,7 @@ pub fn defalias(sym: LispObject, mut definition: LispObject, docstring: LispObje
         // Only add autoload entries after dumping, because the ones before are
         // not useful and else we get loads of them from the loaddefs.el.
 
-        if is_autoload(LispObject::from_raw(symbol.function)) {
+        if is_autoload(symbol.function) {
             // Remember that the function was already an autoload.
             loadhist_attach(unsafe { Fcons(Qt, sym.to_raw()) });
         }
@@ -266,7 +266,7 @@ pub fn defalias(sym: LispObject, mut definition: LispObject, docstring: LispObje
     }
 
     // Handle automatic advice activation.
-    let hook = get(symbol, LispObject::from_raw(Qdefalias_fset_function));
+    let hook = get(symbol, Qdefalias_fset_function);
     if hook.is_not_nil() {
         call!(hook, sym, definition);
     } else {
@@ -274,11 +274,7 @@ pub fn defalias(sym: LispObject, mut definition: LispObject, docstring: LispObje
     }
 
     if docstring.is_not_nil() {
-        put(
-            sym,
-            LispObject::from_raw(Qfunction_documentation),
-            docstring,
-        );
+        put(sym, Qfunction_documentation, docstring);
     }
 
     // We used to return `definition', but now that `defun' and `defmacro' expand
@@ -296,9 +292,9 @@ pub fn defalias(sym: LispObject, mut definition: LispObject, docstring: LispObje
 pub fn subr_arity(subr: LispSubrRef) -> LispObject {
     let minargs = subr.min_args();
     let maxargs = if subr.is_many() {
-        LispObject::from_raw(Qmany)
+        Qmany
     } else if subr.is_unevalled() {
-        LispObject::from_raw(Qunevalled)
+        Qunevalled
     } else {
         LispObject::from(subr.max_args() as EmacsInt)
     };
@@ -311,7 +307,7 @@ pub fn subr_arity(subr: LispSubrRef) -> LispObject {
 #[lisp_fn]
 pub fn subr_name(subr: LispSubrRef) -> LispObject {
     let name = subr.symbol_name();
-    LispObject::from_raw(unsafe { build_string(name) })
+    unsafe { build_string(name) }
 }
 
 include!(concat!(env!("OUT_DIR"), "/data_exports.rs"));

--- a/rust_src/src/editfns.rs
+++ b/rust_src/src/editfns.rs
@@ -105,9 +105,9 @@ pub fn gap_size() -> EmacsInt {
 /// If there is no region active, signal an error.
 fn region_limit(beginningp: bool) -> EmacsInt {
     let current_buf = ThreadState::current_buffer();
-    if LispObject::from_raw(unsafe { globals.f_Vtransient_mark_mode }).is_not_nil()
-        && LispObject::from_raw(unsafe { globals.f_Vmark_even_if_inactive }).is_nil()
-        && current_buf.mark_active().is_nil()
+    if unsafe { globals.f_Vtransient_mark_mode }.is_not_nil() && unsafe {
+        globals.f_Vmark_even_if_inactive
+    }.is_nil() && current_buf.mark_active().is_nil()
     {
         xsignal!(Qmark_inactive);
     }
@@ -364,7 +364,7 @@ pub fn propertize(args: &[LispObject]) -> LispObject {
     let first = it.next().unwrap();
     let orig_string = first.as_string_or_error();
 
-    let copy = LispObject::from_raw(unsafe { Fcopy_sequence(first.to_raw()) });
+    let copy = unsafe { Fcopy_sequence(first.to_raw()) };
 
     let mut properties = Qnil;
 
@@ -393,9 +393,7 @@ pub fn char_to_string(character: LispObject) -> LispObject {
     let mut buffer = [0_u8; MAX_MULTIBYTE_LENGTH];
     let len = write_codepoint(&mut buffer[..], c);
 
-    LispObject::from_raw(unsafe {
-        make_string_from_bytes(buffer.as_ptr() as *const i8, 1, len as isize)
-    })
+    unsafe { make_string_from_bytes(buffer.as_ptr() as *const i8, 1, len as isize) }
 }
 
 /// Convert arg BYTE to a unibyte string containing that byte.
@@ -406,7 +404,7 @@ pub fn byte_to_string(byte: EmacsInt) -> LispObject {
     }
     let byte = byte as i8;
 
-    LispObject::from_raw(unsafe { make_string_from_bytes(&byte as *const i8, 1, 1) })
+    unsafe { make_string_from_bytes(&byte as *const i8, 1, 1) }
 }
 
 /// Return the first character in STRING.
@@ -608,11 +606,11 @@ pub fn constrain_to_field(
     if unsafe { globals.f_Vinhibit_field_text_motion == Qnil } && new_pos != old_pos
         && (get_char_property(
             new_pos,
-            LispObject::from_raw(Qfield),
+            Qfield,
             LispObject::constant_nil()).is_not_nil()
             || get_char_property(
                 old_pos,
-                LispObject::from_raw(Qfield),
+                Qfield,
                 LispObject::constant_nil()).is_not_nil()
             // To recognize field boundaries, we must also look at the
             // previous positions; we could use `Fget_pos_property'
@@ -621,14 +619,10 @@ pub fn constrain_to_field(
             || (new_pos > begv
                 && get_char_property(
                     prev_new,
-                    LispObject::from_raw(Qfield),
+                    Qfield,
                     LispObject::constant_nil()).is_not_nil())
             || (old_pos > begv
-                && get_char_property(
-                    prev_old,
-                    LispObject::from_raw(Qfield),
-                    LispObject::constant_nil(),
-                ).is_not_nil()))
+                && get_char_property(prev_old, Qfield, LispObject::constant_nil()).is_not_nil()))
         && (inhibit_capture_property.is_nil()
             // Field boundaries are again a problem; but now we must
             // decide the case exactly, so we need to call

--- a/rust_src/src/eval_macros.rs
+++ b/rust_src/src/eval_macros.rs
@@ -35,9 +35,7 @@ macro_rules! call {
         let mut argsarray = [$func.to_raw(), $($arg.to_raw()),*];
         #[allow(unused_unsafe)]
         unsafe {
-            LispObject::from_raw(
-                ::remacs_sys::Ffuncall(argsarray.len() as ::libc::ptrdiff_t, argsarray.as_mut_ptr())
-            )
+            ::remacs_sys::Ffuncall(argsarray.len() as ::libc::ptrdiff_t, argsarray.as_mut_ptr())
         }
     }}
 }
@@ -47,15 +45,13 @@ macro_rules! call_raw {
         let mut argsarray = [$func, $($arg),*];
         #[allow(unused_unsafe)]
         unsafe {
-            LispObject::from_raw(
-                ::remacs_sys::Ffuncall(argsarray.len() as ::libc::ptrdiff_t, argsarray.as_mut_ptr())
-            )
+            ::remacs_sys::Ffuncall(argsarray.len() as ::libc::ptrdiff_t, argsarray.as_mut_ptr())
         }
     }};
     ($func:expr) => {{
         #[allow(unused_unsafe)]
         unsafe {
-            LispObject::from_raw(::remacs_sys::Ffuncall(1, &mut $func))
+            ::remacs_sys::Ffuncall(1, &mut $func)
         }
     }}
 }
@@ -65,9 +61,7 @@ macro_rules! callN_raw {
         let mut argsarray = [$($arg),*];
         #[allow(unused_unsafe)]
         unsafe {
-            LispObject::from_raw(
-                $func(argsarray.len() as ::libc::ptrdiff_t, argsarray.as_mut_ptr())
-            )
+            $func(argsarray.len() as ::libc::ptrdiff_t, argsarray.as_mut_ptr())
         }
     }}
 }
@@ -92,7 +86,7 @@ macro_rules! error {
             ::remacs_sys::make_string($str.as_ptr() as *const ::libc::c_char,
                                       $str.len() as ::libc::ptrdiff_t)
         };
-        xsignal!(::remacs_sys::Qerror, $crate::lisp::LispObject::from_raw(strobj));
+        xsignal!(::remacs_sys::Qerror, strobj);
     }};
     ($fmtstr:expr, $($arg:expr),*) => {{
         let formatted = format!($fmtstr, $($arg),*);
@@ -101,14 +95,14 @@ macro_rules! error {
             ::remacs_sys::make_string(formatted.as_ptr() as *const ::libc::c_char,
                                       formatted.len() as ::libc::ptrdiff_t)
         };
-        xsignal!(::remacs_sys::Qerror, $crate::lisp::LispObject::from_raw(strobj));
+        xsignal!(::remacs_sys::Qerror, strobj);
     }};
 }
 
 /// Macro to format a "wrong argument type" error message.
 macro_rules! wrong_type {
     ($pred:expr, $arg:expr) => {
-        xsignal!(::remacs_sys::Qwrong_type_argument, LispObject::from_raw($pred), $arg);
+        xsignal!(::remacs_sys::Qwrong_type_argument, $pred, $arg);
     };
 }
 
@@ -162,7 +156,6 @@ macro_rules! verify_lisp_type {
 macro_rules! per_buffer_var_idx {
     ($field: ident) => {
         #[allow(unused_unsafe)]
-        ($crate::lisp::LispObject::from_raw(
-            unsafe{buffer_local_flags.$field})).as_natnum_or_error() as usize
+        (unsafe{buffer_local_flags.$field}).as_natnum_or_error() as usize
     }
 }

--- a/rust_src/src/ffi.rs
+++ b/rust_src/src/ffi.rs
@@ -10,22 +10,18 @@ use windows;
 
 #[no_mangle]
 pub extern "C" fn circular_list(obj: LispObject) -> ! {
-    lists::circular_list(LispObject::from_raw(obj))
+    lists::circular_list(obj)
 }
 
 #[no_mangle]
 pub extern "C" fn merge(l1: LispObject, l2: LispObject, pred: LispObject) -> LispObject {
-    let result = lists::merge(
-        LispObject::from_raw(l1),
-        LispObject::from_raw(l2),
-        LispObject::from_raw(pred),
-    );
+    let result = lists::merge(l1, l2, pred);
     result.to_raw()
 }
 
 #[no_mangle]
 pub extern "C" fn indirect_function(object: LispObject) -> LispObject {
-    let result = data::indirect_function(LispObject::from_raw(object));
+    let result = data::indirect_function(object);
     result.to_raw()
 }
 
@@ -35,17 +31,13 @@ pub extern "C" fn arithcompare(
     obj2: LispObject,
     comparison: math::ArithComparison,
 ) -> LispObject {
-    let result = math::arithcompare(
-        LispObject::from_raw(obj1),
-        LispObject::from_raw(obj2),
-        comparison,
-    );
+    let result = math::arithcompare(obj1, obj2, comparison);
     LispObject::from(result).to_raw()
 }
 
 #[no_mangle]
 pub extern "C" fn lucid_event_type_list_p(event: LispObject) -> bool {
-    keyboard::lucid_event_type_list_p(LispObject::from_raw(event).as_cons())
+    keyboard::lucid_event_type_list_p(event.as_cons())
 }
 
 #[no_mangle]

--- a/rust_src/src/fns.rs
+++ b/rust_src/src/fns.rs
@@ -28,12 +28,9 @@ use vectors::length;
 /// SUBFEATURE can be used to check a specific subfeature of FEATURE.
 #[lisp_fn(min = "1")]
 pub fn featurep(feature: LispSymbolRef, subfeature: LispObject) -> bool {
-    let mut tem = memq(
-        feature.as_lisp_obj(),
-        LispObject::from_raw(unsafe { globals.f_Vfeatures }),
-    );
+    let mut tem = memq(feature.as_lisp_obj(), unsafe { globals.f_Vfeatures });
     if tem.is_not_nil() && subfeature.is_not_nil() {
-        tem = member(subfeature, get(feature, LispObject::from_raw(Qsubfeatures)));
+        tem = member(subfeature, get(feature, Qsubfeatures));
     }
     tem.is_not_nil()
 }
@@ -47,28 +44,20 @@ pub fn provide(feature: LispSymbolRef, subfeature: LispObject) -> LispObject {
         wrong_type!(Qlistp, subfeature)
     }
     unsafe {
-        if LispObject::from_raw(Vautoload_queue).is_not_nil() {
+        if Vautoload_queue.is_not_nil() {
             Vautoload_queue = Fcons(
                 Fcons(LispObject::from_fixnum(0).to_raw(), globals.f_Vfeatures),
                 Vautoload_queue,
             );
         }
     }
-    if memq(
-        feature.as_lisp_obj(),
-        LispObject::from_raw(unsafe { globals.f_Vfeatures }),
-    ).is_nil()
-    {
+    if memq(feature.as_lisp_obj(), unsafe { globals.f_Vfeatures }).is_nil() {
         unsafe {
             globals.f_Vfeatures = Fcons(feature.as_lisp_obj().to_raw(), globals.f_Vfeatures);
         }
     }
     if subfeature.is_not_nil() {
-        put(
-            feature.as_lisp_obj(),
-            LispObject::from_raw(Qsubfeatures),
-            subfeature,
-        );
+        put(feature.as_lisp_obj(), Qsubfeatures, subfeature);
     }
     unsafe {
         globals.f_Vcurrent_load_list = Fcons(
@@ -78,11 +67,7 @@ pub fn provide(feature: LispSymbolRef, subfeature: LispObject) -> LispObject {
     }
     // Run any load-hooks for this file.
     unsafe {
-        if let Some(c) = assq(
-            feature.as_lisp_obj(),
-            LispObject::from_raw(globals.f_Vafter_load_alist),
-        ).as_cons()
-        {
+        if let Some(c) = assq(feature.as_lisp_obj(), globals.f_Vafter_load_alist).as_cons() {
             Fmapc(Qfuncall, c.cdr().to_raw());
         }
     }
@@ -102,11 +87,7 @@ pub fn provide(feature: LispSymbolRef, subfeature: LispObject) -> LispObject {
 #[lisp_fn(unevalled = "true")]
 pub fn quote(args: LispCons) -> LispObject {
     if args.cdr().is_not_nil() {
-        xsignal!(
-            Qwrong_number_of_arguments,
-            LispObject::from_raw(Qquote),
-            length(args.as_obj())
-        );
+        xsignal!(Qwrong_number_of_arguments, Qquote, length(args.as_obj()));
     }
 
     args.car()
@@ -142,7 +123,7 @@ unsafe extern "C" fn require_unwind(old_value: LispObject) {
 #[lisp_fn(min = "1")]
 pub fn require(feature: LispObject, filename: LispObject, noerror: LispObject) -> LispObject {
     let feature_sym = feature.as_symbol_or_error();
-    let current_load_list = LispObject::from_raw(unsafe { globals.f_Vcurrent_load_list });
+    let current_load_list = unsafe { globals.f_Vcurrent_load_list };
 
     // Record the presence of `require' in this file
     // even if the feature specified is already loaded.
@@ -155,17 +136,13 @@ pub fn require(feature: LispObject, filename: LispObject, noerror: LispObject) -
             .map_or(false, |elt| elt.is_string());
 
     if from_file {
-        let tem = LispObject::cons(LispObject::from_raw(Qrequire), feature);
+        let tem = LispObject::cons(Qrequire, feature);
         if member(tem, current_load_list).is_nil() {
             loadhist_attach(tem.to_raw());
         }
     }
 
-    if memq(
-        feature,
-        LispObject::from_raw(unsafe { globals.f_Vfeatures }),
-    ).is_not_nil()
-    {
+    if memq(feature, unsafe { globals.f_Vfeatures }).is_not_nil() {
         return feature;
     }
 
@@ -183,7 +160,7 @@ pub fn require(feature: LispObject, filename: LispObject, noerror: LispObject) -
     // A certain amount of recursive `require' is legitimate,
     // but if we require the same feature recursively 3 times,
     // signal an error.
-    let nesting = LispObject::from_raw(unsafe { require_nesting_list })
+    let nesting = unsafe { require_nesting_list }
         .iter_cars()
         .filter(|elt| equal(feature, *elt))
         .count();
@@ -219,18 +196,13 @@ pub fn require(feature: LispObject, filename: LispObject, noerror: LispObject) -
 
         // If load failed entirely, return nil.
         if tem == Qnil {
-            return LispObject::from_raw(unbind_to(count, Qnil));
+            return unbind_to(count, Qnil);
         }
     }
 
-    let tem = memq(
-        feature,
-        LispObject::from_raw(unsafe { globals.f_Vfeatures }),
-    );
+    let tem = memq(feature, unsafe { globals.f_Vfeatures });
     if tem.is_nil() {
-        let tem3 = car(car(LispObject::from_raw(unsafe {
-            globals.f_Vload_history
-        })));
+        let tem3 = car(car(unsafe { globals.f_Vload_history }));
 
         if tem3.is_nil() {
             error!(
@@ -252,7 +224,7 @@ pub fn require(feature: LispObject, filename: LispObject, noerror: LispObject) -
         Vautoload_queue = Qt;
     }
 
-    LispObject::from_raw(unsafe { unbind_to(count, feature.to_raw()) })
+    unsafe { unbind_to(count, feature.to_raw()) }
 }
 def_lisp_sym!(Qrequire, "require");
 
@@ -263,14 +235,14 @@ def_lisp_sym!(Qrequire, "require");
 /// usage: (append &rest SEQUENCES)
 #[lisp_fn]
 pub fn append(args: &mut [LispObject]) -> LispObject {
-    LispObject::from_raw(unsafe {
+    unsafe {
         lisp_concat(
             args.len() as isize,
             args.as_mut_ptr() as *mut LispObject,
             Lisp_Type::Lisp_Cons,
             true,
         )
-    })
+    }
 }
 
 /// Concatenate all the arguments and make the result a string.
@@ -279,14 +251,14 @@ pub fn append(args: &mut [LispObject]) -> LispObject {
 /// usage: (concat &rest SEQUENCES)
 #[lisp_fn]
 pub fn concat(args: &mut [LispObject]) -> LispObject {
-    LispObject::from_raw(unsafe {
+    unsafe {
         lisp_concat(
             args.len() as isize,
             args.as_mut_ptr() as *mut LispObject,
             Lisp_Type::Lisp_String,
             false,
         )
-    })
+    }
 }
 
 include!(concat!(env!("OUT_DIR"), "/fns_exports.rs"));

--- a/rust_src/src/fonts.rs
+++ b/rust_src/src/fonts.rs
@@ -43,11 +43,11 @@ impl FontExtraType {
     // Needed for wrong_type! that is using a safe predicate. This may change in the future.
     #[allow(unused_unsafe)]
     pub fn from_symbol_or_error(extra_type: LispObject) -> FontExtraType {
-        if extra_type.eq(LispObject::from_raw(unsafe { Qfont_spec })) {
+        if extra_type.eq(unsafe { Qfont_spec }) {
             FontExtraType::Spec
-        } else if extra_type.eq(LispObject::from_raw(unsafe { Qfont_entity })) {
+        } else if extra_type.eq(unsafe { Qfont_entity }) {
             FontExtraType::Entity
-        } else if extra_type.eq(LispObject::from_raw(unsafe { Qfont_object })) {
+        } else if extra_type.eq(unsafe { Qfont_object }) {
             FontExtraType::Object
         } else {
             wrong_type!(intern("font-extra-type").to_raw(), extra_type);

--- a/rust_src/src/frames.rs
+++ b/rust_src/src/frames.rs
@@ -63,17 +63,17 @@ impl LispFrameRef {
 
     #[inline]
     pub fn minibuffer_window(self) -> LispObject {
-        LispObject::from_raw(unsafe { fget_minibuffer_window(self.as_ptr()) })
+        unsafe { fget_minibuffer_window(self.as_ptr()) }
     }
 
     #[inline]
     pub fn root_window(self) -> LispObject {
-        LispObject::from_raw(unsafe { fget_root_window(self.as_ptr()) })
+        unsafe { fget_root_window(self.as_ptr()) }
     }
 
     #[inline]
     pub fn selected_window(self) -> LispObject {
-        LispObject::from_raw(unsafe { fget_selected_window(self.as_ptr()) })
+        unsafe { fget_selected_window(self.as_ptr()) }
     }
 
     #[inline]
@@ -153,7 +153,7 @@ pub fn window_frame_live_or_selected_with_action<W: FnMut(LispWindowRef) -> ()>(
 /// Return the frame that is now selected.
 #[lisp_fn]
 pub fn selected_frame() -> LispObject {
-    unsafe { LispObject::from_raw(current_frame) }
+    unsafe { current_frame }
 }
 
 /// Return non-nil if OBJECT is a frame which has not been deleted.
@@ -202,7 +202,7 @@ pub fn set_frame_selected_window(
         error!("In `set-frame-selected-window', WINDOW is not on FRAME")
     }
     if frame_ref == selected_frame().as_frame().unwrap() {
-        unsafe { LispObject::from_raw(Fselect_window(window.to_raw(), norecord.to_raw())) }
+        unsafe { Fselect_window(window.to_raw(), norecord.to_raw()) }
     } else {
         frame_ref.set_selected_window(window);
         window
@@ -224,14 +224,14 @@ pub fn framep(object: LispObject) -> LispObject {
 }
 
 fn framep_1(frame: LispFrameRef) -> LispObject {
-    LispObject::from_raw(match unsafe { fget_output_method(frame.as_ptr()) } {
+    match unsafe { fget_output_method(frame.as_ptr()) } {
         output_initial | output_termcap => Qt,
         output_x_window => Qx,
         output_w32 => Qw32,
         output_msdos_raw => Qpc,
         output_ns => Qns,
         _ => panic!("Invalid frame output_method!"),
-    })
+    }
 }
 
 /// The name of the window system that FRAME is displaying through.
@@ -278,7 +278,7 @@ pub fn frame_visible_p(frame: LispFrameRef) -> LispObject {
     if frame.is_visible() {
         LispObject::constant_t()
     } else if frame.is_iconified() {
-        LispObject::from_raw(Qicon)
+        Qicon
     } else {
         LispObject::constant_nil()
     }
@@ -293,10 +293,10 @@ pub fn frame_visible_p(frame: LispFrameRef) -> LispObject {
 pub fn frame_position(frame: LispObject) -> LispObject {
     let frame_ref = frame_live_or_selected(frame);
     unsafe {
-        LispObject::from_raw(Fcons(
+        Fcons(
             LispObject::from_fixnum(EmacsInt::from(frame_ref.left_pos())).to_raw(),
             LispObject::from_fixnum(EmacsInt::from(frame_ref.top_pos())).to_raw(),
-        ))
+        )
     }
 }
 

--- a/rust_src/src/hashtable.rs
+++ b/rust_src/src/hashtable.rs
@@ -40,7 +40,7 @@ impl LispHashTableRef {
     }
 
     pub fn get_hash(self) -> LispObject {
-        LispObject::from_raw(self.hash)
+        self.hash
     }
 
     pub fn set_next(&mut self, next: LispObject) {
@@ -48,7 +48,7 @@ impl LispHashTableRef {
     }
 
     pub fn get_next(self) -> LispObject {
-        LispObject::from_raw(self.next)
+        self.next
     }
 
     pub fn set_index(&mut self, index: LispObject) {
@@ -56,11 +56,11 @@ impl LispHashTableRef {
     }
 
     pub fn get_index(self) -> LispObject {
-        LispObject::from_raw(self.index)
+        self.index
     }
 
     pub fn get_key_and_value(self) -> LispObject {
-        LispObject::from_raw(self.key_and_value)
+        self.key_and_value
     }
 
     pub fn set_key_and_value(&mut self, key_and_value: LispObject) {
@@ -68,15 +68,12 @@ impl LispHashTableRef {
     }
 
     pub fn get_weak(self) -> LispObject {
-        LispObject::from_raw(self.weak)
+        self.weak
     }
 
     #[inline]
     pub fn get_hash_value(self, idx: isize) -> LispObject {
-        aref(
-            LispObject::from_raw(self.key_and_value),
-            (2 * idx + 1) as EmacsInt,
-        )
+        aref(self.key_and_value, (2 * idx + 1) as EmacsInt)
     }
 
     #[inline]
@@ -107,14 +104,11 @@ impl LispHashTableRef {
     }
 
     pub fn get_hash_hash(self, idx: isize) -> LispObject {
-        aref(LispObject::from_raw(self.hash), idx as EmacsInt)
+        aref(self.hash, idx as EmacsInt)
     }
 
     pub fn get_hash_key(self, idx: isize) -> LispObject {
-        aref(
-            LispObject::from_raw(self.key_and_value),
-            (2 * idx) as EmacsInt,
-        )
+        aref(self.key_and_value, (2 * idx) as EmacsInt)
     }
 
     pub fn size(self) -> usize {
@@ -198,11 +192,10 @@ pub fn copy_hash_table(mut table: LispHashTableRef) -> LispHashTableRef {
     unsafe { new_table.copy(table) };
     assert_ne!(new_table.as_ptr(), table.as_ptr());
 
-    let key_and_value =
-        LispObject::from_raw(unsafe { Fcopy_sequence(new_table.get_key_and_value().to_raw()) });
-    let hash = LispObject::from_raw(unsafe { Fcopy_sequence(new_table.get_hash().to_raw()) });
-    let next = LispObject::from_raw(unsafe { Fcopy_sequence(new_table.get_next().to_raw()) });
-    let index = LispObject::from_raw(unsafe { Fcopy_sequence(new_table.get_index().to_raw()) });
+    let key_and_value = unsafe { Fcopy_sequence(new_table.get_key_and_value().to_raw()) };
+    let hash = unsafe { Fcopy_sequence(new_table.get_hash().to_raw()) };
+    let next = unsafe { Fcopy_sequence(new_table.get_next().to_raw()) };
+    let index = unsafe { Fcopy_sequence(new_table.get_index().to_raw()) };
     new_table.set_key_and_value(key_and_value);
     new_table.set_hash(hash);
     new_table.set_next(next);
@@ -295,7 +288,7 @@ pub fn hash_table_size(table: LispHashTableRef) -> EmacsInt {
 /// Return the test TABLE uses.
 #[lisp_fn]
 pub fn hash_table_test(table: LispHashTableRef) -> LispObject {
-    LispObject::from_raw(table.test.name)
+    table.test.name
 }
 
 /// Return the weakness of TABLE.
@@ -324,7 +317,7 @@ pub fn clrhash(hash_table: LispHashTableRef) -> LispHashTableRef {
 /// returns nil, then (funcall TEST x1 x2) also returns nil.
 #[lisp_fn]
 pub fn define_hash_table_test(name: LispObject, test: LispObject, hash: LispObject) -> LispObject {
-    let sym = LispObject::from_raw(Qhash_table_test);
+    let sym = Qhash_table_test;
     put(name, sym, list(&[test, hash]))
 }
 

--- a/rust_src/src/interactive.rs
+++ b/rust_src/src/interactive.rs
@@ -13,7 +13,7 @@ use lisp::defsubr;
 pub fn prefix_numeric_value(raw: LispObject) -> EmacsInt {
     if raw.is_nil() {
         1
-    } else if raw.eq(LispObject::from_raw(Qminus)) {
+    } else if raw.eq(Qminus) {
         -1
     } else if raw.is_integer() {
         raw.as_fixnum_or_error()

--- a/rust_src/src/keyboard.rs
+++ b/rust_src/src/keyboard.rs
@@ -26,9 +26,7 @@ use windows::window_or_selected_unchecked;
 pub fn posn_at_point(pos: LispObject, window: LispObject) -> LispObject {
     let window = window_or_selected_unchecked(window);
 
-    let tem = LispObject::from_raw(unsafe {
-        Fpos_visible_in_window_p(pos.to_raw(), window.to_raw(), Qt)
-    });
+    let tem = unsafe { Fpos_visible_in_window_p(pos.to_raw(), window.to_raw(), Qt) };
     if tem.is_nil() {
         return LispObject::constant_nil();
     }
@@ -96,14 +94,14 @@ pub fn posn_at_x_y(
         y = w.frame_pixel_y(y);
     });
 
-    LispObject::from_raw(unsafe {
+    unsafe {
         make_lispy_position(
             frame.as_ptr(),
             LispObject::from_fixnum(EmacsInt::from(x)).to_raw(),
             LispObject::from_natnum(EmacsInt::from(y)).to_raw(),
             0,
         )
-    })
+    }
 }
 
 /// Return true if EVENT is a list whose elements are all integers or symbols.
@@ -112,10 +110,8 @@ pub fn posn_at_x_y(
 pub fn lucid_event_type_list_p(event: Option<LispCons>) -> bool {
     event.map_or(false, |event| {
         let first = event.car();
-        if first.eq(LispObject::from_raw(Qhelp_echo))
-            || first.eq(LispObject::from_raw(Qvertical_line))
-            || first.eq(LispObject::from_raw(Qmode_line))
-            || first.eq(LispObject::from_raw(Qheader_line))
+        if first.eq(Qhelp_echo) || first.eq(Qvertical_line) || first.eq(Qmode_line)
+            || first.eq(Qheader_line)
         {
             return false;
         }

--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -84,17 +84,17 @@ impl LispObject {
 
     #[inline]
     pub fn constant_unbound() -> LispObject {
-        LispObject::from_raw(Qunbound)
+        Qunbound
     }
 
     #[inline]
     pub fn constant_t() -> LispObject {
-        LispObject::from_raw(Qt)
+        Qt
     }
 
     #[inline]
     pub fn constant_nil() -> LispObject {
-        LispObject::from_raw(Qnil)
+        Qnil
     }
 
     #[inline]
@@ -108,12 +108,7 @@ impl LispObject {
 
     #[inline]
     pub fn from_float(v: EmacsDouble) -> LispObject {
-        LispObject::from_raw(unsafe { make_float(v) })
-    }
-
-    #[inline]
-    pub fn from_raw(i: LispObject) -> LispObject {
-        i
+        unsafe { make_float(v) }
     }
 
     #[inline]
@@ -206,7 +201,7 @@ impl LispObject {
             ((tag << VALBITS) + ptr) as EmacsInt
         };
 
-        LispObject::from_raw(LispObject::from_C(res))
+        LispObject::from_C(res)
     }
 
     #[inline]
@@ -218,7 +213,7 @@ impl LispObject {
 // Obarray support
 impl LispObject {
     pub fn as_obarray_or_error(self) -> LispObarrayRef {
-        LispObarrayRef::new(LispObject::from_raw(check_obarray(self.to_raw())))
+        LispObarrayRef::new(check_obarray(self.to_raw()))
     }
 }
 
@@ -448,7 +443,7 @@ impl LispObject {
         } else {
             (n & INTMASK) as EmacsUint + ((Lisp_Type::Lisp_Int0 as EmacsUint) << VALBITS)
         };
-        LispObject::from_raw(LispObject::from_C(o as EmacsInt))
+        LispObject::from_C(o as EmacsInt)
     }
 
     /// Convert a positive integer into its LispObject representation.
@@ -1182,12 +1177,12 @@ macro_rules! impl_alistval_iter {
     };
 }
 
-impl_alistval_iter! {LiveBufferIter, LispBufferRef, LispObject::from_raw(unsafe { Vbuffer_alist })}
+impl_alistval_iter! {LiveBufferIter, LispBufferRef, unsafe { Vbuffer_alist }}
 
 impl LispObject {
     #[inline]
     pub fn cons(car: LispObject, cdr: LispObject) -> Self {
-        unsafe { LispObject::from_raw(Fcons(car.to_raw(), cdr.to_raw())) }
+        unsafe { Fcons(car.to_raw(), cdr.to_raw()) }
     }
 
     #[inline]
@@ -1289,12 +1284,12 @@ impl LispCons {
 
     /// Return the car (first cell).
     pub fn car(self) -> LispObject {
-        LispObject::from_raw(unsafe { (*self._extract()).car })
+        unsafe { (*self._extract()).car }
     }
 
     /// Return the cdr (second cell).
     pub fn cdr(self) -> LispObject {
-        LispObject::from_raw(unsafe { (*self._extract()).cdr })
+        unsafe { (*self._extract()).cdr }
     }
 
     pub fn as_tuple(self) -> (LispObject, LispObject) {
@@ -1450,7 +1445,7 @@ impl LispObject {
 
     #[inline]
     pub fn empty_unibyte_string() -> LispStringRef {
-        LispStringRef::from(LispObject::from_raw(unsafe { empty_unibyte_string }))
+        LispStringRef::from(unsafe { empty_unibyte_string })
     }
 }
 

--- a/rust_src/src/lists.rs
+++ b/rust_src/src/lists.rs
@@ -379,7 +379,7 @@ pub fn lax_plist_put(plist: LispObject, prop: LispObject, val: LispObject) -> Li
 /// This is the last value stored with `(put SYMBOL PROPNAME VALUE)'.
 #[lisp_fn]
 pub fn get(symbol: LispSymbolRef, propname: LispObject) -> LispObject {
-    let plist_env = LispObject::from_raw(unsafe { globals.f_Voverriding_plist_environment });
+    let plist_env = unsafe { globals.f_Voverriding_plist_environment };
     let propval = plist_get(cdr(assq(symbol.as_lisp_obj(), plist_env)), propname);
     if propval.is_not_nil() {
         propval

--- a/rust_src/src/marker.rs
+++ b/rust_src/src/marker.rs
@@ -144,7 +144,7 @@ pub fn marker_buffer(marker: LispMarkerRef) -> Option<LispBufferRef> {
 /// Set PT from MARKER's clipped position.
 #[no_mangle]
 pub extern "C" fn set_point_from_marker(marker: LispObject) {
-    let marker = LispObject::from_raw(marker).as_marker_or_error();
+    let marker = marker.as_marker_or_error();
     let cur_buf = ThreadState::current_buffer();
     let charpos = clip_to_bounds(
         cur_buf.begv,
@@ -198,7 +198,7 @@ pub fn copy_marker(marker: LispObject, itype: LispObject) -> LispObject {
     if marker.is_not_nil() {
         marker.as_fixnum_coerce_marker_or_error();
     }
-    let new = unsafe { LispObject::from_raw(Fmake_marker()) };
+    let new = unsafe { Fmake_marker() };
     let buffer_or_nil = marker
         .as_marker()
         .and_then(|m| m.buffer())
@@ -275,12 +275,7 @@ pub extern "C" fn set_marker_restricted(
     position: LispObject,
     buffer: LispObject,
 ) -> LispObject {
-    set_marker_internal(
-        LispObject::from_raw(marker),
-        LispObject::from_raw(position),
-        LispObject::from_raw(buffer),
-        true,
-    ).to_raw()
+    set_marker_internal(marker, position, buffer, true).to_raw()
 }
 
 /// Set the position of MARKER, specifying both the
@@ -292,8 +287,8 @@ pub extern "C" fn set_marker_both(
     charpos: ptrdiff_t,
     bytepos: ptrdiff_t,
 ) -> LispObject {
-    let mut m = LispObject::from_raw(marker).as_marker_or_error();
-    if let Some(mut b) = live_buffer(LispObject::from_raw(buffer)) {
+    let mut m = marker.as_marker_or_error();
+    if let Some(mut b) = live_buffer(buffer) {
         attach_marker(m.as_mut(), b.as_mut(), charpos, bytepos);
     } else {
         unsafe { unchain_marker(m.as_mut()) };
@@ -309,9 +304,9 @@ pub extern "C" fn set_marker_restricted_both(
     charpos: ptrdiff_t,
     bytepos: ptrdiff_t,
 ) -> LispObject {
-    let mut m = LispObject::from_raw(marker).as_marker_or_error();
+    let mut m = marker.as_marker_or_error();
 
-    if let Some(mut b) = live_buffer(LispObject::from_raw(buffer)) {
+    if let Some(mut b) = live_buffer(buffer) {
         let cur_buf = ThreadState::current_buffer();
         let clipped_charpos = clip_to_bounds(cur_buf.begv, charpos as EmacsInt, cur_buf.zv);
         let clipped_bytepos =
@@ -330,14 +325,14 @@ pub extern "C" fn set_marker_restricted_both(
 /// Return the char position of marker MARKER, as a C integer.
 #[no_mangle]
 pub extern "C" fn marker_position(marker: LispObject) -> ptrdiff_t {
-    let m = LispObject::from_raw(marker).as_marker_or_error();
+    let m = marker.as_marker_or_error();
     m.charpos_or_error()
 }
 
 /// Return the byte position of marker MARKER, as a C integer.
 #[no_mangle]
 pub extern "C" fn marker_byte_position(marker: LispObject) -> ptrdiff_t {
-    let m = LispObject::from_raw(marker).as_marker_or_error();
+    let m = marker.as_marker_or_error();
     m.bytepos_or_error()
 }
 

--- a/rust_src/src/minibuf.rs
+++ b/rust_src/src/minibuf.rs
@@ -22,7 +22,7 @@ pub fn minibufferp(object: LispObject) -> bool {
         object.as_buffer_or_error();
         object
     };
-    memq(buffer, LispObject::from_raw(unsafe { Vminibuffer_list })).is_not_nil()
+    memq(buffer, unsafe { Vminibuffer_list }).is_not_nil()
 }
 
 /// Return the currently active minibuffer window, or nil if none.
@@ -32,7 +32,7 @@ pub fn active_minibuffer_window() -> LispObject {
         if minibuf_level == 0 {
             LispObject::constant_nil()
         } else {
-            LispObject::from_raw(minibuf_window)
+            minibuf_window
         }
     }
 }

--- a/rust_src/src/obarray.rs
+++ b/rust_src/src/obarray.rs
@@ -20,9 +20,7 @@ impl LispObarrayRef {
 
     /// Return a reference to the Lisp variable `obarray`.
     pub fn global() -> LispObarrayRef {
-        LispObarrayRef(LispObject::from_raw(check_obarray(unsafe {
-            globals.f_Vobarray
-        })))
+        LispObarrayRef(check_obarray(unsafe { globals.f_Vobarray }))
     }
 
     pub fn as_lisp_obj(&self) -> LispObject {
@@ -35,14 +33,14 @@ impl LispObarrayRef {
     pub fn lookup(&self, name: LispObject) -> LispObject {
         let string = name.symbol_or_string_as_string();
         let obj = self.as_lisp_obj();
-        LispObject::from_raw(unsafe {
+        unsafe {
             oblookup(
                 obj.to_raw(),
                 string.const_sdata_ptr(),
                 string.len_chars(),
                 string.len_bytes(),
             )
-        })
+        }
     }
 
     /// Intern the string or symbol STRING. That is, return the new or existing
@@ -54,16 +52,16 @@ impl LispObarrayRef {
         let obj = self.as_lisp_obj();
         if tem.is_symbol() {
             tem
-        } else if LispObject::from_raw(unsafe { globals.f_Vpurify_flag }).is_not_nil() {
+        } else if unsafe { globals.f_Vpurify_flag }.is_not_nil() {
             // When Emacs is running lisp code to dump to an executable, make
             // use of pure storage.
-            LispObject::from_raw(intern_driver(
+            intern_driver(
                 unsafe { Fpurecopy(string.to_raw()) },
                 obj.to_raw(),
                 tem.to_raw(),
-            ))
+            )
         } else {
-            LispObject::from_raw(intern_driver(string.to_raw(), obj.to_raw(), tem.to_raw()))
+            intern_driver(string.to_raw(), obj.to_raw(), tem.to_raw())
         }
     }
 }
@@ -71,10 +69,10 @@ impl LispObarrayRef {
 /// Intern (e.g. create a symbol from) a string.
 pub fn intern<T: AsRef<str>>(string: T) -> LispObject {
     let s = string.as_ref();
-    LispObject::from_raw(intern_1(
+    intern_1(
         s.as_ptr() as *const libc::c_char,
         s.len() as libc::ptrdiff_t,
-    ))
+    )
 }
 
 #[no_mangle]
@@ -101,7 +99,7 @@ pub extern "C" fn check_obarray(obarray: LispObject) -> LispObject {
     let v = obarray.as_vector();
     if v.map_or(0, |v_1| v_1.len()) == 0 {
         // If Vobarray is now invalid, force it to be valid.
-        if LispObject::from_raw(unsafe { globals.f_Vobarray }).eq(obarray) {
+        if unsafe { globals.f_Vobarray }.eq(obarray) {
             unsafe { globals.f_Vobarray = initial_obarray };
         }
         wrong_type!(Qvectorp, obarray);
@@ -116,7 +114,7 @@ pub extern "C" fn map_obarray(
     func: extern "C" fn(LispObject, LispObject),
     arg: LispObject,
 ) {
-    let v = LispObject::from_raw(obarray).as_vector_or_error();
+    let v = obarray.as_vector_or_error();
     for item in v.iter().rev() {
         if let Some(sym) = item.as_symbol() {
             for s in sym.iter() {
@@ -131,7 +129,7 @@ pub extern "C" fn map_obarray(
 #[no_mangle]
 pub extern "C" fn intern_1(s: *const libc::c_char, len: libc::ptrdiff_t) -> LispObject {
     let obarray = LispObarrayRef::global().as_lisp_obj().to_raw();
-    let tem = LispObject::from_raw(unsafe { oblookup(obarray, s, len, len) });
+    let tem = unsafe { oblookup(obarray, s, len, len) };
 
     if tem.is_symbol() {
         tem.to_raw()
@@ -151,14 +149,14 @@ pub extern "C" fn intern_1(s: *const libc::c_char, len: libc::ptrdiff_t) -> Lisp
 #[no_mangle]
 pub extern "C" fn intern_c_string_1(s: *const libc::c_char, len: libc::ptrdiff_t) -> LispObject {
     let obarray = LispObarrayRef::global().as_lisp_obj().to_raw();
-    let tem = LispObject::from_raw(unsafe { oblookup(obarray, s, len, len) });
+    let tem = unsafe { oblookup(obarray, s, len, len) };
 
     if tem.is_symbol() {
         tem.to_raw()
     } else {
         // Creating a non-pure string from a string literal not implemented yet.
         // We could just use make_string here and live with the extra copy.
-        assert!(LispObject::from_raw(unsafe { globals.f_Vpurify_flag }).is_not_nil());
+        assert!(unsafe { globals.f_Vpurify_flag }.is_not_nil());
         intern_driver(unsafe { make_pure_c_string(s, len) }, obarray, tem.to_raw())
     }
 }

--- a/rust_src/src/strings.rs
+++ b/rust_src/src/strings.rs
@@ -69,9 +69,8 @@ pub fn string_as_multibyte(string: LispStringRef) -> LispObject {
         &mut nbytes,
     );
 
-    let new_string = LispObject::from_raw(unsafe {
-        make_uninit_multibyte_string(nchars as EmacsInt, nbytes as EmacsInt)
-    });
+    let new_string =
+        unsafe { make_uninit_multibyte_string(nchars as EmacsInt, nbytes as EmacsInt) };
     let mut new_s = new_string.as_string().unwrap();
     unsafe {
         ptr::copy_nonoverlapping(
@@ -103,7 +102,7 @@ pub fn string_as_multibyte(string: LispStringRef) -> LispObject {
 /// correct sequence.
 #[lisp_fn]
 pub fn string_to_multibyte(string: LispStringRef) -> LispObject {
-    unsafe { LispObject::from_raw(c_string_to_multibyte(string.as_lisp_obj().to_raw())) }
+    unsafe { c_string_to_multibyte(string.as_lisp_obj().to_raw()) }
 }
 
 /// Return a unibyte string with the same individual chars as STRING.
@@ -124,8 +123,7 @@ pub fn string_to_unibyte(string: LispStringRef) -> LispObject {
             error!("Can't convert {}th character to unibyte", converted_size);
         }
 
-        let raw_ptr = unsafe { make_unibyte_string(buffer.as_ptr() as *const libc::c_char, size) };
-        LispObject::from_raw(raw_ptr)
+        unsafe { make_unibyte_string(buffer.as_ptr() as *const libc::c_char, size) }
     } else {
         string.as_lisp_obj()
     }

--- a/rust_src/src/symbols.rs
+++ b/rust_src/src/symbols.rs
@@ -19,15 +19,15 @@ pub type LispSymbolRef = ExternalPtr<Lisp_Symbol>;
 
 impl LispSymbolRef {
     pub fn symbol_name(self) -> LispObject {
-        LispObject::from_raw(self.name)
+        self.name
     }
 
     pub fn get_function(self) -> LispObject {
-        LispObject::from_raw(self.function)
+        self.function
     }
 
     pub fn get_plist(self) -> LispObject {
-        LispObject::from_raw(self.plist)
+        self.plist
     }
 
     pub fn set_plist(&mut self, plist: LispObject) {
@@ -64,7 +64,7 @@ impl LispSymbolRef {
     }
 
     pub fn as_lisp_obj(mut self) -> LispObject {
-        LispObject::from_raw(unsafe { make_lisp_symbol(self.as_mut()) })
+        unsafe { make_lisp_symbol(self.as_mut()) }
     }
 
     /// Return the symbol holding SYMBOL's value.  Signal
@@ -105,7 +105,7 @@ impl LispSymbolRef {
     }
 
     pub fn get_value(self) -> LispObject {
-        LispObject::from_raw(unsafe { self.val.value })
+        unsafe { self.val.value }
     }
 
     pub fn get_blv(self) -> LispBufferLocalValueRef {
@@ -288,7 +288,7 @@ pub fn symbol_value(symbol: LispObject) -> LispObject {
     if val == LispObject::constant_unbound().to_raw() {
         xsignal!(Qvoid_variable, symbol);
     }
-    LispObject::from_raw(val)
+    val
 }
 
 include!(concat!(env!("OUT_DIR"), "/symbols_exports.rs"));

--- a/rust_src/src/syntax.rs
+++ b/rust_src/src/syntax.rs
@@ -12,7 +12,7 @@ use threads::ThreadState;
 /// current buffer.
 #[lisp_fn]
 pub fn syntax_table() -> LispObject {
-    LispObject::from_raw(ThreadState::current_buffer().syntax_table)
+    ThreadState::current_buffer().syntax_table
 }
 
 /// Scan from character number FROM by COUNT lists.

--- a/rust_src/src/textprop.rs
+++ b/rust_src/src/textprop.rs
@@ -19,14 +19,14 @@ use lisp::defsubr;
 /// overlays are considered only if they are associated with OBJECT.
 #[lisp_fn(min = "2")]
 pub fn get_char_property(position: EmacsInt, prop: LispObject, object: LispObject) -> LispObject {
-    LispObject::from_raw(unsafe {
+    unsafe {
         get_char_property_and_overlay(
             LispObject::from(position).to_raw(),
             prop.to_raw(),
             object.to_raw(),
             ptr::null_mut(),
         )
-    })
+    }
 }
 
 include!(concat!(env!("OUT_DIR"), "/textprop_exports.rs"));

--- a/rust_src/src/threads.rs
+++ b/rust_src/src/threads.rs
@@ -24,7 +24,7 @@ impl ThreadState {
 impl ThreadStateRef {
     #[inline]
     pub fn name(self) -> LispObject {
-        LispObject::from_raw(self.name)
+        self.name
     }
 
     #[inline]

--- a/rust_src/src/time.rs
+++ b/rust_src/src/time.rs
@@ -65,7 +65,7 @@ pub extern "C" fn disassemble_lisp_time(
     pusec: *mut LispObject,
     ppsec: *mut LispObject,
 ) -> c_int {
-    let specified_time = LispObject::from_raw(specified_time);
+    let specified_time = specified_time;
 
     let mut high = LispObject::from_fixnum(0);
     let mut low = specified_time;
@@ -136,15 +136,15 @@ pub extern "C" fn decode_time_components(
     result: *mut lisp_time,
     dresult: *mut f64,
 ) -> c_int {
-    let high = LispObject::from_raw(high);
-    let usec = LispObject::from_raw(usec);
-    let psec = LispObject::from_raw(psec);
+    let high = high;
+    let usec = usec;
+    let psec = psec;
 
     if !(high.is_fixnum() && usec.is_fixnum() && psec.is_fixnum()) {
         return 0;
     }
 
-    let low = LispObject::from_raw(low);
+    let low = low;
 
     if !low.is_fixnum() {
         if let Some(t) = low.as_float() {

--- a/rust_src/src/windows.rs
+++ b/rust_src/src/windows.rs
@@ -35,7 +35,7 @@ impl LispWindowRef {
     /// This is also sometimes called a "leaf window" in Emacs sources.
     #[inline]
     pub fn is_live(self) -> bool {
-        LispObject::from_raw(self.contents).is_buffer()
+        self.contents.is_buffer()
     }
 
     #[inline]
@@ -52,12 +52,12 @@ impl LispWindowRef {
 
     #[inline]
     pub fn point_marker(self) -> LispObject {
-        LispObject::from_raw(self.pointm)
+        self.pointm
     }
 
     #[inline]
     pub fn contents(self) -> LispObject {
-        LispObject::from_raw(self.contents)
+        self.contents
     }
 
     /// Return the current height of the mode line of window W. If not known
@@ -89,12 +89,12 @@ impl LispWindowRef {
 
     #[inline]
     pub fn frame(self) -> LispObject {
-        LispObject::from_raw(self.frame)
+        self.frame
     }
 
     #[inline]
     pub fn start_marker(self) -> LispObject {
-        LispObject::from_raw(self.start)
+        self.start
     }
 
     #[inline]
@@ -122,8 +122,8 @@ impl LispWindowRef {
     }
 
     pub fn total_width(self, round: LispObject) -> i32 {
-        let qfloor = LispObject::from_raw(Qfloor);
-        let qceiling = LispObject::from_raw(Qceiling);
+        let qfloor = Qfloor;
+        let qceiling = Qceiling;
 
         if !(round == qfloor || round == qceiling) {
             self.total_cols
@@ -140,8 +140,8 @@ impl LispWindowRef {
     }
 
     pub fn total_height(self, round: LispObject) -> i32 {
-        let qfloor = LispObject::from_raw(Qfloor);
-        let qceiling = LispObject::from_raw(Qceiling);
+        let qfloor = Qfloor;
+        let qceiling = Qceiling;
 
         if !(round == qfloor || round == qceiling) {
             self.total_lines
@@ -203,13 +203,14 @@ impl LispWindowRef {
     /// buffer's 'mode-line-format' value must be non-nil.  Finally, W must
     /// be higher than its frame's canonical character height.
     pub fn wants_mode_line(self) -> bool {
-        let window_mode_line_format =
-            LispObject::from_raw(unsafe { window_parameter(self.as_ptr(), Qmode_line_format) });
+        let window_mode_line_format = unsafe { window_parameter(self.as_ptr(), Qmode_line_format) };
 
         self.is_live() && !self.is_minibuffer() && !self.is_pseudo()
-            && !window_mode_line_format.eq(LispObject::from_raw(Qnone))
+            && !window_mode_line_format.eq(Qnone)
             && (window_mode_line_format.is_not_nil()
-                || LispObject::from_raw(self.contents().as_buffer_or_error().mode_line_format)
+                || self.contents()
+                    .as_buffer_or_error()
+                    .mode_line_format
                     .is_not_nil())
             && self.pixel_height() > self.frame().as_frame_or_error().line_height()
     }
@@ -225,7 +226,7 @@ impl LispWindowRef {
     /// accommodate a mode line too if necessary (the mode line prevails).
     pub fn wants_header_line(self) -> bool {
         let window_header_line_format =
-            LispObject::from_raw(unsafe { window_parameter(self.as_ptr(), Qheader_line_format) });
+            unsafe { window_parameter(self.as_ptr(), Qheader_line_format) };
 
         let mut height = self.frame().as_frame_or_error().line_height();
         if self.wants_mode_line() {
@@ -233,10 +234,10 @@ impl LispWindowRef {
         }
 
         self.is_live() && !self.is_minibuffer() && !self.is_pseudo()
-            && !window_header_line_format.eq(LispObject::from_raw(Qnone))
+            && !window_header_line_format.eq(Qnone)
             && (window_header_line_format.is_not_nil()
-                || LispObject::from_raw(self.contents().as_buffer_or_error().header_line_format)
-                    .is_not_nil()) && self.pixel_height() > height
+                || (self.contents().as_buffer_or_error().header_line_format).is_not_nil())
+            && self.pixel_height() > height
     }
 }
 
@@ -324,7 +325,7 @@ pub fn window_point(window: LispObject) -> Option<EmacsInt> {
 /// selected windows appears and to which many commands apply.
 #[lisp_fn]
 pub fn selected_window() -> LispObject {
-    unsafe { LispObject::from_raw(current_window) }
+    unsafe { current_window }
 }
 
 /// Return the buffer displayed in window WINDOW.
@@ -399,7 +400,7 @@ pub fn window_combination_limit(window: LispWindowRef) -> LispObject {
         error!("Combination limit is meaningful for internal windows only");
     }
 
-    LispObject::from_raw(window.combination_limit)
+    window.combination_limit
 }
 
 /// Set combination limit of window WINDOW to LIMIT; return LIMIT.
@@ -424,7 +425,7 @@ pub fn set_window_combination_limit(mut window: LispWindowRef, limit: LispObject
 #[lisp_fn]
 pub fn minibuffer_selected_window() -> LispObject {
     let level = unsafe { minibuf_level };
-    let current_minibuf = unsafe { LispObject::from_raw(current_minibuf_window) };
+    let current_minibuf = unsafe { current_minibuf_window };
     if level > 0 && selected_window().as_window_or_error().is_minibuffer()
         && current_minibuf.as_window().unwrap().is_live()
     {
@@ -494,7 +495,7 @@ pub fn window_total_height(window: LispObject, round: LispObject) -> LispObject 
 /// Return nil for a window with no parent (e.g. a root window).
 #[lisp_fn(min = "0")]
 pub fn window_parent(window: LispObject) -> LispObject {
-    LispObject::from_raw(unsafe { wget_parent(window_valid_or_selected(window).as_ptr()) })
+    (unsafe { wget_parent(window_valid_or_selected(window).as_ptr()) })
 }
 
 /// Return the frame that window WINDOW is on.
@@ -530,7 +531,7 @@ pub fn minibuffer_window(frame: LispObject) -> LispObject {
 #[lisp_fn(min = "0")]
 pub fn window_display_table(window: LispObject) -> LispObject {
     let win = window_live_or_selected(window);
-    LispObject::from_raw(win.display_table)
+    win.display_table
 }
 
 pub fn window_wants_mode_line(window: LispWindowRef) -> bool {
@@ -552,7 +553,7 @@ pub fn set_window_parameter(
 ) -> LispObject {
     let w = window_or_selected(window);
     let w_params = unsafe { wget_window_parameters(w.as_ptr()) };
-    let old_alist_elt = assq(parameter, LispObject::from_raw(w_params));
+    let old_alist_elt = assq(parameter, w_params);
     if old_alist_elt.is_nil() {
         unsafe {
             wset_window_parameters(
@@ -592,7 +593,7 @@ pub extern "C" fn CURRENT_MODE_LINE_FACE_ID_3(
             if selw == current {
                 return MODE_LINE_FACE_ID;
             } else if minibuf_level > 0 {
-                let minibuf = LispObject::from_raw(current_minibuf_window);
+                let minibuf = current_minibuf_window;
                 if let Some(minibuf_window) = minibuf.as_window() {
                     if mbw == minibuf_window && scrw == minibuf_window {
                         return MODE_LINE_FACE_ID;
@@ -659,13 +660,7 @@ pub fn window_list(
         error!("Window is on a different frame");
     }
 
-    unsafe {
-        LispObject::from_raw(window_list_1(
-            w_obj.to_raw(),
-            minibuf.to_raw(),
-            f_obj.to_raw(),
-        ))
-    }
+    unsafe { (window_list_1(w_obj.to_raw(), minibuf.to_raw(), f_obj.to_raw())) }
 }
 
 /// Return a list of all live windows.
@@ -704,13 +699,7 @@ pub fn window_list_one(
     minibuf: LispObject,
     all_frames: LispObject,
 ) -> LispObject {
-    unsafe {
-        LispObject::from_raw(window_list_1(
-            window.to_raw(),
-            minibuf.to_raw(),
-            all_frames.to_raw(),
-        ))
-    }
+    unsafe { (window_list_1(window.to_raw(), minibuf.to_raw(), all_frames.to_raw())) }
 }
 
 include!(concat!(env!("OUT_DIR"), "/windows_exports.rs"));


### PR DESCRIPTION
Now that we've merged LispObject and Lisp_Object, there's no need for
this function. Removing it makes the code significantly less verbose
in places.