### PR TITLE
Follow GNU Emacs document style for em-dashes:

### DIFF
--- a/rust_src/src/casefiddle.rs
+++ b/rust_src/src/casefiddle.rs
@@ -9,7 +9,7 @@ use remacs_sys::{casify_object, CaseAction};
 /// This means that each word's first character is converted to either
 /// title case or upper case, and the rest to lower case.
 /// The argument may be a character or string.  The result has the same type.
-/// The argument object is not altered -- the value is a copy.  If argument
+/// The argument object is not altered--the value is a copy.  If argument
 /// is a character, characters which map to multiple code points when
 /// cased, e.g. ﬁ, are returned unchanged.
 #[lisp_fn]
@@ -19,7 +19,7 @@ pub fn capitalize(object: LispObject) -> LispObject {
 
 /// Convert argument to lower case and return that.
 /// The argument may be a character or string.  The result has the same type.
-/// The argument object is not altered -- the value is a copy.
+/// The argument object is not altered--the value is a copy.
 #[lisp_fn]
 pub fn downcase(object: LispObject) -> LispObject {
     unsafe { casify_object(CaseAction::CaseDown, object) }
@@ -27,7 +27,7 @@ pub fn downcase(object: LispObject) -> LispObject {
 
 /// Convert argument to upper case and return that.
 /// The argument may be a character or string.  The result has the same type.
-/// The argument object is not altered -- the value is a copy.  If argument
+/// The argument object is not altered--the value is a copy.  If argument
 /// is a character, characters which map to multiple code points when
 /// cased, e.g. ﬁ, are returned unchanged.
 /// See also `capitalize', `downcase' and `upcase-initials'.


### PR DESCRIPTION
they do not have surrounding spaces around them