### PR TITLE
Don't run a full build at the C errors stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ jobs:
         - sudo apt install -y texinfo libgif-dev libxpm-dev
         - travis_wait rustup install $(cat rust-toolchain)
         - ./autogen.sh && ./configure --without-makeinfo --with-x=no --with-ns=no --without-gconf --without-gsettings --with-gif=no
-        - make -j 3
+        - make -C src globals.h
       script:
         - ./.travis-cerrors.sh
 


### PR DESCRIPTION
All we're checking is that we get a compile error when we should. We
don't need a full build for this, and it's adding ~20 minutes to our
build time.