### PR TITLE
Rust dired file-attributes-lessp

### DIFF
--- a/rust_src/src/dired.rs
+++ b/rust_src/src/dired.rs
@@ -14,7 +14,7 @@ use strings::string_lessp;
 
 /// Return t if first arg file attributes list is less than second.
 /// Comparison is in lexicographic order and case is significant.
-#[lisp_fn(min = "2")]
+#[lisp_fn]
 pub fn file_attributes_lessp(f1: LispObject, f2: LispObject) -> LispObject {
     LispObject::from_bool(string_lessp(car(f1), car(f2)))
 }

--- a/rust_src/src/dired.rs
+++ b/rust_src/src/dired.rs
@@ -9,7 +9,15 @@ use remacs_sys::build_string;
 use remacs_sys::globals;
 
 use lisp::{defsubr, LispObject};
-use lists::list;
+use lists::{car, list};
+use strings::string_lessp;
+
+/// Return t if first arg file attributes list is less than second.
+/// Comparison is in lexicographic order and case is significant.
+#[lisp_fn(min = "2")]
+pub fn file_attributes_lessp(f1: LispObject, f2: LispObject) -> LispObject {
+    LispObject::from_bool(string_lessp(car(f1), car(f2)))
+}
 
 fn get_user_real_login_name() -> LispObject {
     unsafe { globals.Vuser_real_login_name }

--- a/src/dired.c
+++ b/src/dired.c
@@ -1028,14 +1028,6 @@ file_attributes (int fd, char const *name,
 		INTEGER_TO_CONS (s.st_ino),
 		INTEGER_TO_CONS (s.st_dev));
 }
-
-DEFUN ("file-attributes-lessp", Ffile_attributes_lessp, Sfile_attributes_lessp, 2, 2, 0,
-       doc: /* Return t if first arg file attributes list is less than second.
-Comparison is in lexicographic order and case is significant.  */)
-  (Lisp_Object f1, Lisp_Object f2)
-{
-  return Fstring_lessp (Fcar (f1), Fcar (f2));
-}
 
 
 DEFUN ("system-groups", Fsystem_groups, Ssystem_groups, 0, 0, 0,
@@ -1072,7 +1064,6 @@ syms_of_dired (void)
   defsubr (&Sfile_name_completion);
   defsubr (&Sfile_name_all_completions);
   defsubr (&Sfile_attributes);
-  defsubr (&Sfile_attributes_lessp);
   defsubr (&Ssystem_groups);
 
   DEFVAR_LISP ("completion-ignored-extensions", Vcompletion_ignored_extensions,

--- a/test/rust_src/src/dired-tests.el
+++ b/test/rust_src/src/dired-tests.el
@@ -13,6 +13,9 @@
   (should-error (eval
                  '(file-attributes-lessp '("rms" t) "wilfred"))
                 :type 'wrong-type-argument)
+  (should (not (file-attributes-lessp '() '())))
+  (should (not (file-attributes-lessp '() '(""))))
+  (should (file-attributes-lessp '("") '()))
   (should (file-attributes-lessp '("rms" t) '("wilfred" t)))
   (should (not (file-attributes-lessp '("wilfred" t) '("rms" t)))))
 

--- a/test/rust_src/src/dired-tests.el
+++ b/test/rust_src/src/dired-tests.el
@@ -5,19 +5,23 @@
 (require 'ert)
 
 (ert-deftest test-file-attributes-lessp ()
-  (should-error (eval '(file-attributes-lessp '("rms" t)))
-                :type 'wrong-number-of-arguments)
-  (should-error (eval
-                 '(file-attributes-lessp "rms" "wilfred"))
-                :type 'wrong-type-argument)
-  (should-error (eval
-                 '(file-attributes-lessp '("rms" t) "wilfred"))
-                :type 'wrong-type-argument)
-  (should (not (file-attributes-lessp '() '())))
-  (should (not (file-attributes-lessp '() '(""))))
-  (should (file-attributes-lessp '("") '()))
-  (should (file-attributes-lessp '("rms" t) '("wilfred" t)))
-  (should (not (file-attributes-lessp '("wilfred" t) '("rms" t)))))
+  (let ((rstr "rms")
+	(wstr "wilfred")
+	(lnull '())
+	(snull '("")))
+    (should-error (eval '(file-attributes-lessp '(rstr t)))
+		  :type 'wrong-number-of-arguments)
+    (should-error (eval
+		   '(file-attributes-lessp rstr wstr))
+		  :type 'wrong-type-argument)
+    (should-error (eval
+		   '(file-attributes-lessp '(rstr t) wstr))
+		  :type 'wrong-type-argument)
+    (should (not (file-attributes-lessp lnull lnull)))
+    (should (not (file-attributes-lessp lnull snull)))
+    (should (file-attributes-lessp snull lnull))
+    (should (file-attributes-lessp '(rstr t) '(wstr t)))
+    (should (not (file-attributes-lessp '(wstr t) '(rstr t))))))
 
 (ert-deftest test-system-users ()
   (should-error (eval '(system-users 'rms)) :type 'wrong-number-of-arguments)

--- a/test/rust_src/src/dired-tests.el
+++ b/test/rust_src/src/dired-tests.el
@@ -4,6 +4,18 @@
 
 (require 'ert)
 
+(ert-deftest test-file-attributes-lessp ()
+  (should-error (eval '(file-attributes-lessp '("rms" t)))
+                :type 'wrong-number-of-arguments)
+  (should-error (eval
+                 '(file-attributes-lessp "rms" "wilfred"))
+                :type 'wrong-type-argument)
+  (should-error (eval
+                 '(file-attributes-lessp '("rms" t) "wilfred"))
+                :type 'wrong-type-argument)
+  (should (file-attributes-lessp '("rms" t) '("wilfred" t)))
+  (should (not (file-attributes-lessp '("wilfred" t) '("rms" t)))))
+
 (ert-deftest test-system-users ()
   (should-error (eval '(system-users 'rms)) :type 'wrong-number-of-arguments)
   ;; The result should be a list of >= 1 user name(s) on all Unix and GNU systems.

--- a/test/rust_src/src/dired-tests.el
+++ b/test/rust_src/src/dired-tests.el
@@ -11,6 +11,8 @@
 	(snull '("")))
     (should-error (eval '(file-attributes-lessp '(rstr t)))
 		  :type 'wrong-number-of-arguments)
+    (should-error (eval '(file-attributes-lessp '(rstr t) '(wstr t) snull))
+		  :type 'wrong-number-of-arguments)
     (should-error (eval
 		   '(file-attributes-lessp rstr wstr))
 		  :type 'wrong-type-argument)


### PR DESCRIPTION
I've got a new&improved file-attributes (and directory-files) that works good on not(windows) but am seeing some Windows problems. And my ability to debug non-trivial stuff on Windows is limited (as I'm not able to build Remacs on my Windows sys yet).

But in the meantime here is file-attributes-lessp.  Seems not to cause any more ```make check``` fails on Linux and Windows (Appveyor). Was tested earlier on MacOS and I assume it's ok but lets see Travis results.

