### PR TITLE
Try to find Rust code in find-function-C-source

### DIFF
--- a/lisp/emacs-lisp/find-func.el
+++ b/lisp/emacs-lisp/find-func.el
@@ -242,6 +242,15 @@ return the symbol's function definition."
 
 (defun find-function-C-source (fun-or-var file type)
   "Find the source location where FUN-OR-VAR is defined in FILE.
+TYPE should be nil to find a function, or `defvar' to find a variable.
+
+Despite its name, this function will also look in the Rust directory."
+  (if (string-suffix-p ".rs" file)
+      (find-function-rust-source fun-or-var file)
+    (find-function--C-source fun-or-var file type)))
+
+(defun find-function--C-source (fun-or-var file type)
+  "Find the source location where FUN-OR-VAR is defined in FILE.
 TYPE should be nil to find a function, or `defvar' to find a variable."
   (let ((dir (or find-function-C-source-directory
                  (read-directory-name "Emacs C source dir: " nil nil t))))


### PR DESCRIPTION
Most Emacs functions are written in Lisp, with a few primitives like
display functions and basic arithmetic being written in a lower-level
language. In GNU Emacs that language is C, while in Remacs both C and
Rust are used.

Now consider the function `find-function-C-source'. In GNU Emacs, this
is what is used to find the source code for primitive functions, since
primitive functions are written in C. So is it a function for finding
the source code for primitive functions in general, or just those
written in C? In GNU Emacs that question is academic, but in Remacs it
needs to be answered. This commit takes the broad view that the
function is really intended to find all primitive functions, not just
those written in C.

As evidence, consider this perfectly good piece of real-life code:

  (if primitive-p
      (cdr (find-function-C-source sym path nil))
    (cdr (find-function-search-for-symbol sym nil path)))

This code looks for `sym' in the C directory if it's primitive and
elsewhere otherwise. But in Remacs, primitives can be defined in
Rust. In that case, this code will look for the function in C, fail to
find it, and raise an error. The author probably did not mean to
exclude Rust primitives from the search, so the function ought to be
rewritten to capture its intended use and avoid doing anything
unexpected.

It would be great if `find-function-C-source' could just be renamed to
something more accurate like `find-function-primitive-source', but for
compatibility with existing code it will be better to shim in a simple
dispatch on the file name, and decide there whether to look for the
function in Rust or C.