### PR TITLE
Add set_window_prev_buffers, set_window_next_buffers, window_prev_buffers, and window_next buffers

### DIFF
--- a/rust_src/src/windows.rs
+++ b/rust_src/src/windows.rs
@@ -12,7 +12,8 @@ use remacs_sys::{estimate_mode_line_height, is_minibuffer, minibuf_level,
                  selected_window as current_window, set_buffer_internal, wget_current_matrix,
                  wget_mode_line_height, wget_parent, wget_pixel_height, wget_pseudo_window_p,
                  wget_window_parameters, window_menu_bar_p, window_parameter, window_tool_bar_p,
-                 wset_mode_line_height, wset_redisplay, wset_window_parameters, window_list_1};
+                 wset_mode_line_height, wset_next_buffers, wset_prev_buffers, wset_redisplay,
+                 wset_window_parameters, window_list_1};
 use remacs_sys::Fcons;
 use remacs_sys::globals;
 
@@ -768,11 +769,37 @@ pub fn window_prev_buffers(window: LispObject) -> LispObject {
     window_live_or_selected(window).prev_buffers
 }
 
+/// Set WINDOW's previous buffers to PREV-BUFFERS.
+/// WINDOW must be a live window and defaults to the selected one.
+/// PREV-BUFFERS should be a list of elements (BUFFER WINDOW-START POS),
+/// where BUFFER is a buffer, WINDOW-START is the start position of the
+/// window for that buffer, and POS is a window-specific point value.
+#[lisp_fn]
+pub fn set_window_prev_buffers(window: LispObject, prev_buffers: LispObject) -> LispObject {
+    let mut w = window_live_or_selected(window);
+    unsafe {
+        wset_prev_buffers(w.as_mut(), prev_buffers);
+    }
+    prev_buffers
+}
+
 /// Return list of buffers recently re-shown in WINDOW.
 /// WINDOW must be a live window and defaults to the selected one.
 #[lisp_fn(min = "0")]
 pub fn window_next_buffers(window: LispObject) -> LispObject {
     window_live_or_selected(window).next_buffers
+}
+
+/// Set WINDOW's next buffers to NEXT-BUFFERS.
+/// WINDOW must be a live window and defaults to the selected one.
+/// NEXT-BUFFERS should be a list of buffers.
+#[lisp_fn]
+pub fn set_window_next_buffers(window: LispObject, next_buffers: LispObject) -> LispObject {
+    let mut w = window_live_or_selected(window);
+    unsafe {
+        wset_next_buffers(w.as_mut(), next_buffers);
+    }
+    next_buffers
 }
 
 /// Make point value in WINDOW be at position POS in WINDOW's buffer.

--- a/rust_src/src/windows.rs
+++ b/rust_src/src/windows.rs
@@ -761,6 +761,20 @@ pub fn window_use_time(window: LispObject) -> LispObject {
     LispObject::from(use_time)
 }
 
+/// Return buffers previously shown in WINDOW.
+/// WINDOW must be a live window and defaults to the selected one.
+#[lisp_fn(min = "0")]
+pub fn window_prev_buffers(window: LispObject) -> LispObject {
+    window_live_or_selected(window).prev_buffers
+}
+
+/// Return list of buffers recently re-shown in WINDOW.
+/// WINDOW must be a live window and defaults to the selected one.
+#[lisp_fn(min = "0")]
+pub fn window_next_buffers(window: LispObject) -> LispObject {
+    window_live_or_selected(window).next_buffers
+}
+
 /// Make point value in WINDOW be at position POS in WINDOW's buffer.
 /// WINDOW must be a live window and defaults to the selected one.
 /// Return POS.

--- a/src/window.c
+++ b/src/window.c
@@ -1735,31 +1735,6 @@ though when run from an idle timer with a delay of zero seconds.  */)
   return Fnreverse (rows);
 }
 
-DEFUN ("set-window-prev-buffers", Fset_window_prev_buffers,
-       Sset_window_prev_buffers, 2, 2, 0,
-       doc: /* Set WINDOW's previous buffers to PREV-BUFFERS.
-WINDOW must be a live window and defaults to the selected one.
-
-PREV-BUFFERS should be a list of elements (BUFFER WINDOW-START POS),
-where BUFFER is a buffer, WINDOW-START is the start position of the
-window for that buffer, and POS is a window-specific point value.  */)
-     (Lisp_Object window, Lisp_Object prev_buffers)
-{
-  wset_prev_buffers (decode_live_window (window), prev_buffers);
-  return prev_buffers;
-}
-
-DEFUN ("set-window-next-buffers", Fset_window_next_buffers,
-       Sset_window_next_buffers, 2, 2, 0,
-       doc: /* Set WINDOW's next buffers to NEXT-BUFFERS.
-WINDOW must be a live window and defaults to the selected one.
-NEXT-BUFFERS should be a list of buffers.  */)
-     (Lisp_Object window, Lisp_Object next_buffers)
-{
-  wset_next_buffers (decode_live_window (window), next_buffers);
-  return next_buffers;
-}
-
 DEFUN ("window-parameters", Fwindow_parameters, Swindow_parameters,
        0, 1, 0,
        doc: /* Return the parameters of WINDOW and their values.
@@ -7281,8 +7256,6 @@ displayed after a scrolling operation to be somewhat inaccurate.  */);
   defsubr (&Swindow_vscroll);
   defsubr (&Sset_window_vscroll);
   defsubr (&Scompare_window_configurations);
-  defsubr (&Sset_window_prev_buffers);
-  defsubr (&Sset_window_next_buffers);
   defsubr (&Swindow_parameters);
   defsubr (&Swindow_parameter);
 }

--- a/src/window.c
+++ b/src/window.c
@@ -1735,19 +1735,6 @@ though when run from an idle timer with a delay of zero seconds.  */)
   return Fnreverse (rows);
 }
 
-DEFUN ("window-prev-buffers", Fwindow_prev_buffers, Swindow_prev_buffers,
-       0, 1, 0,
-       doc:  /* Return buffers previously shown in WINDOW.
-WINDOW must be a live window and defaults to the selected one.
-
-The return value is a list of elements (BUFFER WINDOW-START POS),
-where BUFFER is a buffer, WINDOW-START is the start position of the
-window for that buffer, and POS is a window-specific point value.  */)
-  (Lisp_Object window)
-{
-  return decode_live_window (window)->prev_buffers;
-}
-
 DEFUN ("set-window-prev-buffers", Fset_window_prev_buffers,
        Sset_window_prev_buffers, 2, 2, 0,
        doc: /* Set WINDOW's previous buffers to PREV-BUFFERS.
@@ -1760,15 +1747,6 @@ window for that buffer, and POS is a window-specific point value.  */)
 {
   wset_prev_buffers (decode_live_window (window), prev_buffers);
   return prev_buffers;
-}
-
-DEFUN ("window-next-buffers", Fwindow_next_buffers, Swindow_next_buffers,
-       0, 1, 0,
-       doc:  /* Return list of buffers recently re-shown in WINDOW.
-WINDOW must be a live window and defaults to the selected one.  */)
-     (Lisp_Object window)
-{
-  return decode_live_window (window)->next_buffers;
 }
 
 DEFUN ("set-window-next-buffers", Fset_window_next_buffers,
@@ -7303,9 +7281,7 @@ displayed after a scrolling operation to be somewhat inaccurate.  */);
   defsubr (&Swindow_vscroll);
   defsubr (&Sset_window_vscroll);
   defsubr (&Scompare_window_configurations);
-  defsubr (&Swindow_prev_buffers);
   defsubr (&Sset_window_prev_buffers);
-  defsubr (&Swindow_next_buffers);
   defsubr (&Sset_window_next_buffers);
   defsubr (&Swindow_parameters);
   defsubr (&Swindow_parameter);


### PR DESCRIPTION
I've been having some trouble porting `set_window_prev/next_buffers`.

After running make, I get
```
cargo build --release --manifest-path ../rust_src/Cargo.toml
   Compiling remacs v0.1.0 (file:///home/brian/mygit/remacs/rust_src)
warning: static item is never used: `Sset_window_prev_buffers`
   --> src/windows.rs:777:1
    |
777 | #[lisp_fn]
    | ^^^^^^^^^^
    |
    = note: #[warn(dead_code)] on by default
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)

warning: static item is never used: `Sset_window_next_buffers`
   --> src/windows.rs:796:1
    |
796 | #[lisp_fn]
    | ^^^^^^^^^^
    |
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)

    Finished release [optimized] target(s) in 47.54 secs
mkdir -p ../rust_src/target/
echo "--release " > ../rust_src/target/.rustflags.tmp
diff -q ../rust_src/target/.rustflags ../rust_src/target/.rustflags.tmp || cp ../rust_src/target/.rustflags.tmp ../rust_src/target/.rustflags
rm -f ../rust_src/target/.rustflags.tmp
make -C ../admin/charsets all
make[2]: Entering directory '/home/brian/mygit/remacs/admin/charsets'
make[2]: Nothing to be done for 'all'.
make[2]: Leaving directory '/home/brian/mygit/remacs/admin/charsets'
make -C ../admin/unidata charscript.el
make[2]: Entering directory '/home/brian/mygit/remacs/admin/unidata'
make[2]: Nothing to be done for 'charscript.el'.
make[2]: Leaving directory '/home/brian/mygit/remacs/admin/unidata'
  CCLD     temacs
/bin/mkdir -p ../etc
setfattr -n user.pax.flags -v er temacs
make -C ../lisp update-subdirs
make[2]: Entering directory '/home/brian/mygit/remacs/lisp'
make[2]: Leaving directory '/home/brian/mygit/remacs/lisp'
./temacs --batch  --load loadup bootstrap
Loading loadup.el (source)...
Using load-path (/home/brian/mygit/remacs/lisp /home/brian/mygit/remacs/lisp/emacs-lisp /home/brian/mygit/remacs/lisp/language /home/brian/mygit/remacs/lisp/international /home/brian/mygit/remacs/lisp/textmodes /home/brian/mygit/remacs/lisp/vc)
Loading emacs-lisp/byte-run...
Loading emacs-lisp/backquote...
Loading subr...
Loading version...
Loading widget...
Loading custom...
Loading emacs-lisp/map-ynp...
Loading international/mule...
Loading international/mule-conf...
Loading env...
Loading format...
Loading bindings...
Loading window...
Loading files...
Loading emacs-lisp/macroexp...
Loading cus-face...
Loading faces...
Loading button...
Loading /home/brian/mygit/remacs/lisp/loaddefs.el (source)...
Symbol’s function definition is void: set-window-prev-buffers
make[1]: *** [Makefile:776: bootstrap-emacs] Error 255
make[1]: Leaving directory '/home/brian/mygit/remacs/src'
make: *** [Makefile:426: src] Error 2
```

I noticed that the other `wset` functions used in `windows.rs` do not have an `inline` specifier, though removing the `inline` specifier from `wset_next/prev_buffers()` introduced different errors. Whether or not I remove the calls to `wset_prev/next_buffers()`, the compiler says that the static item `Sset_window_prev_buffers` is not used. From what I can tell, this means that I might be passing the Rust functions into #[lisp_fn] incorrectly. I'm not sure how to compile with `-Z external-macro-backtrace` as the compiler suggests to look into this.