### PR TITLE
Port process-coding-system, process-thread, current-thread, and thread--blocker.

### DIFF
--- a/rust_src/src/process.rs
+++ b/rust_src/src/process.rs
@@ -276,6 +276,13 @@ pub fn process_coding_system(process: LispProcessRef) -> LispObject {
     LispObject::cons(process.decode_coding_system, process.encode_coding_system)
 }
 
+/// Return the locking thread of PROCESS.
+/// If PROCESS is unlocked, this function returns nil.
+#[lisp_fn]
+pub fn process_thread(process: LispProcessRef) -> LispObject {
+    process.thread
+}
+
 /// Set buffer associated with PROCESS to BUFFER (a buffer, or nil).
 /// Return BUFFER.
 #[lisp_fn]

--- a/rust_src/src/process.rs
+++ b/rust_src/src/process.rs
@@ -270,6 +270,12 @@ pub fn process_status(process: LispObject) -> LispObject {
     status
 }
 
+/// Return a cons of coding systems for decoding and encoding of PROCESS.
+#[lisp_fn]
+pub fn process_coding_system(process: LispProcessRef) -> LispObject {
+    LispObject::cons(process.decode_coding_system, process.encode_coding_system)
+}
+
 /// Set buffer associated with PROCESS to BUFFER (a buffer, or nil).
 /// Return BUFFER.
 #[lisp_fn]

--- a/rust_src/src/threads.rs
+++ b/rust_src/src/threads.rs
@@ -68,4 +68,15 @@ pub fn current_thread() -> LispObject {
     ThreadState::current_thread().as_lisp_obj()
 }
 
+/// Return the object that THREAD is blocking on.
+// If THREAD is blocked in `thread-join' on a second thread, return that
+// thread.
+// If THREAD is blocked in `mutex-lock', return the mutex.
+// If THREAD is blocked in `condition-wait', return the condition variable.
+// Otherwise, if THREAD is not blocked, return nil.
+#[lisp_fn(name = "thread--blocker")]
+pub fn thread_blocker(thread: ThreadStateRef) -> LispObject {
+    thread.event_object
+}
+
 include!(concat!(env!("OUT_DIR"), "/threads_exports.rs"));

--- a/src/process.c
+++ b/src/process.c
@@ -7067,16 +7067,6 @@ encode subprocess input. */)
   return Qnil;
 }
 
-DEFUN ("process-coding-system",
-       Fprocess_coding_system, Sprocess_coding_system, 1, 1, 0,
-       doc: /* Return a cons of coding systems for decoding and encoding of PROCESS.  */)
-  (register Lisp_Object process)
-{
-  CHECK_PROCESS (process);
-  return Fcons (XPROCESS (process)->decode_coding_system,
-		XPROCESS (process)->encode_coding_system);
-}
-
 DEFUN ("set-process-filter-multibyte", Fset_process_filter_multibyte,
        Sset_process_filter_multibyte, 2, 2, 0,
        doc: /* Set multibyteness of the strings given to PROCESS's filter.
@@ -7649,7 +7639,6 @@ returns non-`nil'.  */);
   defsubr (&Sinternal_default_process_sentinel);
   defsubr (&Sinternal_default_process_filter);
   defsubr (&Sset_process_coding_system);
-  defsubr (&Sprocess_coding_system);
   defsubr (&Sset_process_filter_multibyte);
   defsubr (&Sprocess_filter_multibyte_p);
 

--- a/src/process.c
+++ b/src/process.c
@@ -1118,16 +1118,6 @@ If THREAD is nil, the process is unlocked.  */)
   return thread;
 }
 
-DEFUN ("process-thread", Fprocess_thread, Sprocess_thread,
-       1, 1, 0,
-       doc: /* Ret the locking thread of PROCESS.
-If PROCESS is unlocked, this function returns nil.  */)
-  (Lisp_Object process)
-{
-  CHECK_PROCESS (process);
-  return XPROCESS (process)->thread;
-}
-
 DEFUN ("set-process-window-size", Fset_process_window_size,
        Sset_process_window_size, 3, 3, 0,
        doc: /* Tell PROCESS that it has logical window size WIDTH by HEIGHT.
@@ -7607,7 +7597,6 @@ returns non-`nil'.  */);
 
   defsubr (&Sdelete_process);
   defsubr (&Sset_process_thread);
-  defsubr (&Sprocess_thread);
   defsubr (&Sset_process_window_size);
   defsubr (&Sset_process_inherit_coding_system_flag);
   defsubr (&Sprocess_contact);

--- a/src/thread.c
+++ b/src/thread.c
@@ -808,15 +808,6 @@ If NAME is given, it must be a string; it names the new thread.  */)
   return result;
 }
 
-DEFUN ("current-thread", Fcurrent_thread, Scurrent_thread, 0, 0, 0,
-       doc: /* Return the current thread.  */)
-  (void)
-{
-  Lisp_Object result;
-  XSETTHREAD (result, current_thread);
-  return result;
-}
-
 static void
 thread_signal_callback (void *arg)
 {
@@ -1006,7 +997,6 @@ syms_of_threads (void)
     {
       defsubr (&Sthread_yield);
       defsubr (&Smake_thread);
-      defsubr (&Scurrent_thread);
       defsubr (&Sthread_signal);
       defsubr (&Sthread_join);
       defsubr (&Sthread_blocker);

--- a/src/thread.c
+++ b/src/thread.c
@@ -845,23 +845,6 @@ or `thread-join' in the target thread.  */)
   return Qnil;
 }
 
-DEFUN ("thread--blocker", Fthread_blocker, Sthread_blocker, 1, 1, 0,
-       doc: /* Return the object that THREAD is blocking on.
-If THREAD is blocked in `thread-join' on a second thread, return that
-thread.
-If THREAD is blocked in `mutex-lock', return the mutex.
-If THREAD is blocked in `condition-wait', return the condition variable.
-Otherwise, if THREAD is not blocked, return nil.  */)
-  (Lisp_Object thread)
-{
-  struct thread_state *tstate;
-
-  CHECK_THREAD (thread);
-  tstate = XTHREAD (thread);
-
-  return tstate->event_object;
-}
-
 static void
 thread_join_callback (void *arg)
 {
@@ -999,7 +982,6 @@ syms_of_threads (void)
       defsubr (&Smake_thread);
       defsubr (&Sthread_signal);
       defsubr (&Sthread_join);
-      defsubr (&Sthread_blocker);
       defsubr (&Sall_threads);
       defsubr (&Smake_mutex);
       defsubr (&Smutex_lock);


### PR DESCRIPTION
Closes #750 and #797.

I'm not sure if I ported `current-thread` correctly. Should the return type be `ThreadStateRef` instead of `LispObject`? I wrote `LispObject` only because that is what `LispObject::tag_ptr()` returns.