### PR TITLE
ubuntu docker dependencies

### DIFF
--- a/docker/ubuntu/32bit/Dockerfile
+++ b/docker/ubuntu/32bit/Dockerfile
@@ -24,7 +24,9 @@ RUN apt-get update && apt-get -y upgrade && apt-get autoremove && apt-get clean
 RUN apt-get update && apt-get install -y \
     automake \
     build-essential \
+    clang \
     curl \
+    libclang-dev \
     libgif-dev \
     libgnutls-dev \
     libgtk-3-dev \
@@ -33,6 +35,7 @@ RUN apt-get update && apt-get install -y \
     libtiff-dev \
     libxml2-dev \
     libxpm-dev \
+    libxt-dev \
     texinfo
 
 

--- a/docker/ubuntu/32bit/config.yaml
+++ b/docker/ubuntu/32bit/config.yaml
@@ -26,7 +26,9 @@ base_config: |
     RUN apt-get update && apt-get install -y \
         automake \
         build-essential \
+        clang \
         curl \
+        libclang-dev \
         libgif-dev \
         libgnutls-dev \
         libgtk-3-dev \
@@ -35,4 +37,5 @@ base_config: |
         libtiff-dev \
         libxml2-dev \
         libxpm-dev \
+        libxt-dev \
         texinfo

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -3,7 +3,9 @@ FROM ubuntu:xenial
 RUN apt-get update && apt-get install -y \
     automake \
     build-essential \
+    clang \
     curl \
+    libclang-dev \
     libgif-dev \
     libgnutls-dev \
     libgtk-3-dev \
@@ -12,6 +14,7 @@ RUN apt-get update && apt-get install -y \
     libtiff-dev \
     libxml2-dev \
     libxpm-dev \
+    libxt-dev \
     texinfo
 
 

--- a/docker/ubuntu/config.yaml
+++ b/docker/ubuntu/config.yaml
@@ -5,7 +5,9 @@ base_config: |
     RUN apt-get update && apt-get install -y \
         automake \
         build-essential \
+        clang \
         curl \
+        libclang-dev \
         libgif-dev \
         libgnutls-dev \
         libgtk-3-dev \
@@ -14,4 +16,5 @@ base_config: |
         libtiff-dev \
         libxml2-dev \
         libxpm-dev \
+        libxt-dev \
         texinfo


### PR DESCRIPTION
Added missing dependencies (libclang-dev, clang, libxt-dev) to the ubuntu Dockerfiles. Fixes https://github.com/Wilfred/remacs/issues/791 and https://github.com/Wilfred/remacs/issues/788 for docker ubuntu builds.

Perhaps the clang dependency isn't needed (?) when adding compiler flags as decribed in https://github.com/Wilfred/remacs/issues/788, but this fixes the 'stdbool.h not found' error (https://github.com/Wilfred/remacs/issues/791 and second part of https://github.com/Wilfred/remacs/issues/788) for now.