### PR TITLE
Added clang check in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1523,6 +1523,9 @@ AC_DEFUN([AC_TYPE_SIZE_T])
 # Likewise for obsolescent test for uid_t, gid_t; Emacs assumes them.
 AC_DEFUN([AC_TYPE_UID_T])
 
+# Make sure CLANG libraries are present
+AC_CHECK_LIB([clang], [main], [], [AC_MSG_ERROR("Cannot find clang library")])
+
 # sqrt and other floating-point functions such as fmod and frexp
 # are found in -lm on many systems.
 OLD_LIBS=$LIBS


### PR DESCRIPTION
This is first time I'm tinkering with Autotools configuration files. Please suggest if `AC_CHECK_LIB` is not the right way to do this check.

I tested in my local Ubuntu system. I don't have access to Windows machine. I will test this in Mac in some time.

Fixes #788.