### PR TITLE
Port the window-parameter lisp function to Rust

### DIFF
--- a/rust_src/src/windows.rs
+++ b/rust_src/src/windows.rs
@@ -258,7 +258,6 @@ pub fn window_or_selected_unchecked(window: LispObject) -> LispObject {
 }
 
 /// Same as the `decode_any_window` function
-#[allow(dead_code)] // FIXME: Remove as soon as it is used
 fn window_or_selected(window: LispObject) -> LispWindowRef {
     window_or_selected_unchecked(window).as_window_or_error()
 }
@@ -521,6 +520,15 @@ pub fn frame_root_window(frame_or_window: LispObject) -> LispObject {
 pub fn minibuffer_window(frame: LispObject) -> LispObject {
     let frame = frame_live_or_selected(frame);
     frame.minibuffer_window
+}
+
+/// Return WINDOW's value for PARAMETER.
+/// WINDOW can be any window and defaults to the selected one.
+#[lisp_fn(name = "window-parameter")]
+pub fn window_parameter_defun(window: LispObject, parameter: LispObject) -> LispObject {
+    let mut w = window_or_selected(window);
+
+    unsafe { window_parameter(w.as_mut(), parameter) }
 }
 
 /// Return the display-table that WINDOW is using.

--- a/src/window.c
+++ b/src/window.c
@@ -1728,18 +1728,6 @@ window_parameter (struct window *w, Lisp_Object parameter)
   return CDR_SAFE (result);
 }
 
-
-DEFUN ("window-parameter", Fwindow_parameter, Swindow_parameter,
-       2, 2, 0,
-       doc:  /* Return WINDOW's value for PARAMETER.
-WINDOW can be any window and defaults to the selected one.  */)
-  (Lisp_Object window, Lisp_Object parameter)
-{
-  struct window *w = decode_any_window (window);
-
-  return window_parameter (w, parameter);
-}
-
 struct Lisp_Char_Table *
 window_display_table (struct window *w)
 {
@@ -7231,7 +7219,6 @@ displayed after a scrolling operation to be somewhat inaccurate.  */);
   defsubr (&Sset_window_vscroll);
   defsubr (&Scompare_window_configurations);
   defsubr (&Swindow_parameters);
-  defsubr (&Swindow_parameter);
 }
 
 void


### PR DESCRIPTION
The non-lisp-defun C function `window_parameter` already existed so I added `_defun` to this rust function like I saw a couple other places in the codebase. Is this the right way to do it?

Closes #832 