### PR TITLE
Add variable-documentation tests

### DIFF
--- a/test/rust_src/src/data-tests.el
+++ b/test/rust_src/src/data-tests.el
@@ -115,5 +115,18 @@
   :expected-result :failed
   (describe-function 'rename-buffer))
 
+(ert-deftest data-test--get-variable-documentation ()
+  ;; `gc-cons-threshold' is defined in C.
+  (should
+   (integerp
+    (get 'gc-cons-threshold 'variable-documentation))))
+
+(ert-deftest data-test--get-variable-documentation-fail ()
+  ;; `last-command' is defined in Rust.
+  :expected-result :failed
+  (should
+   (integerp
+    (get 'last-command 'variable-documentation))))
+
 (provide 'data-tests)
 ;;; data-tests.el ends here


### PR DESCRIPTION
Variables defined in Rust aren't documented properly. These are some
tiny reproducing examples.

See https://github.com/Wilfred/remacs/issues/876.