### PR TITLE
don't skip the doc strings of kboard or per_buffer variables

### DIFF
--- a/test/rust_src/src/data-tests.el
+++ b/test/rust_src/src/data-tests.el
@@ -123,7 +123,6 @@
 
 (ert-deftest data-test--get-variable-documentation-fail ()
   ;; `last-command' is defined in Rust.
-  :expected-result :failed
   (should
    (integerp
     (get 'last-command 'variable-documentation))))


### PR DESCRIPTION
The logic here was inverted. We don't want to report per keyboard or
per buffer variables as globals, but we do still want to put their
docstrings into the DOC file.

Fixes #876 