### PR TITLE
libgnutls-dev changes to libgnutls28-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ more Emacs-y.
         rustup install `cat rust-toolchain`
 
 2. You will need a C compiler and toolchain. On Linux, you can do
-   something like `apt-get install build-essential automake`. On
+   something like `apt-get install build-essential automake clang`. On
    macOS, you'll need Xcode.
 
 3. You will need some C libraries. On Linux, you can install

--- a/README.md
+++ b/README.md
@@ -152,13 +152,13 @@ more Emacs-y.
         rustup install `cat rust-toolchain`
 
 2. You will need a C compiler and toolchain. On Linux, you can do
-   something like `apt-get install build-essential automake clang`. On
+   something like `apt install build-essential automake clang`. On
    macOS, you'll need Xcode.
 
 3. You will need some C libraries. On Linux, you can install
    everything you need with:
 
-        apt-get install texinfo libjpeg-dev libtiff-dev \
+        apt install texinfo libjpeg-dev libtiff-dev \
           libgif-dev libxpm-dev libgtk-3-dev libgnutls28-dev \
           libncurses5-dev libxml2-dev libxt-dev
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ more Emacs-y.
 
         apt-get install texinfo libjpeg-dev libtiff-dev \
           libgif-dev libxpm-dev libgtk-3-dev libgnutls28-dev \
-          libncurses5-dev libxml2-dev
+          libncurses5-dev libxml2-dev libxt-dev
 
     On macOS, you'll need libxml2 (via `xcode-select --install`) and
     gnutls (via `brew install gnutls`).

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ more Emacs-y.
    everything you need with:
 
         apt-get install texinfo libjpeg-dev libtiff-dev \
-          libgif-dev libxpm-dev libgtk-3-dev libgnutls-dev \
+          libgif-dev libxpm-dev libgtk-3-dev libgnutls28-dev \
           libncurses5-dev libxml2-dev
 
     On macOS, you'll need libxml2 (via `xcode-select --install`) and


### PR DESCRIPTION
On Ubuntu 18.04 libgnutls-dev is libgnutls28-dev

EDIT: Also added clang as a requirement. See commit https://github.com/Wilfred/remacs/pull/888/commits/6ffa657e9ada212588e50a268777c5126d366011

EDIT2: Added libxt-dev, a required dependency. 