### PR TITLE
Port car-less-than-car

### DIFF
--- a/rust_src/src/fileio.rs
+++ b/rust_src/src/fileio.rs
@@ -3,8 +3,17 @@ use std::path;
 
 use remacs_macros::lisp_fn;
 
-use lisp::defsubr;
+use lisp::{defsubr, LispCons};
+use math::{arithcompare, ArithComparison};
 use multibyte::LispStringRef;
+
+/// Return t if (car A) is numerically less than (car B).
+#[lisp_fn]
+pub fn car_less_than_car(a: LispCons, b: LispCons) -> bool {
+    arithcompare(a.car(), b.car(), ArithComparison::Less)
+}
+
+def_lisp_sym!(Qcar_less_than_car, "car-less-than-car");
 
 /// Return non-nil if NAME ends with a directory separator character.
 #[lisp_fn]

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -5005,13 +5005,6 @@ write_region (Lisp_Object start, Lisp_Object end, Lisp_Object filename,
 }
 
 
-DEFUN ("car-less-than-car", Fcar_less_than_car, Scar_less_than_car, 2, 2, 0,
-       doc: /* Return t if (car A) is numerically less than (car B).  */)
-  (Lisp_Object a, Lisp_Object b)
-{
-  return arithcompare (Fcar (a), Fcar (b), ARITH_LESS);
-}
-
 /* Build the complete list of annotations appropriate for writing out
    the text between START and END, by calling all the functions in
    write-region-annotate-functions and merging the lists they return.
@@ -5858,8 +5851,6 @@ behaves as if file names were encoded in `utf-8'.  */);
      multibyteness of the current buffer after inserting a file.  */
   DEFSYM (Qafter_insert_file_set_coding, "after-insert-file-set-coding");
 
-  DEFSYM (Qcar_less_than_car, "car-less-than-car");
-
   Fput (Qfile_error, Qerror_conditions,
 	Fpurecopy (list2 (Qfile_error, Qerror)));
   Fput (Qfile_error, Qerror_message,
@@ -6074,7 +6065,6 @@ This includes interactive calls to `delete-file' and
   defsubr (&Sfile_newer_than_file_p);
   defsubr (&Sinsert_file_contents);
   defsubr (&Swrite_region);
-  defsubr (&Scar_less_than_car);
   defsubr (&Sverify_visited_file_modtime);
   defsubr (&Svisited_file_modtime);
   defsubr (&Sset_visited_file_modtime);

--- a/test/rust_src/src/fileio-tests.el
+++ b/test/rust_src/src/fileio-tests.el
@@ -4,6 +4,14 @@
 
 (require 'ert)
 
+(ert-deftest test-car-less-than-car ()
+  (should (car-less-than-car '(1 2 3) '(3 2 1)))
+  (should-not (car-less-than-car '(3 2 1) '(1 2 3)))
+  (should-not (car-less-than-car '(1 2 3) '(1 2 3)))
+  (should-error (car-less-than-car '() '(1)))
+  (should-error (car-less-than-car '(1) '()))
+  (should-error (car-less-than-car '("a") '("b"))))
+
 (ert-deftest test-directory-name-p ()
   (should-error (eval '(directory-name-p)) :type 'wrong-number-of-arguments)
   (should-error (eval '(directory-name-p 3 4)) :type 'wrong-number-of-arguments)


### PR DESCRIPTION
This is a strange function, right? It could easily be written in Lisp,
but I guess it's implemented as a primitive for efficiency. It's
mostly used as a predicate in calls to `sort'.