### PR TITLE
rustup-toolchain will be installed when running ./autogen.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,9 +148,6 @@ more Emacs-y.
    rustup will use that version as long as you are in the Remacs
    repository
 
-        cd /path/to/remacs
-        rustup install `cat rust-toolchain`
-
 2. You will need a C compiler and toolchain. On Linux, you can do
    something like `apt install build-essential automake clang`. On
    macOS, you'll need Xcode.

--- a/README.md
+++ b/README.md
@@ -142,11 +142,9 @@ more Emacs-y.
 ### Requirements
 
 1. You will need
-   [Rust installed](https://www.rust-lang.org/en-US/install.html). Remacs
-   uses unstable Rust features, so you will need to use nightly. The
-   file `rust-toolchain` indicates the correct version to install;
-   rustup will use that version as long as you are in the Remacs
-   repository
+   [Rust installed](https://www.rust-lang.org/en-US/install.html). 
+   The file `rust-toolchain` indicates the version that gets installed.
+   This happens automatically, so don't override the toolchain manually.
 
 2. You will need a C compiler and toolchain. On Linux, you can do
    something like `apt install build-essential automake clang`. On


### PR DESCRIPTION
```bash
remacs$ ./autogen.sh
Checking Rust toolchain install ...
info: syncing channel updates for 'nightly-2018-09-09-x86_64-unknown-linux-gnu'
info: latest update on 2018-09-09, rust version 1.30.0-nightly (0198a1ea4 2018-09-08)
info: downloading component 'rustc'
info: downloading component 'rust-std'
info: downloading component 'cargo'
info: downloading component 'rust-docs'
info: installing component 'rustc'
info: installing component 'rust-std'
info: installing component 'cargo'
info: installing component 'rust-docs'
...
```