### PR TITLE
Port byteorder

### DIFF
--- a/rust_src/src/data.rs
+++ b/rust_src/src/data.rs
@@ -331,6 +331,18 @@ pub fn subr_name(subr: LispSubrRef) -> LispObject {
     unsafe { build_string(name) }
 }
 
+/// Return the byteorder for the machine.
+/// Returns 66 (ASCII uppercase B) for big endian machines or 108
+/// (ASCII lowercase l) for small endian machines.
+#[lisp_fn]
+pub fn byteorder() -> u8 {
+    if cfg!(endian = "big") {
+        b'B'
+    } else {
+        b'l'
+    }
+}
+
 /***********************************************************************
                 Getting and Setting Values of Symbols
  ***********************************************************************/

--- a/src/data.c
+++ b/src/data.c
@@ -1588,19 +1588,6 @@ In this case, zeros are shifted in on the left.  */)
   return ash_lsh_impl (value, count, true);
 }
 
-DEFUN ("byteorder", Fbyteorder, Sbyteorder, 0, 0, 0,
-       doc: /* Return the byteorder for the machine.
-Returns 66 (ASCII uppercase B) for big endian machines or 108 (ASCII
-lowercase l) for small endian machines.  */
-       attributes: const)
-  (void)
-{
-  unsigned i = 0x04030201;
-  int order = *(char *)&i == 1 ? 108 : 66;
-
-  return make_number (order);
-}
-
 /* Because we round up the bool vector allocate size to word_size
    units, we can safely read past the "end" of the vector in the
    operations below.  These extra bits are always zero.  */
@@ -2141,7 +2128,6 @@ syms_of_data (void)
   defsubr (&Sstring_to_number);
   defsubr (&Slsh);
   defsubr (&Sash);
-  defsubr (&Sbyteorder);
 #ifdef HAVE_MODULES
   defsubr (&Suser_ptrp);
 #endif

--- a/test/rust_src/src/data-tests.el
+++ b/test/rust_src/src/data-tests.el
@@ -85,6 +85,9 @@
                 'A)))
   )
 
+(ert-deftest data-test--byteorder ()
+  (should (member (byteorder) '(66 108))))
+
 (ert-deftest data-test--subr-arity ()
   (should-error (subr-arity 'insert))
   (should (equal '(0 . many) (subr-arity (symbol-function 'insert))))


### PR DESCRIPTION
The implemention is a little different, but it shouldn't matter. I
couldn't think of a better way to test it, since the function is by
definition platform-dependent.