### PR TITLE
Port remaining casefiddle Lisp functions

### DIFF
--- a/rust_src/src/casefiddle.rs
+++ b/rust_src/src/casefiddle.rs
@@ -3,7 +3,7 @@ use remacs_macros::lisp_fn;
 
 use lisp::defsubr;
 use lisp::LispObject;
-use remacs_sys::{case_action, casify_object, casify_word};
+use remacs_sys::{case_action, casify_object, casify_region_nil, casify_word};
 
 /// Convert argument to capitalized form and return that.
 /// This means that each word's first character is converted to either
@@ -15,6 +15,16 @@ use remacs_sys::{case_action, casify_object, casify_word};
 #[lisp_fn]
 pub fn capitalize(object: LispObject) -> LispObject {
     unsafe { casify_object(case_action::CASE_CAPITALIZE, object) }
+}
+
+/// Convert the region to capitalized form.
+/// This means that each word's first character is converted to either
+/// title case or upper case, and the rest to lower case.  In
+/// programs, give two arguments, the starting and ending character
+/// positions to operate on.
+#[lisp_fn(intspec = "r")]
+pub fn capitalize_region(beg: LispObject, end: LispObject) -> LispObject {
+    unsafe { casify_region_nil(case_action::CASE_CAPITALIZE, beg, end) }
 }
 
 /// Capitalize from point to the end of word, moving over.
@@ -73,6 +83,18 @@ pub fn upcase(object: LispObject) -> LispObject {
 #[lisp_fn]
 pub fn upcase_initials(obj: LispObject) -> LispObject {
     unsafe { casify_object(case_action::CASE_CAPITALIZE_UP, obj) }
+}
+
+// Like Fcapitalize_region but change only the initials.
+
+/// Upcase the initial of each word in the region.
+/// This means that each word's first character is converted to either
+/// title case or upper case, and the rest are left unchanged.  In
+/// programs, give two arguments, the starting and ending character
+/// positions to operate on.
+#[lisp_fn(intspec = "r")]
+pub fn upcase_initials_region(beg: LispObject, end: LispObject) -> LispObject {
+    unsafe { casify_region_nil(case_action::CASE_CAPITALIZE_UP, beg, end) }
 }
 
 /// Convert to upper case from point to end of word, moving over.

--- a/rust_src/src/casefiddle.rs
+++ b/rust_src/src/casefiddle.rs
@@ -36,4 +36,18 @@ pub fn upcase(object: LispObject) -> LispObject {
     unsafe { casify_object(case_action::CASE_UP, object) }
 }
 
+/* Like Fcapitalize but change only the initials.  */
+
+/// Convert the initial of each word in the argument to upper case.
+/// This means that each word's first character is converted to either
+/// title case or upper case, and the rest are left unchanged.  The
+/// argument may be a character or string.  The result has the same
+/// type.  The argument object is not altered--the value is a copy.
+/// If argument is a character, characters which map to multiple code
+/// points when cased, e.g. ﬁ, are returned unchanged.
+#[lisp_fn]
+pub fn upcase_initials(obj: LispObject) -> LispObject {
+    unsafe { casify_object(case_action::CASE_CAPITALIZE_UP, obj) }
+}
+
 include!(concat!(env!("OUT_DIR"), "/casefiddle_exports.rs"));

--- a/rust_src/src/casefiddle.rs
+++ b/rust_src/src/casefiddle.rs
@@ -3,7 +3,7 @@ use remacs_macros::lisp_fn;
 
 use lisp::defsubr;
 use lisp::LispObject;
-use remacs_sys::{case_action, casify_object};
+use remacs_sys::{case_action, casify_object, casify_word};
 
 /// Convert argument to capitalized form and return that.
 /// This means that each word's first character is converted to either
@@ -17,12 +17,37 @@ pub fn capitalize(object: LispObject) -> LispObject {
     unsafe { casify_object(case_action::CASE_CAPITALIZE, object) }
 }
 
+/// Capitalize from point to the end of word, moving over.
+/// With numerical argument ARG, capitalize the next ARG-1 words as
+/// well.  This gives the word(s) a first character in upper case and
+/// the rest lower case.
+///
+/// If point is in the middle of a word, the part of that word before
+/// point is ignored when moving forward.
+///
+/// With negative argument, capitalize previous words but do not move.
+#[lisp_fn(intspec = "p")]
+pub fn capitalize_word(arg: LispObject) -> LispObject {
+    unsafe { casify_word(case_action::CASE_CAPITALIZE, arg) }
+}
+
 /// Convert argument to lower case and return that.
 /// The argument may be a character or string.  The result has the same type.
 /// The argument object is not altered--the value is a copy.
 #[lisp_fn]
 pub fn downcase(object: LispObject) -> LispObject {
     unsafe { casify_object(case_action::CASE_DOWN, object) }
+}
+
+/// Convert to lower case from point to end of word, moving over.
+///
+/// If point is in the middle of a word, the part of that word before
+/// point is ignored when moving forward.
+///
+/// With negative argument, convert previous words but do not move.
+#[lisp_fn(intspec = "p")]
+pub fn downcase_word(arg: LispObject) -> LispObject {
+    unsafe { casify_word(case_action::CASE_DOWN, arg) }
 }
 
 /// Convert argument to upper case and return that.
@@ -48,6 +73,18 @@ pub fn upcase(object: LispObject) -> LispObject {
 #[lisp_fn]
 pub fn upcase_initials(obj: LispObject) -> LispObject {
     unsafe { casify_object(case_action::CASE_CAPITALIZE_UP, obj) }
+}
+
+/// Convert to upper case from point to end of word, moving over.
+///
+/// If point is in the middle of a word, the part of that word before
+/// point is ignored when moving forward.
+///
+/// With negative argument, convert previous words but do not move.
+/// See also `capitalize-word'.
+#[lisp_fn(intspec = "p")]
+pub fn upcase_word(arg: LispObject) -> LispObject {
+    unsafe { casify_word(case_action::CASE_UP, arg) }
 }
 
 include!(concat!(env!("OUT_DIR"), "/casefiddle_exports.rs"));

--- a/rust_src/src/casefiddle.rs
+++ b/rust_src/src/casefiddle.rs
@@ -3,8 +3,9 @@ use remacs_macros::lisp_fn;
 
 use lisp::defsubr;
 use lisp::LispObject;
-use remacs_sys::Qnil;
 use remacs_sys::{case_action, casify_object, casify_region_nil, casify_word};
+use remacs_sys::{control_x_map, initial_define_key, meta_map};
+use remacs_sys::{Qdisabled, Qnil, Qt};
 
 use obarray::intern;
 use symbols::symbol_value;
@@ -170,6 +171,15 @@ fn casefiddle_region(
 
         Qnil
     }
+}
+
+#[no_mangle]
+pub extern "C" fn syms_of_casefiddle() {
+    def_lisp_sym!(Qidentity, "identity");
+    def_lisp_sym!(Qtitlecase, "titlecase");
+    def_lisp_sym!(Qspecial_uppercase, "special-uppercase");
+    def_lisp_sym!(Qspecial_lowercase, "special-lowercase");
+    def_lisp_sym!(Qspecial_titlecase, "special-titlecase");
 }
 
 include!(concat!(env!("OUT_DIR"), "/casefiddle_exports.rs"));

--- a/rust_src/src/casefiddle.rs
+++ b/rust_src/src/casefiddle.rs
@@ -1,8 +1,12 @@
 //! Case conversion functions.
+use std::ffi::CString;
+
 use remacs_macros::lisp_fn;
 
+use keymap::Ctl;
 use lisp::defsubr;
 use lisp::LispObject;
+use lists::put;
 use remacs_sys::{case_action, casify_object, casify_region_nil, casify_word};
 use remacs_sys::{control_x_map, initial_define_key, meta_map};
 use remacs_sys::{Qdisabled, Qnil, Qt};
@@ -180,6 +184,41 @@ pub extern "C" fn syms_of_casefiddle() {
     def_lisp_sym!(Qspecial_uppercase, "special-uppercase");
     def_lisp_sym!(Qspecial_lowercase, "special-lowercase");
     def_lisp_sym!(Qspecial_titlecase, "special-titlecase");
+}
+
+#[no_mangle]
+pub extern "C" fn keys_of_casefiddle() {
+    unsafe {
+        initial_define_key(
+            control_x_map,
+            Ctl('L'),
+            CString::new("downcase-region").unwrap().as_ptr(),
+        );
+        initial_define_key(
+            control_x_map,
+            Ctl('U'),
+            CString::new("upcase-region").unwrap().as_ptr(),
+        );
+
+        initial_define_key(
+            meta_map,
+            'c' as i32,
+            CString::new("capitalize-word").unwrap().as_ptr(),
+        );
+        initial_define_key(
+            meta_map,
+            'l' as i32,
+            CString::new("downcase-word").unwrap().as_ptr(),
+        );
+        initial_define_key(
+            meta_map,
+            'u' as i32,
+            CString::new("upcase-word").unwrap().as_ptr(),
+        );
+    }
+
+    put(intern("upcase-region"), Qdisabled, Qt);
+    put(intern("downcase-region"), Qdisabled, Qt);
 }
 
 include!(concat!(env!("OUT_DIR"), "/casefiddle_exports.rs"));

--- a/src/casefiddle.c
+++ b/src/casefiddle.c
@@ -330,21 +330,6 @@ casify_object (enum case_action flag, Lisp_Object obj)
   else
     return do_casify_unibyte_string (&ctx, obj);
 }
-
-/* Like Fcapitalize but change only the initials.  */
-
-DEFUN ("upcase-initials", Fupcase_initials, Supcase_initials, 1, 1, 0,
-       doc: /* Convert the initial of each word in the argument to upper case.
-This means that each word's first character is converted to either
-title case or upper case, and the rest are left unchanged.
-The argument may be a character or string.  The result has the same type.
-The argument object is not altered--the value is a copy.  If argument
-is a character, characters which map to multiple code points when
-cased, e.g. ﬁ, are returned unchanged.  */)
-  (Lisp_Object obj)
-{
-  return casify_object (CASE_CAPITALIZE_UP, obj);
-}
 
 /* Based on CTX, case region in a unibyte buffer from *STARTP to *ENDP.
 
@@ -624,7 +609,6 @@ syms_of_casefiddle (void)
   DEFSYM (Qspecial_lowercase, "special-lowercase");
   DEFSYM (Qspecial_titlecase, "special-titlecase");
 
-  defsubr (&Supcase_initials);
   defsubr (&Supcase_region);
   defsubr (&Sdowncase_region);
   defsubr (&Scapitalize_region);

--- a/src/casefiddle.c
+++ b/src/casefiddle.c
@@ -549,7 +549,7 @@ character positions to operate on.  */)
   return Qnil;
 }
 
-static Lisp_Object
+Lisp_Object
 casify_word (enum case_action flag, Lisp_Object arg)
 {
   CHECK_NUMBER (arg);
@@ -558,46 +558,6 @@ casify_word (enum case_action flag, Lisp_Object arg)
     farend = XINT (arg) <= 0 ? BEGV : ZV;
   SET_PT (casify_region (flag, make_number (PT), make_number (farend)));
   return Qnil;
-}
-
-DEFUN ("upcase-word", Fupcase_word, Supcase_word, 1, 1, "p",
-       doc: /* Convert to upper case from point to end of word, moving over.
-
-If point is in the middle of a word, the part of that word before point
-is ignored when moving forward.
-
-With negative argument, convert previous words but do not move.
-See also `capitalize-word'.  */)
-  (Lisp_Object arg)
-{
-  return casify_word (CASE_UP, arg);
-}
-
-DEFUN ("downcase-word", Fdowncase_word, Sdowncase_word, 1, 1, "p",
-       doc: /* Convert to lower case from point to end of word, moving over.
-
-If point is in the middle of a word, the part of that word before point
-is ignored when moving forward.
-
-With negative argument, convert previous words but do not move.  */)
-  (Lisp_Object arg)
-{
-  return casify_word (CASE_DOWN, arg);
-}
-
-DEFUN ("capitalize-word", Fcapitalize_word, Scapitalize_word, 1, 1, "p",
-       doc: /* Capitalize from point to the end of word, moving over.
-With numerical argument ARG, capitalize the next ARG-1 words as well.
-This gives the word(s) a first character in upper case
-and the rest lower case.
-
-If point is in the middle of a word, the part of that word before point
-is ignored when moving forward.
-
-With negative argument, capitalize previous words but do not move.  */)
-  (Lisp_Object arg)
-{
-  return casify_word (CASE_CAPITALIZE, arg);
 }
 
 void
@@ -613,9 +573,6 @@ syms_of_casefiddle (void)
   defsubr (&Sdowncase_region);
   defsubr (&Scapitalize_region);
   defsubr (&Supcase_initials_region);
-  defsubr (&Supcase_word);
-  defsubr (&Sdowncase_word);
-  defsubr (&Scapitalize_word);
 }
 
 void

--- a/src/casefiddle.c
+++ b/src/casefiddle.c
@@ -467,61 +467,6 @@ casify_region (enum case_action flag, Lisp_Object b, Lisp_Object e)
   return orig_end + added;
 }
 
-DEFUN ("upcase-region", Fupcase_region, Supcase_region, 2, 3,
-       "(list (region-beginning) (region-end) (region-noncontiguous-p))",
-       doc: /* Convert the region to upper case.  In programs, wants two arguments.
-These arguments specify the starting and ending character numbers of
-the region to operate on.  When used as a command, the text between
-point and the mark is operated on.
-See also `capitalize-region'.  */)
-  (Lisp_Object beg, Lisp_Object end, Lisp_Object region_noncontiguous_p)
-{
-  Lisp_Object bounds = Qnil;
-
-  if (!NILP (region_noncontiguous_p))
-    {
-      bounds = call1 (Fsymbol_value (intern ("region-extract-function")),
-		      intern ("bounds"));
-
-      while (CONSP (bounds))
-	{
-	  casify_region (CASE_UP, XCAR (XCAR (bounds)), XCDR (XCAR (bounds)));
-	  bounds = XCDR (bounds);
-	}
-    }
-  else
-    casify_region (CASE_UP, beg, end);
-
-  return Qnil;
-}
-
-DEFUN ("downcase-region", Fdowncase_region, Sdowncase_region, 2, 3,
-       "(list (region-beginning) (region-end) (region-noncontiguous-p))",
-       doc: /* Convert the region to lower case.  In programs, wants two arguments.
-These arguments specify the starting and ending character numbers of
-the region to operate on.  When used as a command, the text between
-point and the mark is operated on.  */)
-  (Lisp_Object beg, Lisp_Object end, Lisp_Object region_noncontiguous_p)
-{
-  Lisp_Object bounds = Qnil;
-
-  if (!NILP (region_noncontiguous_p))
-    {
-      bounds = call1 (Fsymbol_value (intern ("region-extract-function")),
-		      intern ("bounds"));
-
-      while (CONSP (bounds))
-	{
-	  casify_region (CASE_DOWN, XCAR (XCAR (bounds)), XCDR (XCAR (bounds)));
-	  bounds = XCDR (bounds);
-	}
-    }
-  else
-    casify_region (CASE_DOWN, beg, end);
-
-  return Qnil;
-}
-
 /* casify_region returns a pointer, which complicates interaction
    with Rust. This wraps that and returns nil. It can be deleted once
    casify_region is ported. */
@@ -551,9 +496,6 @@ syms_of_casefiddle (void)
   DEFSYM (Qspecial_uppercase, "special-uppercase");
   DEFSYM (Qspecial_lowercase, "special-lowercase");
   DEFSYM (Qspecial_titlecase, "special-titlecase");
-
-  defsubr (&Supcase_region);
-  defsubr (&Sdowncase_region);
 }
 
 void

--- a/src/casefiddle.c
+++ b/src/casefiddle.c
@@ -522,30 +522,13 @@ point and the mark is operated on.  */)
   return Qnil;
 }
 
-DEFUN ("capitalize-region", Fcapitalize_region, Scapitalize_region, 2, 2, "r",
-       doc: /* Convert the region to capitalized form.
-This means that each word's first character is converted to either
-title case or upper case, and the rest to lower case.
-In programs, give two arguments, the starting and ending
-character positions to operate on.  */)
-  (Lisp_Object beg, Lisp_Object end)
+/* casify_region returns a pointer, which complicates interaction
+   with Rust. This wraps that and returns nil. It can be deleted once
+   casify_region is ported. */
+Lisp_Object
+casify_region_nil (enum case_action flag, Lisp_Object b, Lisp_Object e)
 {
-  casify_region (CASE_CAPITALIZE, beg, end);
-  return Qnil;
-}
-
-/* Like Fcapitalize_region but change only the initials.  */
-
-DEFUN ("upcase-initials-region", Fupcase_initials_region,
-       Supcase_initials_region, 2, 2, "r",
-       doc: /* Upcase the initial of each word in the region.
-This means that each word's first character is converted to either
-title case or upper case, and the rest are left unchanged.
-In programs, give two arguments, the starting and ending
-character positions to operate on.  */)
-  (Lisp_Object beg, Lisp_Object end)
-{
-  casify_region (CASE_CAPITALIZE_UP, beg, end);
+  casify_region(flag, b, e);
   return Qnil;
 }
 
@@ -571,8 +554,6 @@ syms_of_casefiddle (void)
 
   defsubr (&Supcase_region);
   defsubr (&Sdowncase_region);
-  defsubr (&Scapitalize_region);
-  defsubr (&Supcase_initials_region);
 }
 
 void

--- a/src/casefiddle.c
+++ b/src/casefiddle.c
@@ -487,16 +487,3 @@ casify_word (enum case_action flag, Lisp_Object arg)
   SET_PT (casify_region (flag, make_number (PT), make_number (farend)));
   return Qnil;
 }
-
-void
-keys_of_casefiddle (void)
-{
-  initial_define_key (control_x_map, Ctl ('U'), "upcase-region");
-  Fput (intern ("upcase-region"), Qdisabled, Qt);
-  initial_define_key (control_x_map, Ctl ('L'), "downcase-region");
-  Fput (intern ("downcase-region"), Qdisabled, Qt);
-
-  initial_define_key (meta_map, 'u', "upcase-word");
-  initial_define_key (meta_map, 'l', "downcase-word");
-  initial_define_key (meta_map, 'c', "capitalize-word");
-}

--- a/src/casefiddle.c
+++ b/src/casefiddle.c
@@ -489,16 +489,6 @@ casify_word (enum case_action flag, Lisp_Object arg)
 }
 
 void
-syms_of_casefiddle (void)
-{
-  DEFSYM (Qidentity, "identity");
-  DEFSYM (Qtitlecase, "titlecase");
-  DEFSYM (Qspecial_uppercase, "special-uppercase");
-  DEFSYM (Qspecial_lowercase, "special-lowercase");
-  DEFSYM (Qspecial_titlecase, "special-titlecase");
-}
-
-void
 keys_of_casefiddle (void)
 {
   initial_define_key (control_x_map, Ctl ('U'), "upcase-region");

--- a/src/lisp.h
+++ b/src/lisp.h
@@ -4091,6 +4091,7 @@ extern void syms_of_callint (void);
 
 enum case_action {CASE_UP, CASE_DOWN, CASE_CAPITALIZE, CASE_CAPITALIZE_UP};
 Lisp_Object casify_object (enum case_action flag, Lisp_Object obj);
+Lisp_Object casify_region_nil (enum case_action flag, Lisp_Object b, Lisp_Object e);
 Lisp_Object casify_word (enum case_action flag, Lisp_Object obj);
 extern void syms_of_casefiddle (void);
 extern void keys_of_casefiddle (void);

--- a/src/lisp.h
+++ b/src/lisp.h
@@ -4091,6 +4091,7 @@ extern void syms_of_callint (void);
 
 enum case_action {CASE_UP, CASE_DOWN, CASE_CAPITALIZE, CASE_CAPITALIZE_UP};
 Lisp_Object casify_object (enum case_action flag, Lisp_Object obj);
+Lisp_Object casify_word (enum case_action flag, Lisp_Object obj);
 extern void syms_of_casefiddle (void);
 extern void keys_of_casefiddle (void);
 


### PR DESCRIPTION
A lot of work is still being done in C, but all the exposed Lisp stuff is in Rust.