### PR TITLE
Port casify_word

### DIFF
--- a/src/casefiddle.c
+++ b/src/casefiddle.c
@@ -429,7 +429,7 @@ do_casify_multibyte_region (struct casing_context *ctx,
 /* flag is CASE_UP, CASE_DOWN or CASE_CAPITALIZE or CASE_CAPITALIZE_UP.  b and
    e specify range of buffer to operate on.  Return character position of the
    end of the region after changes.  */
-static ptrdiff_t
+ptrdiff_t
 casify_region (enum case_action flag, Lisp_Object b, Lisp_Object e)
 {
   ptrdiff_t added;
@@ -474,16 +474,5 @@ Lisp_Object
 casify_region_nil (enum case_action flag, Lisp_Object b, Lisp_Object e)
 {
   casify_region(flag, b, e);
-  return Qnil;
-}
-
-Lisp_Object
-casify_word (enum case_action flag, Lisp_Object arg)
-{
-  CHECK_NUMBER (arg);
-  ptrdiff_t farend = scan_words (PT, XINT (arg));
-  if (!farend)
-    farend = XINT (arg) <= 0 ? BEGV : ZV;
-  SET_PT (casify_region (flag, make_number (PT), make_number (farend)));
   return Qnil;
 }

--- a/src/lisp.h
+++ b/src/lisp.h
@@ -4091,8 +4091,8 @@ extern void syms_of_callint (void);
 
 enum case_action {CASE_UP, CASE_DOWN, CASE_CAPITALIZE, CASE_CAPITALIZE_UP};
 Lisp_Object casify_object (enum case_action flag, Lisp_Object obj);
+ptrdiff_t casify_region (enum case_action flag, Lisp_Object b, Lisp_Object e);
 Lisp_Object casify_region_nil (enum case_action flag, Lisp_Object b, Lisp_Object e);
-Lisp_Object casify_word (enum case_action flag, Lisp_Object obj);
 extern void syms_of_casefiddle (void);
 extern void keys_of_casefiddle (void);
 


### PR DESCRIPTION
I actually wanted to port the casify lisp functions, but somebody beat me to it so I tried doing `casify_word`.

I'm not sure I'm using the correct functions to deal with this, so a review would be much appreciated.