### PR TITLE
delete `no` option for `--with-x-toolkit`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -312,13 +312,12 @@ AC_ARG_WITH([x-toolkit],[AS_HELP_STRING([--with-x-toolkit=KIT],
  [use an X toolkit (KIT one of: yes or gtk, gtk2, gtk3, no)])],
 [	  case "${withval}" in
 	    y | ye | yes )	val=gtk ;;
-	    n | no )		val=no  ;;
 	    g | gt | gtk  )	val=gtk ;;
 	    gtk2  )	val=gtk2 ;;
 	    gtk3  )	val=gtk3 ;;
 	    * )
 AC_MSG_ERROR(['--with-x-toolkit=$withval' is invalid;
-this option's value should be 'yes', 'no', 'gtk',
+this option's value should be 'yes', 'gtk',
 'gtk2' or 'gtk3'.  'yes' and 'gtk' are synonyms.])
 	    ;;
 	  esac
@@ -2129,7 +2128,6 @@ dnl USE_X_TOOLKIT is set.
       gtk3 ) with_gtk3=yes
              term_header=gtkutil.h
              USE_X_TOOLKIT=none ;;
-      no ) USE_X_TOOLKIT=none ;;
 dnl If user did not say whether to use a toolkit, make this decision later:
 dnl use the toolkit if we have gtk, or X11R5 or newer.
       * ) USE_X_TOOLKIT=maybe ;;

--- a/src/dispextern.h
+++ b/src/dispextern.h
@@ -3318,9 +3318,6 @@ extern void x_reference_bitmap (struct frame *, ptrdiff_t);
 extern ptrdiff_t x_create_bitmap_from_data (struct frame *, char *,
 					    unsigned int, unsigned int);
 extern ptrdiff_t x_create_bitmap_from_file (struct frame *, Lisp_Object);
-#if defined HAVE_XPM && defined HAVE_X_WINDOWS && !defined USE_GTK
-extern ptrdiff_t x_create_bitmap_from_xpm_data (struct frame *, const char **);
-#endif
 #ifndef x_destroy_bitmap
 extern void x_destroy_bitmap (struct frame *, ptrdiff_t);
 #endif

--- a/src/dispnew.c
+++ b/src/dispnew.c
@@ -759,14 +759,6 @@ clear_current_matrices (register struct frame *f)
   if (f->current_matrix)
     clear_glyph_matrix (f->current_matrix);
 
-#if defined (HAVE_X_WINDOWS) && ! defined (USE_GTK)
-  /* Clear the matrix of the menu bar window, if such a window exists.
-     The menu bar window is currently used to display menus on X when
-     no toolkit support is compiled in.  */
-  if (WINDOWP (f->menu_bar_window))
-    clear_glyph_matrix (XWINDOW (f->menu_bar_window)->current_matrix);
-#endif
-
 #if defined (HAVE_WINDOW_SYSTEM) && ! defined (USE_GTK) && ! defined (HAVE_NS)
   /* Clear the matrix of the tool-bar window, if any.  */
   if (WINDOWP (f->tool_bar_window))
@@ -786,11 +778,6 @@ clear_desired_matrices (register struct frame *f)
 {
   if (f->desired_matrix)
     clear_glyph_matrix (f->desired_matrix);
-
-#if defined (HAVE_X_WINDOWS) && ! defined (USE_GTK)
-  if (WINDOWP (f->menu_bar_window))
-    clear_glyph_matrix (XWINDOW (f->menu_bar_window)->desired_matrix);
-#endif
 
 #if defined (HAVE_WINDOW_SYSTEM) && ! defined (USE_GTK) && ! defined (HAVE_NS)
   if (WINDOWP (f->tool_bar_window))
@@ -2073,39 +2060,6 @@ adjust_frame_glyphs_for_window_redisplay (struct frame *f)
   /* Allocate/reallocate window matrices.  */
   allocate_matrices_for_window_redisplay (XWINDOW (FRAME_ROOT_WINDOW (f)));
 
-#if defined (HAVE_X_WINDOWS) && ! defined (USE_GTK)
-  /* Allocate/ reallocate matrices of the dummy window used to display
-     the menu bar under X when no X toolkit support is available.  */
-  {
-    /* Allocate a dummy window if not already done.  */
-    struct window *w;
-    if (NILP (f->menu_bar_window))
-      {
-	Lisp_Object frame;
-	fset_menu_bar_window (f, make_window ());
-	w = XWINDOW (f->menu_bar_window);
-	XSETFRAME (frame, f);
-	wset_frame (w, frame);
-	w->pseudo_window_p = 1;
-      }
-    else
-      w = XWINDOW (f->menu_bar_window);
-
-    /* Set window dimensions to frame dimensions and allocate or
-       adjust glyph matrices of W.  */
-    w->pixel_left = 0;
-    w->left_col = 0;
-    w->pixel_top = 0;
-    w->top_line = 0;
-    w->pixel_width = (FRAME_PIXEL_WIDTH (f)
-		      - 2 * FRAME_INTERNAL_BORDER_WIDTH (f));
-    w->total_cols = FRAME_TOTAL_COLS (f);
-    w->pixel_height = FRAME_MENU_BAR_HEIGHT (f);
-    w->total_lines = FRAME_MENU_BAR_LINES (f);
-    allocate_matrices_for_window_redisplay (w);
-  }
-#endif
-
 #if defined (HAVE_WINDOW_SYSTEM) && ! defined (USE_GTK) && ! defined (HAVE_NS)
   {
     /* Allocate/ reallocate matrices of the tool bar window.  If we
@@ -2174,19 +2128,6 @@ free_glyphs (struct frame *f)
       /* Release window sub-matrices.  */
       if (!NILP (f->root_window))
         free_window_matrices (XWINDOW (f->root_window));
-
-#if defined (HAVE_X_WINDOWS) && ! defined (USE_GTK)
-      /* Free the dummy window for menu bars without X toolkit and its
-	 glyph matrices.  */
-      if (!NILP (f->menu_bar_window))
-	{
-	  struct window *w = XWINDOW (f->menu_bar_window);
-	  free_glyph_matrix (w->desired_matrix);
-	  free_glyph_matrix (w->current_matrix);
-	  w->desired_matrix = w->current_matrix = NULL;
-	  fset_menu_bar_window (f, Qnil);
-	}
-#endif
 
 #if defined (HAVE_WINDOW_SYSTEM) && ! defined (USE_GTK) && ! defined (HAVE_NS)
       /* Free the tool bar window and its glyph matrices.  */
@@ -3073,13 +3014,6 @@ update_frame (struct frame *f, bool force_p, bool inhibit_hairy_id_p)
       /* Update all windows in the window tree of F, maybe stopping
 	 when pending input is detected.  */
       update_begin (f);
-
-#if defined (HAVE_X_WINDOWS) && ! defined (USE_GTK)
-      /* Update the menu bar on X frames that don't have toolkit
-	 support.  */
-      if (WINDOWP (f->menu_bar_window))
-	update_window (XWINDOW (f->menu_bar_window), true);
-#endif
 
 #if defined (HAVE_WINDOW_SYSTEM) && ! defined (USE_GTK) && ! defined (HAVE_NS)
       /* Update the tool-bar window, if present.  */

--- a/src/emacs-icon.h
+++ b/src/emacs-icon.h
@@ -22,7 +22,7 @@ along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.  */
 
 /* Note that the GTK port uses gdk to display the icon, so Emacs need
    not have XPM support compiled in.  */
-#if (defined (HAVE_XPM) && defined (HAVE_X_WINDOWS)) || defined (USE_GTK)
+#if defined (USE_GTK)
 static const char * gnu_xpm_bits[] = {
 /* width height ncolors chars_per_pixel */
 "32 32 255 2",
@@ -315,7 +315,7 @@ static const char * gnu_xpm_bits[] = {
 "OPOPOPOPOPOPOPOPILILBIILPKCBJAAHJFBPILILOBOBAIOPOPOPOPOPOPOPOPOP",
 "OPOPOPOPOPOPOPOPOPOPILMIGECABCPKGHAIILOBOBOPOPOPOPOPOPOPOPOPOPOP",
 "OPOPOPOPOPOPOPOPOPOPOPOPOPCAOPOPOPOPOPOPOPOPOPOPOPOPOPOPOPOPOPOP"};
-#endif /* (defined (HAVE_XPM) && defined (HAVE_X_WINDOWS)) || defined (USE_GTK) */
+#endif /* defined (USE_GTK) */
 
 #define gnu_xbm_width 50
 #define gnu_xbm_height 50

--- a/src/frame.c
+++ b/src/frame.c
@@ -4693,34 +4693,6 @@ display_x_get_resource (Display_Info *dpyinfo, Lisp_Object attribute,
 			    attribute, class, component, subclass);
 }
 
-#if defined HAVE_X_WINDOWS && !defined USE_GTK
-/* Used when C code wants a resource value.  */
-/* Called from oldXMenu/Create.c.  */
-char *
-x_get_resource_string (const char *attribute, const char *class)
-{
-  char *result;
-  struct frame *sf = SELECTED_FRAME ();
-  ptrdiff_t invocation_namelen = SBYTES (Vinvocation_name);
-  USE_SAFE_ALLOCA;
-
-  /* Allocate space for the components, the dots which separate them,
-     and the final '\0'.  */
-  ptrdiff_t name_keysize = invocation_namelen + strlen (attribute) + 2;
-  ptrdiff_t class_keysize = sizeof (EMACS_CLASS) - 1 + strlen (class) + 2;
-  char *name_key = SAFE_ALLOCA (name_keysize + class_keysize);
-  char *class_key = name_key + name_keysize;
-
-  esprintf (name_key, "%s.%s", SSDATA (Vinvocation_name), attribute);
-  sprintf (class_key, "%s.%s", EMACS_CLASS, class);
-
-  result = x_get_string_resource (FRAME_DISPLAY_INFO (sf)->xrdb,
-				  name_key, class_key);
-  SAFE_FREE ();
-  return result;
-}
-#endif
-
 /* Return the value of parameter PARAM.
 
    First search ALIST, then Vdefault_frame_alist, then the X defaults

--- a/src/frame.h
+++ b/src/frame.h
@@ -171,12 +171,6 @@ struct frame
      most recently buried buffer is first.  For last-buffer.  */
   Lisp_Object buried_buffer_list;
 
-#if defined (HAVE_X_WINDOWS) && ! defined (USE_GTK)
-  /* A dummy window used to display menu bars under X when no X
-     toolkit support is available.  */
-  Lisp_Object menu_bar_window;
-#endif
-
 #if defined (HAVE_WINDOW_SYSTEM) && ! defined (USE_GTK) && ! defined (HAVE_NS)
   /* A window used to display the tool-bar of a frame.  */
   Lisp_Object tool_bar_window;
@@ -633,13 +627,6 @@ fset_menu_bar_vector (struct frame *f, Lisp_Object val)
 {
   f->menu_bar_vector = val;
 }
-#if defined (HAVE_X_WINDOWS) && ! defined (USE_GTK)
-INLINE void
-fset_menu_bar_window (struct frame *f, Lisp_Object val)
-{
-  f->menu_bar_window = val;
-}
-#endif
 INLINE void
 fset_name (struct frame *f, Lisp_Object val)
 {

--- a/src/image.c
+++ b/src/image.c
@@ -3509,56 +3509,6 @@ xpm_image_p (Lisp_Object object)
 
 #endif /* HAVE_XPM || HAVE_NS */
 
-#if defined HAVE_XPM && defined HAVE_X_WINDOWS && !defined USE_GTK
-ptrdiff_t
-x_create_bitmap_from_xpm_data (struct frame *f, const char **bits)
-{
-  Display_Info *dpyinfo = FRAME_DISPLAY_INFO (f);
-  ptrdiff_t id;
-  int rc;
-  XpmAttributes attrs;
-  Pixmap bitmap, mask;
-
-  memset (&attrs, 0, sizeof attrs);
-
-  attrs.visual = FRAME_X_VISUAL (f);
-  attrs.colormap = FRAME_X_COLORMAP (f);
-  attrs.valuemask |= XpmVisual;
-  attrs.valuemask |= XpmColormap;
-
-#ifdef ALLOC_XPM_COLORS
-  attrs.color_closure = f;
-  attrs.alloc_color = xpm_alloc_color;
-  attrs.free_colors = xpm_free_colors;
-  attrs.valuemask |= XpmAllocColor | XpmFreeColors | XpmColorClosure;
-  xpm_init_color_cache (f, &attrs);
-#endif
-
-  rc = XpmCreatePixmapFromData (FRAME_X_DISPLAY (f), FRAME_X_DRAWABLE (f),
-				(char **) bits, &bitmap, &mask, &attrs);
-  if (rc != XpmSuccess)
-    {
-      XpmFreeAttributes (&attrs);
-      return -1;
-    }
-
-  id = x_allocate_bitmap_record (f);
-  dpyinfo->bitmaps[id - 1].pixmap = bitmap;
-  dpyinfo->bitmaps[id - 1].have_mask = true;
-  dpyinfo->bitmaps[id - 1].mask = mask;
-  dpyinfo->bitmaps[id - 1].file = NULL;
-  dpyinfo->bitmaps[id - 1].height = attrs.height;
-  dpyinfo->bitmaps[id - 1].width = attrs.width;
-  dpyinfo->bitmaps[id - 1].depth = attrs.depth;
-  dpyinfo->bitmaps[id - 1].refcount = 1;
-
-#ifdef ALLOC_XPM_COLORS
-  xpm_free_color_cache ();
-#endif
-  XpmFreeAttributes (&attrs);
-  return id;
-}
-#endif /* defined (HAVE_XPM) && defined (HAVE_X_WINDOWS) */
 
 /* Load image IMG which will be displayed on frame F.  Value is
    true if successful.  */

--- a/src/window.c
+++ b/src/window.c
@@ -258,13 +258,8 @@ wget_pseudo_window_p(struct window *w)
 bool
 window_menu_bar_p(struct window *W)
 {
-#if defined (HAVE_X_WINDOWS) && ! defined (USE_GTK)
-  return (WINDOWP (WINDOW_XFRAME (W)->menu_bar_window)
-          && (W) == XWINDOW (WINDOW_XFRAME (W)->menu_bar_window));
-#else
 /* No menu bar windows if X toolkit is in use.  */
   return false;
-#endif
 }
 
 /* True if W is a tool bar window.  */


### PR DESCRIPTION
After merging #885, the x-toolkit has only four options now.
 * no
 * yes or gtk (means gtk2 or gtk3)
 * gtk2
 * gtk3

This PR delete the `no` option. After merging this, the `HAVE_X_WINDOWS` and
`USE_GTK` will equal in value. They will just be same in Remacs.