### PR TITLE
More Clippy!!

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,8 @@ Thank you for contributing to Remacs!
   can be found in the section on [Remacs style](#remacs-style).
 * Check for Rust compiler warnings, as CI won't go green if there
   are warnings.
+* Try to check your code with Clippy. `cargo clippy` will run the linter.
+  You can install clippy with `rustup component add clippy-preview`.
 * Format your code with
   [rustfmt](https://github.com/rust-lang-nursery/rustfmt). Make sure
   you have the correct version by using rustup (it will use the

--- a/lib-src/hashdir/src/main.rs
+++ b/lib-src/hashdir/src/main.rs
@@ -25,7 +25,6 @@ fn main() {
     let mut hash_input: String = String::with_capacity(1024);
     for path in processed_paths {
         for entry in ignore::Walk::new(path)
-            .into_iter()
             .filter(|e| {
                 let entry = e.as_ref().unwrap();
                 let filename = entry.file_name().to_string_lossy();

--- a/lib-src/hashdir/src/main.rs
+++ b/lib-src/hashdir/src/main.rs
@@ -3,7 +3,7 @@ extern crate ignore;
 extern crate sha2;
 use sha2::Digest;
 
-fn process_path<'a>(path: &str) -> String {
+fn process_path(path: &str) -> String {
     let path = std::path::Path::new("../src").join(path);
     let buf = std::fs::canonicalize(path).unwrap();
     buf.to_string_lossy().to_string()
@@ -29,10 +29,11 @@ fn main() {
             .filter(|e| {
                 let entry = e.as_ref().unwrap();
                 let filename = entry.file_name().to_string_lossy();
-                entry.file_type().unwrap().is_dir() || filename.ends_with(".c")
-                    || filename.ends_with(".h") || filename.ends_with(".rs")
-            })
-            .filter_map(|e| e.ok())
+                entry.file_type().unwrap().is_dir()
+                    || filename.ends_with(".c")
+                    || filename.ends_with(".h")
+                    || filename.ends_with(".rs")
+            }).filter_map(|e| e.ok())
         {
             if entry.file_type().unwrap().is_file() {
                 hash_input.push_str(&entry.path().to_string_lossy().to_string());

--- a/rust_src/remacs-lib/docfile.rs
+++ b/rust_src/remacs-lib/docfile.rs
@@ -27,12 +27,12 @@ const FUNCTION: c_int = 5;
 type AddGlobalFn = fn(c_int, *const c_char, c_int, *const c_char) -> *const ();
 
 #[no_mangle]
-pub extern "C" fn scan_rust_file(
+pub unsafe extern "C" fn scan_rust_file(
     filename: *const c_char,
     generate_globals: c_int,
     add_global: AddGlobalFn,
 ) {
-    let filename = unsafe { CStr::from_ptr(filename) }.to_str().unwrap();
+    let filename = CStr::from_ptr(filename).to_str().unwrap();
     let fp = BufReader::new(File::open(&*filename).unwrap());
 
     let mut in_docstring = false;
@@ -147,8 +147,8 @@ pub extern "C" fn scan_rust_file(
                 }
                 // Print contents for docfile to stdout
                 print!(
-                    "\x1f{}{}\n{}\n{}",
-                    "F", attr_props.name, docstring, docstring_usage
+                    "\x1fF{}\n{}\n{}",
+                    attr_props.name, docstring, docstring_usage
                 );
             }
         } else if line.starts_with("def_lisp_sym!(") {

--- a/rust_src/remacs-lib/files.rs
+++ b/rust_src/remacs-lib/files.rs
@@ -22,15 +22,15 @@ use std::env;
 const NUM_RETRIES: usize = 50;
 
 #[no_mangle]
-pub extern "C" fn rust_make_temp(template: *mut c_char, flags: c_int) -> c_int {
+pub unsafe extern "C" fn rust_make_temp(template: *mut c_char, flags: c_int) -> c_int {
     let save_errno = errno::errno();
-    let template_string = unsafe { CStr::from_ptr(template).to_string_lossy().into_owned() };
+    let template_string = CStr::from_ptr(template).to_string_lossy().into_owned();
 
     match make_temporary_file(template_string, flags) {
         Ok(result) => {
             errno::set_errno(save_errno);
             let name = CString::new(result.1).unwrap();
-            unsafe { libc::strcpy(template, name.as_ptr()) };
+            libc::strcpy(template, name.as_ptr());
             result.0
         }
 

--- a/rust_src/remacs-macros/lib.rs
+++ b/rust_src/remacs-macros/lib.rs
@@ -145,7 +145,6 @@ pub fn lisp_fn(attr_ts: TokenStream, fn_ts: TokenStream) -> TokenStream {
                         ::remacs_sys::xmalloc(::std::mem::size_of::<::remacs_sys::Lisp_Subr>())
                         as *mut ::remacs_sys::Lisp_Subr;
                     ::std::ptr::copy_nonoverlapping(&subr, ptr, 1);
-                    ::std::mem::forget(subr);
                     ::lisp::ExternalPtr::new(ptr)
                 }
             };

--- a/rust_src/src/buffers.rs
+++ b/rust_src/src/buffers.rs
@@ -588,9 +588,9 @@ pub fn overlay_properties(overlay: LispOverlayRef) -> LispObject {
 }
 
 #[no_mangle]
-pub extern "C" fn validate_region(b: *mut LispObject, e: *mut LispObject) {
-    let start = unsafe { *b };
-    let stop = unsafe { *e };
+pub unsafe extern "C" fn validate_region(b: *mut LispObject, e: *mut LispObject) {
+    let start = *b;
+    let stop = *e;
 
     let mut beg = start.as_fixnum_coerce_marker_or_error();
     let mut end = stop.as_fixnum_coerce_marker_or_error();
@@ -599,10 +599,8 @@ pub extern "C" fn validate_region(b: *mut LispObject, e: *mut LispObject) {
         mem::swap(&mut beg, &mut end);
     }
 
-    unsafe {
-        *b = LispObject::from(beg);
-        *e = LispObject::from(end);
-    }
+    *b = LispObject::from(beg);
+    *e = LispObject::from(end);
 
     let buf = ThreadState::current_buffer();
     let begv = buf.begv as EmacsInt;

--- a/rust_src/src/buffers.rs
+++ b/rust_src/src/buffers.rs
@@ -69,7 +69,7 @@ impl LispBufferRef {
         LispObject::tag_ptr(self, Lisp_Type::Lisp_Vectorlike)
     }
 
-    pub fn is_read_only(&self) -> bool {
+    pub fn is_read_only(self) -> bool {
         self.read_only_.into()
     }
 
@@ -366,12 +366,12 @@ impl LispBufferRef {
 
 impl LispBufferRef {
     #[inline]
-    pub fn overlays_before(&self) -> Option<LispOverlayRef> {
+    pub fn overlays_before(self) -> Option<LispOverlayRef> {
         unsafe { self.overlays_before.as_ref().map(|m| mem::transmute(m)) }
     }
 
     #[inline]
-    pub fn overlays_after(&self) -> Option<LispOverlayRef> {
+    pub fn overlays_after(self) -> Option<LispOverlayRef> {
         unsafe { self.overlays_after.as_ref().map(|m| mem::transmute(m)) }
     }
 }

--- a/rust_src/src/buffers.rs
+++ b/rust_src/src/buffers.rs
@@ -674,10 +674,8 @@ pub extern "C" fn nsberror(spec: LispObject) -> ! {
 #[lisp_fn]
 pub fn overlay_lists() -> LispObject {
     let list_overlays = |ol: LispOverlayRef| -> LispObject {
-        let ol_list = ol
-            .iter()
-            .fold(Qnil, |accum, n| unsafe { Fcons(n.as_lisp_obj(), accum) });
-        ol_list
+        ol.iter()
+            .fold(Qnil, |accum, n| unsafe { Fcons(n.as_lisp_obj(), accum) })
     };
 
     let cur_buf = ThreadState::current_buffer();

--- a/rust_src/src/buffers.rs
+++ b/rust_src/src/buffers.rs
@@ -438,10 +438,7 @@ impl LispBufferLocalValueRef {
 /// followed by the rest of the buffers.
 #[lisp_fn(min = "0")]
 pub fn buffer_list(frame: LispObject) -> LispObject {
-    let mut buffers: Vec<LispObject> = unsafe { Vbuffer_alist }
-        .iter_cars_safe()
-        .map(|o| cdr(o))
-        .collect();
+    let mut buffers: Vec<LispObject> = unsafe { Vbuffer_alist }.iter_cars_safe().map(cdr).collect();
 
     match frame.as_frame() {
         None => Flist(buffers.len() as isize, buffers.as_mut_ptr()),

--- a/rust_src/src/data.rs
+++ b/rust_src/src/data.rs
@@ -31,13 +31,13 @@ use field_offset::FieldOffset;
 
 // Lisp_Fwd predicates which can go away as the callers are ported to Rust
 #[no_mangle]
-pub extern "C" fn KBOARD_OBJFWDP(a: *const Lisp_Fwd) -> bool {
-    unsafe { (*a).u_intfwd.ty == Lisp_Fwd_Kboard_Obj }
+pub unsafe extern "C" fn KBOARD_OBJFWDP(a: *const Lisp_Fwd) -> bool {
+    (*a).u_intfwd.ty == Lisp_Fwd_Kboard_Obj
 }
 
 #[no_mangle]
-pub extern "C" fn OBJFWDP(a: *const Lisp_Fwd) -> bool {
-    unsafe { (*a).u_intfwd.ty == Lisp_Fwd_Obj }
+pub unsafe extern "C" fn OBJFWDP(a: *const Lisp_Fwd) -> bool {
+    (*a).u_intfwd.ty == Lisp_Fwd_Obj
 }
 
 /// Find the function at the end of a chain of symbol function indirections.
@@ -429,37 +429,35 @@ pub struct Lisp_Kboard_Objfwd {
 /// This does not handle buffer-local variables; use
 /// swap_in_symval_forwarding for that.
 #[no_mangle]
-pub extern "C" fn do_symval_forwarding(valcontents: *mut Lisp_Fwd) -> LispObject {
-    unsafe {
-        match (*valcontents).u_intfwd.ty {
-            Lisp_Fwd_Int => LispObject::from(*(*valcontents).u_intfwd.intvar),
-            Lisp_Fwd_Bool => LispObject::from(*(*valcontents).u_boolfwd.boolvar),
-            Lisp_Fwd_Obj => (*(*valcontents).u_objfwd.objvar),
-            Lisp_Fwd_Buffer_Obj => *(*valcontents)
-                .u_buffer_objfwd
-                .offset
-                .apply_ptr(ThreadState::current_buffer().as_mut()),
-            Lisp_Fwd_Kboard_Obj => {
-                // We used to simply use current_kboard here, but from Lisp
-                // code, its value is often unexpected.  It seems nicer to
-                // allow constructions like this to work as intuitively expected:
-                //
-                // (with-selected-frame frame
-                // (define-key local-function-map "\eOP" [f1]))
-                //
-                // On the other hand, this affects the semantics of
-                // last-command and real-last-command, and people may rely on
-                // that.  I took a quick look at the Lisp codebase, and I
-                // don't think anything will break.  --lorentey
-                let frame = selected_frame().as_frame_or_error();
-                if !frame.is_live() {
-                    emacs_abort();
-                }
-                let kboard = (*frame.terminal).kboard;
-                *(*valcontents).u_kboard_objfwd.offset.apply_ptr(kboard)
+pub unsafe extern "C" fn do_symval_forwarding(valcontents: *mut Lisp_Fwd) -> LispObject {
+    match (*valcontents).u_intfwd.ty {
+        Lisp_Fwd_Int => LispObject::from(*(*valcontents).u_intfwd.intvar),
+        Lisp_Fwd_Bool => LispObject::from(*(*valcontents).u_boolfwd.boolvar),
+        Lisp_Fwd_Obj => (*(*valcontents).u_objfwd.objvar),
+        Lisp_Fwd_Buffer_Obj => *(*valcontents)
+            .u_buffer_objfwd
+            .offset
+            .apply_ptr(ThreadState::current_buffer().as_mut()),
+        Lisp_Fwd_Kboard_Obj => {
+            // We used to simply use current_kboard here, but from Lisp
+            // code, its value is often unexpected.  It seems nicer to
+            // allow constructions like this to work as intuitively expected:
+            //
+            // (with-selected-frame frame
+            // (define-key local-function-map "\eOP" [f1]))
+            //
+            // On the other hand, this affects the semantics of
+            // last-command and real-last-command, and people may rely on
+            // that.  I took a quick look at the Lisp codebase, and I
+            // don't think anything will break.  --lorentey
+            let frame = selected_frame().as_frame_or_error();
+            if !frame.is_live() {
+                emacs_abort();
             }
-            _ => emacs_abort(),
+            let kboard = (*frame.terminal).kboard;
+            *(*valcontents).u_kboard_objfwd.offset.apply_ptr(kboard)
         }
+        _ => emacs_abort(),
     }
 }
 
@@ -471,34 +469,34 @@ pub extern "C" fn do_symval_forwarding(valcontents: *mut Lisp_Fwd) -> LispObject
 /// BUF non-zero means set the value in buffer BUF instead of the
 /// current buffer.  This only plays a role for per-buffer variables.
 #[no_mangle]
-pub extern "C" fn store_symval_forwarding(
+pub unsafe extern "C" fn store_symval_forwarding(
     valcontents: *mut Lisp_Fwd,
     newval: LispObject,
     mut buf: *mut Lisp_Buffer,
 ) {
-    match unsafe { (*valcontents).u_intfwd.ty } {
-        Lisp_Fwd_Int => unsafe { (*(*valcontents).u_intfwd.intvar) = newval.as_fixnum_or_error() },
-        Lisp_Fwd_Bool => unsafe { (*(*valcontents).u_boolfwd.boolvar) = newval.is_not_nil() },
-        Lisp_Fwd_Obj => unsafe {
+    match (*valcontents).u_intfwd.ty {
+        Lisp_Fwd_Int => (*(*valcontents).u_intfwd.intvar) = newval.as_fixnum_or_error(),
+        Lisp_Fwd_Bool => (*(*valcontents).u_boolfwd.boolvar) = newval.is_not_nil(),
+        Lisp_Fwd_Obj => {
             (*(*valcontents).u_objfwd.objvar) = newval;
             update_buffer_defaults((*valcontents).u_objfwd.objvar, newval);
-        },
+        }
         Lisp_Fwd_Buffer_Obj => {
-            let predicate = unsafe { (*valcontents).u_buffer_objfwd.predicate };
+            let predicate = (*valcontents).u_buffer_objfwd.predicate;
 
             if newval.is_not_nil() && predicate.is_symbol() {
-                let mut prop = unsafe { Fget(predicate, Qchoice) };
+                let mut prop = Fget(predicate, Qchoice);
                 if prop.is_not_nil() {
                     if memq(newval, prop).is_nil() {
-                        unsafe { wrong_choice(prop, newval) };
+                        wrong_choice(prop, newval);
                     }
                 } else {
-                    prop = unsafe { Fget(predicate, Qrange) };
+                    prop = Fget(predicate, Qrange);
                     if prop.is_cons() {
                         let (min, max) = prop.as_cons_or_error().as_tuple();
                         let args = [min, newval, max];
                         if !newval.is_number() || leq(&args) {
-                            unsafe { wrong_range(min, max, newval) };
+                            wrong_range(min, max, newval);
                         }
                     } else if predicate.is_function() && call!(predicate, newval).is_nil() {
                         wrong_type!(predicate, newval);
@@ -509,21 +507,17 @@ pub extern "C" fn store_symval_forwarding(
             if buf.is_null() {
                 buf = ThreadState::current_buffer().as_mut();
             }
-            unsafe {
-                *(*valcontents).u_buffer_objfwd.offset.apply_ptr_mut(buf) = newval;
-            }
+            *(*valcontents).u_buffer_objfwd.offset.apply_ptr_mut(buf) = newval;
         }
         Lisp_Fwd_Kboard_Obj => {
             let frame = selected_frame().as_frame_or_error();
             if !frame.is_live() {
-                unsafe { emacs_abort() };
+                emacs_abort();
             }
-            unsafe {
-                let kboard = (*frame.terminal).kboard;
-                *(*valcontents).u_kboard_objfwd.offset.apply_ptr_mut(kboard) = newval;
-            }
+            let kboard = (*frame.terminal).kboard;
+            *(*valcontents).u_kboard_objfwd.offset.apply_ptr_mut(kboard) = newval;
         }
-        _ => unsafe { emacs_abort() },
+        _ => emacs_abort(),
     }
 }
 

--- a/rust_src/src/decompress.rs
+++ b/rust_src/src/decompress.rs
@@ -37,7 +37,7 @@ fn create_buffer_decoder<'a>(buffer: &'a [u8]) -> Box<Read + 'a> {
 /// This function can be called only in unibyte buffers.
 #[lisp_fn]
 pub fn zlib_decompress_region(mut start: LispObject, mut end: LispObject) -> bool {
-    validate_region(&mut start, &mut end);
+    unsafe { validate_region(&mut start, &mut end) };
 
     let mut current_buffer = ThreadState::current_buffer();
 
@@ -79,9 +79,7 @@ pub fn zlib_decompress_region(mut start: LispObject, mut end: LispObject) -> boo
         let old_gap_size = current_buffer.gap_size();
 
         if old_gap_size < avail_out {
-            unsafe {
-                make_gap(avail_out - old_gap_size);
-            }
+            unsafe { make_gap(avail_out - old_gap_size) };
         }
 
         let new_gap_size = avail_out;
@@ -102,9 +100,7 @@ pub fn zlib_decompress_region(mut start: LispObject, mut end: LispObject) -> boo
             // Continue to decompress the remaining data.
             Ok(decompressed) => {
                 let decompressed = decompressed as isize;
-                unsafe {
-                    insert_from_gap(decompressed, decompressed, false);
-                }
+                unsafe { insert_from_gap(decompressed, decompressed, false) };
 
                 decompressed_bytes += decompressed;
 
@@ -114,9 +110,7 @@ pub fn zlib_decompress_region(mut start: LispObject, mut end: LispObject) -> boo
             // Decompress failed.
             _ => {
                 // Delete any uncompressed data already inserted on error.
-                unsafe {
-                    del_range(iend, iend + decompressed_bytes);
-                }
+                unsafe { del_range(iend, iend + decompressed_bytes) };
 
                 // Put point where it was, or if the buffer has shrunk because the
                 // compressed data is bigger than the uncompressed, at

--- a/rust_src/src/dired_unix.rs
+++ b/rust_src/src/dired_unix.rs
@@ -229,11 +229,11 @@ fn read_dir(dname: &str, fnames: &mut Vec<String>, match_re: Option<LispObject>)
     }
 
     let dot = String::from(".");
-    if let Some(_) = match_re_maybe(dot.to_owned(), match_re, &re) {
+    if match_re_maybe(dot.to_owned(), match_re, &re).is_some() {
         fnames.push(dot);
     }
     let dotdot = String::from("..");
-    if let Some(_) = match_re_maybe(dotdot.to_owned(), match_re, &re) {
+    if match_re_maybe(dotdot.to_owned(), match_re, &re).is_some() {
         fnames.push(dotdot);
     }
 
@@ -244,7 +244,7 @@ fn read_dir(dname: &str, fnames: &mut Vec<String>, match_re: Option<LispObject>)
         let f_dec_lo = unsafe { decode_file_name(f_enc_lo) }; // decoded
         let f = f_dec_lo.to_stdstring();
 
-        if let Some(_) = match_re_maybe(f.to_owned(), match_re, &re) {
+        if match_re_maybe(f.to_owned(), match_re, &re).is_some() {
             fnames.push(f);
         }
     }

--- a/rust_src/src/dired_unix.rs
+++ b/rust_src/src/dired_unix.rs
@@ -551,7 +551,7 @@ impl FileAttrs {
 
         //  2. File uid as a string or a number.  If a string value cannot be
         //  looked up, a numeric value, either an integer or a float, is returned.
-        self.idf_is_int = !("string" == self.id_format);
+        self.idf_is_int = "string" != self.id_format;
         if self.idf_is_int {
             self.idf_uid = md.uid();
             self.idf_gid = md.gid();

--- a/rust_src/src/dired_unix.rs
+++ b/rust_src/src/dired_unix.rs
@@ -548,12 +548,10 @@ impl FileAttrs {
             self.use_c_internal = true;
 
             return Ok(());
+        } else if ft.is_dir() {
+            self.ftype_is_dir = true;
         } else {
-            if ft.is_dir() {
-                self.ftype_is_dir = true;
-            } else {
-                self.ftype_is_dir = false;
-            }
+            self.ftype_is_dir = false;
         }
 
         self.nlinks = md.nlink();
@@ -623,12 +621,10 @@ impl FileAttrs {
         //  0. t for directory, string (name linked to) for symbolic link, or nil.
         if self.ftype_is_sym {
             attrs.push(self.ftype_sym_path.to_owned().to_bstring());
+        } else if self.ftype_is_dir {
+            attrs.push(Qt);
         } else {
-            if self.ftype_is_dir {
-                attrs.push(Qt);
-            } else {
-                attrs.push(Qnil);
-            }
+            attrs.push(Qnil);
         }
 
         //  1. Number of links to file.

--- a/rust_src/src/dired_unix.rs
+++ b/rust_src/src/dired_unix.rs
@@ -589,11 +589,11 @@ impl FileAttrs {
         }
 
         self.atime_s = md.atime();
-        self.atime_ns = c_long::from(md.atime_nsec());
+        self.atime_ns = md.atime_nsec();
         self.mtime_s = md.mtime();
-        self.mtime_ns = c_long::from(md.mtime_nsec());
+        self.mtime_ns = md.mtime_nsec();
         self.ctime_s = md.ctime();
-        self.ctime_ns = c_long::from(md.ctime_nsec());
+        self.ctime_ns = md.ctime_nsec();
 
         self.size = md.size();
 

--- a/rust_src/src/dired_unix.rs
+++ b/rust_src/src/dired_unix.rs
@@ -274,9 +274,9 @@ fn match_re_maybe(f: String, match_re: Option<LispObject>, re: &RegEx) -> Option
 
 fn fnames_to_list(fnames: &mut Vec<String>, dname: String, full: &FullPath) -> LispObject {
     match *full {
-        FullPath::No => list(&mut fnames.iter().map(|x| x.to_bstring()).collect::<Vec<_>>()),
+        FullPath::No => list(&fnames.iter().map(|x| x.to_bstring()).collect::<Vec<_>>()),
         FullPath::Yes => list(
-            &mut fnames
+            &fnames
                 .iter()
                 .map(|x| x.to_full(dname.to_owned()))
                 .map(|x| x.to_bstring())
@@ -293,7 +293,7 @@ fn fattrs_to_list(
 ) -> LispObject {
     match *full {
         FullPath::No => list(
-            &mut fnames
+            &fnames
                 .iter()
                 .map(|x| x.to_bstring())
                 .zip(fattrs.to_owned())
@@ -301,7 +301,7 @@ fn fattrs_to_list(
                 .collect::<Vec<_>>(),
         ),
         FullPath::Yes => list(
-            &mut fnames
+            &fnames
                 .iter()
                 .map(|x| x.to_full(dname.to_owned()))
                 .map(|x| x.to_bstring())
@@ -688,7 +688,7 @@ impl FileAttrs {
         //     integer can hold, this is a cons cell, similar to the inode number.
         attrs.push(LispObject::from_natnum(self.dev));
 
-        list(&mut attrs)
+        list(&attrs)
     }
 }
 
@@ -751,5 +751,5 @@ pub fn get_users() -> LispObject {
         unames.push(get_user_real_login_name());
     }
 
-    list(&mut unames)
+    list(&unames)
 }

--- a/rust_src/src/dired_unix.rs
+++ b/rust_src/src/dired_unix.rs
@@ -427,13 +427,14 @@ pub extern "C" fn directory_files_internal(
         id_format,
     );
 
-    let mut dd = DirData::Files { fnames: Vec::new() };
-    if attrs {
-        dd = DirData::FilesAttrs {
+    let mut dd = if attrs {
+        DirData::FilesAttrs {
             fnames: Vec::new(),
             fattrs: Vec::new(),
-        };
-    }
+        }
+    } else {
+        DirData::Files { fnames: Vec::new() }
+    };
 
     directory_files_core(&dr, &mut dd)
 }

--- a/rust_src/src/eval.rs
+++ b/rust_src/src/eval.rs
@@ -1022,7 +1022,7 @@ pub fn funcall(args: &mut [LispObject]) -> LispObject {
 
     // Increment the lisp eval depth
     let mut current_thread = ThreadState::current_thread();
-    current_thread.m_lisp_eval_depth = current_thread.m_lisp_eval_depth + 1;
+    current_thread.m_lisp_eval_depth += 1;
 
     unsafe {
         if current_thread.m_lisp_eval_depth > globals.max_lisp_eval_depth {
@@ -1078,7 +1078,7 @@ pub fn funcall(args: &mut [LispObject]) -> LispObject {
 
     unsafe { check_cons_list() };
 
-    current_thread.m_lisp_eval_depth = current_thread.m_lisp_eval_depth - 1;
+    current_thread.m_lisp_eval_depth -= 1;
 
     unsafe {
         if backtrace_debug_on_exit(current_thread.m_specpdl.offset(count)) {

--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -318,7 +318,7 @@ impl<T> ExternalPtr<T> {
         self.0.is_null()
     }
 
-    pub fn as_ptr(&self) -> *const T {
+    pub fn as_ptr(self) -> *const T {
         self.0
     }
 

--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -12,6 +12,7 @@ use std::mem;
 use std::ops::{Deref, DerefMut};
 use std::slice;
 
+use remacs_sys;
 use remacs_sys::{build_string, empty_unibyte_string, internal_equal, lispsym, make_float};
 use remacs_sys::{pvec_type, EmacsDouble, EmacsInt, EmacsUint, EqualKind, Fcons, Lisp_Bits,
                  CHECK_IMPURE, FONT_ENTITY_MAX, FONT_OBJECT_MAX, FONT_SPEC_MAX, INTMASK,
@@ -405,7 +406,7 @@ impl LispObject {
     }
 
     unsafe fn to_misc_unchecked(self) -> LispMiscRef {
-        LispMiscRef::new(mem::transmute(self.get_untaggedptr()))
+        LispMiscRef::new(self.get_untaggedptr() as *mut remacs_sys::Lisp_Misc_Any)
     }
 }
 
@@ -643,9 +644,9 @@ impl LispObject {
     #[inline]
     pub fn as_vectorlike(self) -> Option<LispVectorlikeRef> {
         if self.is_vectorlike() {
-            Some(LispVectorlikeRef::new(unsafe {
-                mem::transmute(self.get_untaggedptr())
-            }))
+            Some(LispVectorlikeRef::new(
+                self.get_untaggedptr() as *mut remacs_sys::Lisp_Vectorlike
+            ))
         } else {
             None
         }
@@ -663,7 +664,7 @@ impl LispObject {
     */
 
     pub unsafe fn as_vectorlike_unchecked(self) -> LispVectorlikeRef {
-        LispVectorlikeRef::new(mem::transmute(self.get_untaggedptr()))
+        LispVectorlikeRef::new(self.get_untaggedptr() as *mut remacs_sys::Lisp_Vectorlike)
     }
 
     pub fn as_vector(self) -> Option<LispVectorRef> {
@@ -1031,7 +1032,7 @@ impl From<LispObject> for ThreadStateRef {
 impl LispObject {
     pub fn as_hash_table_or_error(self) -> LispHashTableRef {
         if self.is_hash_table() {
-            LispHashTableRef::new(unsafe { mem::transmute(self.get_untaggedptr()) })
+            LispHashTableRef::new(self.get_untaggedptr() as *mut remacs_sys::Lisp_Hash_Table)
         } else {
             wrong_type!(Qhash_table_p, self);
         }
@@ -1297,7 +1298,7 @@ impl LispCons {
     }
 
     fn _extract(self) -> *mut Lisp_Cons {
-        unsafe { mem::transmute(self.0.get_untaggedptr()) }
+        self.0.get_untaggedptr() as *mut remacs_sys::Lisp_Cons
     }
 
     /// Return the car (first cell).
@@ -1369,7 +1370,7 @@ impl LispObject {
     #[inline]
     unsafe fn to_float_unchecked(self) -> LispFloatRef {
         debug_assert!(self.is_float());
-        LispFloatRef::new(mem::transmute(self.get_untaggedptr()))
+        LispFloatRef::new(self.get_untaggedptr() as *mut remacs_sys::Lisp_Float)
     }
 
     unsafe fn get_float_data_unchecked(self) -> EmacsDouble {
@@ -1458,7 +1459,7 @@ impl LispObject {
 
     #[inline]
     pub unsafe fn as_string_unchecked(self) -> LispStringRef {
-        LispStringRef::new(mem::transmute(self.get_untaggedptr()))
+        LispStringRef::new(self.get_untaggedptr() as *mut remacs_sys::Lisp_String)
     }
 
     #[inline]

--- a/rust_src/src/lread.rs
+++ b/rust_src/src/lread.rs
@@ -15,19 +15,15 @@ use field_offset::FieldOffset;
 // C variable of type EMACS_INT.  Sample call (with "xx" to fool make-docfile):
 // DEFxxVAR_INT ("emacs-priority", &emacs_priority, "Documentation");
 #[no_mangle]
-pub extern "C" fn defvar_int(
+pub unsafe extern "C" fn defvar_int(
     i_fwd: *mut Lisp_Intfwd,
     namestring: *const libc::c_schar,
     address: *mut EmacsInt,
 ) {
-    unsafe {
-        (*i_fwd).ty = Lisp_Fwd_Int;
-        (*i_fwd).intvar = address;
-    }
-    let sym = unsafe {
-        intern_c_string_1(namestring, libc::strlen(namestring) as libc::ptrdiff_t)
-            .as_symbol_or_error()
-    };
+    (*i_fwd).ty = Lisp_Fwd_Int;
+    (*i_fwd).intvar = address;
+    let sym = intern_c_string_1(namestring, libc::strlen(namestring) as libc::ptrdiff_t)
+        .as_symbol_or_error();
     sym.set_declared_special(true);
     sym.set_redirect(symbol_redirect::SYMBOL_FORWARDED);
     sym.set_fwd(i_fwd as *mut Lisp_Fwd);
@@ -36,19 +32,15 @@ pub extern "C" fn defvar_int(
 /* Similar but define a variable whose value is t if address contains 1,
    nil if address contains 0.  */
 #[no_mangle]
-pub extern "C" fn defvar_bool(
+pub unsafe extern "C" fn defvar_bool(
     b_fwd: *mut Lisp_Boolfwd,
     namestring: *const libc::c_schar,
     address: *mut bool,
 ) {
-    unsafe {
-        (*b_fwd).ty = Lisp_Fwd_Bool;
-        (*b_fwd).boolvar = address;
-    }
-    let sym = unsafe {
-        intern_c_string_1(namestring, libc::strlen(namestring) as libc::ptrdiff_t)
-            .as_symbol_or_error()
-    };
+    (*b_fwd).ty = Lisp_Fwd_Bool;
+    (*b_fwd).boolvar = address;
+    let sym = intern_c_string_1(namestring, libc::strlen(namestring) as libc::ptrdiff_t)
+        .as_symbol_or_error();
     sym.set_declared_special(true);
     sym.set_redirect(symbol_redirect::SYMBOL_FORWARDED);
     sym.set_fwd(b_fwd as *mut Lisp_Fwd);
@@ -60,66 +52,61 @@ pub extern "C" fn defvar_bool(
 /// gc-marked for some other reason, since marking the same slot twice
 /// can cause trouble with strings.
 #[no_mangle]
-pub extern "C" fn defvar_lisp_nopro(
+pub unsafe extern "C" fn defvar_lisp_nopro(
     o_fwd: *mut Lisp_Objfwd,
     namestring: *const libc::c_schar,
     address: *mut LispObject,
 ) {
-    unsafe {
-        (*o_fwd).ty = Lisp_Fwd_Obj;
-        (*o_fwd).objvar = address;
-    }
-    let sym = unsafe {
-        intern_c_string_1(namestring, libc::strlen(namestring) as libc::ptrdiff_t)
-            .as_symbol_or_error()
-    };
+    (*o_fwd).ty = Lisp_Fwd_Obj;
+    (*o_fwd).objvar = address;
+    let sym = intern_c_string_1(namestring, libc::strlen(namestring) as libc::ptrdiff_t)
+        .as_symbol_or_error();
     sym.set_declared_special(true);
     sym.set_redirect(symbol_redirect::SYMBOL_FORWARDED);
     sym.set_fwd(o_fwd as *mut Lisp_Fwd);
 }
 
 #[no_mangle]
-pub extern "C" fn defvar_lisp(
+pub unsafe extern "C" fn defvar_lisp(
     o_fwd: *mut Lisp_Objfwd,
     namestring: *const libc::c_schar,
     address: *mut LispObject,
 ) {
     defvar_lisp_nopro(o_fwd, namestring, address);
-    unsafe { staticpro(address) };
+    staticpro(address);
 }
 
 /// Similar but define a variable whose value is the Lisp Object stored
 /// at a particular offset in the current kboard object.
 #[no_mangle]
-pub extern "C" fn defvar_kboard(
+pub unsafe extern "C" fn defvar_kboard(
     ko_fwd: *mut Lisp_Kboard_Objfwd,
     namestring: *const libc::c_schar,
     offset: i32,
 ) {
-    defvar_kboard_offset(ko_fwd, namestring, unsafe {
-        FieldOffset::<remacs_sys::kboard, LispObject>::new_from_offset(offset as usize)
-    })
+    defvar_kboard_offset(
+        ko_fwd,
+        namestring,
+        FieldOffset::<remacs_sys::kboard, LispObject>::new_from_offset(offset as usize),
+    )
 }
 
-pub fn defvar_kboard_offset(
+pub unsafe fn defvar_kboard_offset(
     ko_fwd: *mut Lisp_Kboard_Objfwd,
     namestring: *const libc::c_schar,
     offset: FieldOffset<remacs_sys::kboard, LispObject>,
 ) {
-    unsafe {
-        (*ko_fwd).ty = Lisp_Fwd_Kboard_Obj;
-        (*ko_fwd).offset = offset;
-    }
-    let sym = intern_c_string_1(namestring, unsafe {
-        libc::strlen(namestring) as libc::ptrdiff_t
-    }).as_symbol_or_error();
+    (*ko_fwd).ty = Lisp_Fwd_Kboard_Obj;
+    (*ko_fwd).offset = offset;
+    let sym = intern_c_string_1(namestring, libc::strlen(namestring) as libc::ptrdiff_t)
+        .as_symbol_or_error();
     sym.set_declared_special(true);
     sym.set_redirect(symbol_redirect::SYMBOL_FORWARDED);
     sym.set_fwd(ko_fwd as *mut Lisp_Fwd);
 }
 
 #[no_mangle]
-pub extern "C" fn defvar_per_buffer(
+pub unsafe extern "C" fn defvar_per_buffer(
     bo_fwd: *mut Lisp_Buffer_Objfwd,
     namestring: *const libc::c_schar,
     offset: FieldOffset<remacs_sys::Lisp_Buffer, LispObject>,
@@ -128,30 +115,26 @@ pub extern "C" fn defvar_per_buffer(
     defvar_per_buffer_offset(bo_fwd, namestring, offset, predicate);
 }
 
-pub fn defvar_per_buffer_offset(
+pub unsafe fn defvar_per_buffer_offset(
     bo_fwd: *mut Lisp_Buffer_Objfwd,
     namestring: *const libc::c_schar,
     offset: FieldOffset<remacs_sys::Lisp_Buffer, LispObject>,
     predicate: LispObject,
 ) {
-    unsafe {
-        (*bo_fwd).ty = Lisp_Fwd_Buffer_Obj;
-        (*bo_fwd).offset = offset;
-        (*bo_fwd).predicate = predicate;
-    }
-    let sym = unsafe {
-        intern_c_string_1(namestring, libc::strlen(namestring) as libc::ptrdiff_t)
-            .as_symbol_or_error()
-    };
+    (*bo_fwd).ty = Lisp_Fwd_Buffer_Obj;
+    (*bo_fwd).offset = offset;
+    (*bo_fwd).predicate = predicate;
+    let sym = intern_c_string_1(namestring, libc::strlen(namestring) as libc::ptrdiff_t)
+        .as_symbol_or_error();
     sym.set_declared_special(true);
     sym.set_redirect(symbol_redirect::SYMBOL_FORWARDED);
     sym.set_fwd(bo_fwd as *mut Lisp_Fwd);
-    let local = offset.apply_mut(unsafe { &mut remacs_sys::buffer_local_symbols });
+    let local = offset.apply_mut(&mut remacs_sys::buffer_local_symbols);
     *local = sym.as_lisp_obj();
-    let flags = offset.apply(unsafe { &remacs_sys::buffer_local_flags });
+    let flags = offset.apply(&remacs_sys::buffer_local_flags);
     if flags.is_nil() {
         /* Did a DEFVAR_PER_BUFFER without initializing the corresponding
            slot of buffer_local_flags.  */
-        unsafe { remacs_sys::emacs_abort() };
+        remacs_sys::emacs_abort();
     }
 }

--- a/rust_src/src/marker.rs
+++ b/rust_src/src/marker.rs
@@ -631,7 +631,7 @@ pub extern "C" fn buf_charpos_to_bytepos(b: *mut Lisp_Buffer, charpos: isize) ->
         }
     }
 
-    if charpos - best_below < best_above - charpos {
+    let result = if charpos - best_below < best_above - charpos {
         let record = charpos - best_below > 5000;
 
         while best_below != charpos {
@@ -651,7 +651,7 @@ pub extern "C" fn buf_charpos_to_bytepos(b: *mut Lisp_Buffer, charpos: isize) ->
         buffer_ref.cached_charpos = best_below;
         buffer_ref.cached_bytepos = best_below_byte;
 
-        return best_below_byte;
+        best_below_byte
     } else {
         let record = best_above - charpos > 5000;
 
@@ -673,8 +673,10 @@ pub extern "C" fn buf_charpos_to_bytepos(b: *mut Lisp_Buffer, charpos: isize) ->
         buffer_ref.cached_charpos = best_above;
         buffer_ref.cached_bytepos = best_above_byte;
 
-        return best_above_byte;
-    }
+        best_above_byte
+    };
+
+    result
 }
 
 #[no_mangle]
@@ -746,7 +748,7 @@ pub extern "C" fn buf_bytepos_to_charpos(b: *mut Lisp_Buffer, bytepos: isize) ->
     // We have one known above and one known below.
     // Scan, counting characters, from whichever one is closer.
 
-    if bytepos - best_below_byte < best_above_byte - bytepos {
+    let result = if bytepos - best_below_byte < best_above_byte - bytepos {
         let record = bytepos - best_below_byte > 5000;
 
         while best_below_byte < bytepos {
@@ -772,7 +774,7 @@ pub extern "C" fn buf_bytepos_to_charpos(b: *mut Lisp_Buffer, bytepos: isize) ->
         buffer_ref.cached_charpos = best_below;
         buffer_ref.cached_bytepos = best_below_byte;
 
-        return best_below;
+        best_below
     } else {
         let record = best_above_byte - bytepos > 5000;
 
@@ -799,8 +801,10 @@ pub extern "C" fn buf_bytepos_to_charpos(b: *mut Lisp_Buffer, bytepos: isize) ->
         buffer_ref.cached_charpos = best_above;
         buffer_ref.cached_bytepos = best_above_byte;
 
-        return best_above;
-    }
+        best_above
+    };
+
+    result
 }
 
 #[no_mangle]

--- a/rust_src/src/marker.rs
+++ b/rust_src/src/marker.rs
@@ -631,7 +631,7 @@ pub extern "C" fn buf_charpos_to_bytepos(b: *mut Lisp_Buffer, charpos: isize) ->
         }
     }
 
-    let result = if charpos - best_below < best_above - charpos {
+    if charpos - best_below < best_above - charpos {
         let record = charpos - best_below > 5000;
 
         while best_below != charpos {
@@ -674,9 +674,7 @@ pub extern "C" fn buf_charpos_to_bytepos(b: *mut Lisp_Buffer, charpos: isize) ->
         buffer_ref.cached_bytepos = best_above_byte;
 
         best_above_byte
-    };
-
-    result
+    }
 }
 
 #[no_mangle]
@@ -748,7 +746,7 @@ pub extern "C" fn buf_bytepos_to_charpos(b: *mut Lisp_Buffer, bytepos: isize) ->
     // We have one known above and one known below.
     // Scan, counting characters, from whichever one is closer.
 
-    let result = if bytepos - best_below_byte < best_above_byte - bytepos {
+    if bytepos - best_below_byte < best_above_byte - bytepos {
         let record = bytepos - best_below_byte > 5000;
 
         while best_below_byte < bytepos {
@@ -802,9 +800,7 @@ pub extern "C" fn buf_bytepos_to_charpos(b: *mut Lisp_Buffer, bytepos: isize) ->
         buffer_ref.cached_bytepos = best_above_byte;
 
         best_above
-    };
-
-    result
+    }
 }
 
 #[no_mangle]

--- a/rust_src/src/marker.rs
+++ b/rust_src/src/marker.rs
@@ -254,8 +254,11 @@ pub fn copy_marker(marker: LispObject, itype: LispObject) -> LispObject {
         .map_or(Qnil, |b| b.as_lisp_obj());
 
     set_marker(new, marker, buffer_or_nil);
-    new.as_marker()
-        .map(|mut m| m.set_insertion_type(itype.is_not_nil()));
+
+    if let Some(mut m) = new.as_marker() {
+        m.set_insertion_type(itype.is_not_nil())
+    }
+
     new
 }
 

--- a/rust_src/src/minibuf.rs
+++ b/rust_src/src/minibuf.rs
@@ -186,15 +186,11 @@ pub fn read_from_minibuffer(
         get_keymap(keymap, true, false)
     };
 
-    let mut histvar: LispObject;
-    let mut histpos: LispObject;
-    if hist.is_symbol() {
-        histvar = hist;
-        histpos = Qnil;
+    let (mut histvar, mut histpos) = if hist.is_symbol() {
+        (hist, Qnil)
     } else {
-        histvar = car_safe(hist);
-        histpos = cdr_safe(hist);
-    }
+        (car_safe(hist), cdr_safe(hist))
+    };
 
     if histvar.is_nil() {
         histvar = Qminibuffer_history

--- a/rust_src/src/multibyte.rs
+++ b/rust_src/src/multibyte.rs
@@ -746,7 +746,7 @@ pub fn char_byte8_p(c: Codepoint) -> bool {
 
 pub fn char_to_byte8(c: Codepoint) -> u8 {
     if char_byte8_p(c) {
-        (c - 0x3FFF00) as u8
+        (c - 0x003F_FF00) as u8
     } else {
         (c & 0xFF) as u8
     }

--- a/rust_src/src/multibyte.rs
+++ b/rust_src/src/multibyte.rs
@@ -93,11 +93,11 @@ impl LispStringRef {
         self.data as *mut c_char
     }
 
-    pub fn const_data_ptr(&self) -> *const c_uchar {
+    pub fn const_data_ptr(self) -> *const c_uchar {
         self.data as *const c_uchar
     }
 
-    pub fn const_sdata_ptr(&self) -> *const c_char {
+    pub fn const_sdata_ptr(self) -> *const c_char {
         self.data as *const c_char
     }
 

--- a/rust_src/src/multibyte.rs
+++ b/rust_src/src/multibyte.rs
@@ -243,8 +243,8 @@ fn string_overflow() -> ! {
 /// bytes it may occupy when converted to multibyte string by
 /// `str_to_multibyte`.
 #[no_mangle]
-pub extern "C" fn count_size_as_multibyte(ptr: *const c_uchar, len: ptrdiff_t) -> ptrdiff_t {
-    let slice = unsafe { slice::from_raw_parts(ptr, len as usize) };
+pub unsafe extern "C" fn count_size_as_multibyte(ptr: *const c_uchar, len: ptrdiff_t) -> ptrdiff_t {
+    let slice = slice::from_raw_parts(ptr, len as usize);
     slice.iter().fold(0, |total, &byte| {
         let n = if is_ascii(Codepoint::from(byte)) {
             1
@@ -381,15 +381,12 @@ pub extern "C" fn char_resolve_modifier_mask(ch: EmacsInt) -> EmacsInt {
 /// Store multibyte form of character CP at TO.  If CP has modifier bits,
 /// handle them appropriately.
 #[no_mangle]
-pub extern "C" fn char_string(mut cp: c_uint, to: *mut c_uchar) -> c_int {
+pub unsafe extern "C" fn char_string(mut cp: c_uint, to: *mut c_uchar) -> c_int {
     if cp & char_bits::CHAR_MODIFIER_MASK != 0 {
         cp = char_resolve_modifier_mask(EmacsInt::from(cp)) as Codepoint;
         cp &= !char_bits::CHAR_MODIFIER_MASK;
     }
-    write_codepoint(
-        unsafe { slice::from_raw_parts_mut(to, MAX_MULTIBYTE_LENGTH) },
-        cp,
-    ) as c_int
+    write_codepoint(slice::from_raw_parts_mut(to, MAX_MULTIBYTE_LENGTH), cp) as c_int
 }
 
 /// Convert unibyte text at STR of BYTES bytes to a multibyte text
@@ -398,13 +395,13 @@ pub extern "C" fn char_string(mut cp: c_uint, to: *mut c_uchar) -> c_int {
 /// that we can use LEN bytes at STR as a work area and that is
 /// enough.  Returns the byte length of the multibyte string.
 #[no_mangle]
-pub extern "C" fn str_to_multibyte(
+pub unsafe extern "C" fn str_to_multibyte(
     ptr: *mut c_uchar,
     len: ptrdiff_t,
     bytes: ptrdiff_t,
 ) -> ptrdiff_t {
     // slice covers the whole work area to be able to write back
-    let slice = unsafe { slice::from_raw_parts_mut(ptr, len as usize) };
+    let slice = slice::from_raw_parts_mut(ptr, len as usize);
     // first, search ASCII-only prefix that we can skip processing
     let mut start = 0;
     for (idx, &byte) in slice.iter().enumerate() {
@@ -421,13 +418,11 @@ pub extern "C" fn str_to_multibyte(
     // large enough, so we can read from there while writing the output
     let offset = (len - bytes) as usize;
     let slice = &mut slice[start..];
-    unsafe {
-        ptr::copy(
-            slice.as_mut_ptr(),
-            slice[offset..].as_mut_ptr(),
-            bytes as usize - start,
-        );
-    }
+    ptr::copy(
+        slice.as_mut_ptr(),
+        slice[offset..].as_mut_ptr(),
+        bytes as usize - start,
+    );
     let mut to = 0;
     for from in offset..slice.len() {
         let byte = slice[from];
@@ -527,14 +522,17 @@ pub fn multibyte_length_by_head(byte: c_uchar) -> usize {
 /// sequences while assuming that there's no invalid sequence.  It
 /// ignores enable-multibyte-characters.
 #[no_mangle]
-pub extern "C" fn multibyte_chars_in_text(ptr: *const c_uchar, nbytes: ptrdiff_t) -> ptrdiff_t {
-    let slice = unsafe { slice::from_raw_parts(ptr, nbytes as usize) };
+pub unsafe extern "C" fn multibyte_chars_in_text(
+    ptr: *const c_uchar,
+    nbytes: ptrdiff_t,
+) -> ptrdiff_t {
+    let slice = slice::from_raw_parts(ptr, nbytes as usize);
     let len = slice.len();
     let mut idx = 0;
     let mut chars = 0;
     // TODO: make this an iterator?
     while idx < len {
-        idx += multibyte_length(&slice[idx..], true).unwrap_or_else(|| unsafe { emacs_abort() });
+        idx += multibyte_length(&slice[idx..], true).unwrap_or_else(|| emacs_abort());
         chars += 1;
     }
     chars as ptrdiff_t
@@ -546,13 +544,13 @@ pub extern "C" fn multibyte_chars_in_text(ptr: *const c_uchar, nbytes: ptrdiff_t
 /// characters not constructing a valid multibyte sequence are
 /// represented by 2-byte in a multibyte text.
 #[no_mangle]
-pub extern "C" fn parse_str_as_multibyte(
+pub unsafe extern "C" fn parse_str_as_multibyte(
     ptr: *const c_uchar,
     len: ptrdiff_t,
     nchars: *mut ptrdiff_t,
     nbytes: *mut ptrdiff_t,
 ) {
-    let slice = unsafe { slice::from_raw_parts(ptr, len as usize) };
+    let slice = slice::from_raw_parts(ptr, len as usize);
     let len = slice.len();
     let mut chars = 0;
     let mut bytes = 0;
@@ -576,10 +574,8 @@ pub extern "C" fn parse_str_as_multibyte(
             }
         }
     }
-    unsafe {
-        *nchars = chars;
-        *nbytes = bytes;
-    }
+    *nchars = chars;
+    *nbytes = bytes;
 }
 
 /// Arrange unibyte text at STR of NBYTES bytes as a multibyte text.
@@ -590,14 +586,14 @@ pub extern "C" fn parse_str_as_multibyte(
 /// area and that is enough.  Return the number of bytes of the
 /// resulting text.
 #[no_mangle]
-pub extern "C" fn str_as_multibyte(
+pub unsafe extern "C" fn str_as_multibyte(
     ptr: *mut c_uchar,
     len: ptrdiff_t,
     mut nbytes: ptrdiff_t,
     nchars: *mut ptrdiff_t,
 ) -> ptrdiff_t {
     // slice covers the whole work area to be able to write back
-    let slice = unsafe { slice::from_raw_parts_mut(ptr, len as usize) };
+    let slice = slice::from_raw_parts_mut(ptr, len as usize);
     // first, search ASCII-only prefix that we can skip processing
     let mut start = None;
     let mut chars = 0;
@@ -619,13 +615,11 @@ pub extern "C" fn str_as_multibyte(
         // large enough, so we can read from there while writing the output
         let offset = (len - nbytes) as usize;
         let slice = &mut slice[start..];
-        unsafe {
-            ptr::copy(
-                slice.as_mut_ptr(),
-                slice[offset..].as_mut_ptr(),
-                nbytes as usize - start,
-            );
-        }
+        ptr::copy(
+            slice.as_mut_ptr(),
+            slice[offset..].as_mut_ptr(),
+            nbytes as usize - start,
+        );
         let mut to = 0;
         let mut from = offset;
         while from < slice.len() {
@@ -646,9 +640,7 @@ pub extern "C" fn str_as_multibyte(
         nbytes = (start + to) as ptrdiff_t;
     }
     if !nchars.is_null() {
-        unsafe {
-            *nchars = chars;
-        }
+        *nchars = chars;
     }
     nbytes
 }
@@ -656,8 +648,8 @@ pub extern "C" fn str_as_multibyte(
 /// Arrange multibyte text at STR of LEN bytes as a unibyte text.  It
 /// actually converts characters in the range 0x80..0xFF to unibyte.
 #[no_mangle]
-pub extern "C" fn str_as_unibyte(ptr: *mut c_uchar, bytes: ptrdiff_t) -> ptrdiff_t {
-    let slice = unsafe { slice::from_raw_parts_mut(ptr, bytes as usize) };
+pub unsafe extern "C" fn str_as_unibyte(ptr: *mut c_uchar, bytes: ptrdiff_t) -> ptrdiff_t {
+    let slice = slice::from_raw_parts_mut(ptr, bytes as usize);
     let mut from = 0;
     while from < bytes as usize {
         let byte = slice[from];
@@ -693,22 +685,18 @@ pub extern "C" fn str_as_unibyte(ptr: *mut c_uchar, bytes: ptrdiff_t) -> ptrdiff
 /// the ending address (i.e., the starting address of the next
 /// character) of the multibyte form.
 #[no_mangle]
-pub extern "C" fn string_char(
+pub unsafe extern "C" fn string_char(
     ptr: *const c_uchar,
     advanced: *mut *const c_uchar,
     len: *mut c_int,
 ) -> c_int {
-    let slice = unsafe { slice::from_raw_parts(ptr, MAX_MULTIBYTE_LENGTH) };
+    let slice = slice::from_raw_parts(ptr, MAX_MULTIBYTE_LENGTH);
     let (cp, cplen) = multibyte_char_at(slice);
     if !len.is_null() {
-        unsafe {
-            *len = cplen as c_int;
-        }
+        *len = cplen as c_int;
     }
     if !advanced.is_null() {
-        unsafe {
-            *advanced = ptr.offset(cplen as isize);
-        }
+        *advanced = ptr.offset(cplen as isize);
     }
     cp as c_int
 }
@@ -719,13 +707,13 @@ pub extern "C" fn string_char(
 /// Usually, the value is the same as CHARS, but is less than it if SRC
 /// contains a non-ASCII, non-eight-bit character.
 #[no_mangle]
-pub extern "C" fn str_to_unibyte(
+pub unsafe extern "C" fn str_to_unibyte(
     src: *const c_uchar,
     dst: *mut c_uchar,
     chars: ptrdiff_t,
 ) -> ptrdiff_t {
-    let mut srcslice = unsafe { slice::from_raw_parts(src, chars as usize) };
-    let dstslice = unsafe { slice::from_raw_parts_mut(dst, chars as usize) };
+    let mut srcslice = slice::from_raw_parts(src, chars as usize);
+    let dstslice = slice::from_raw_parts_mut(dst, chars as usize);
     for i in 0..chars {
         let (cp, cplen) = multibyte_char_at(srcslice);
         srcslice = &srcslice[cplen..];

--- a/rust_src/src/process.rs
+++ b/rust_src/src/process.rs
@@ -306,7 +306,7 @@ fn pset_filter(mut process: LispProcessRef, val: LispObject) -> LispObject {
 }
 
 fn set_process_filter_masks(process: LispProcessRef) -> () {
-    if !(process.infd == -1) && process.filter.eq(Qt) {
+    if process.infd != -1 && process.filter.eq(Qt) {
         if process.status.ne(Qlisten) {
             unsafe { delete_read_fd(process.infd) };
         // Network or serial process not stopped:

--- a/rust_src/src/remacs_sys.rs
+++ b/rust_src/src/remacs_sys.rs
@@ -35,7 +35,7 @@ include!(concat!(env!("OUT_DIR"), "/globals.rs"));
 pub const VAL_MAX: EmacsInt = (EMACS_INT_MAX >> (GCTYPEBITS - 1));
 pub const VALMASK: EmacsInt = [VAL_MAX, -(1 << GCTYPEBITS)][USE_LSB_TAG as usize];
 pub const INTMASK: EmacsInt = (EMACS_INT_MAX >> (Lisp_Bits::INTTYPEBITS - 1));
-pub const PSEUDOVECTOR_FLAG: usize = 0x4000000000000000;
+pub const PSEUDOVECTOR_FLAG: usize = 0x4000_0000_0000_0000;
 
 // These signal an error, therefore are marked as non-returning.
 extern "C" {

--- a/rust_src/src/str2sig.rs
+++ b/rust_src/src/str2sig.rs
@@ -45,7 +45,7 @@ const numname: [(&str, c_int); 30] = [
 ];
 
 #[cfg(target_os = "macos")]
-const numname: [(&'static str, c_int); 27] = [
+const numname: [(&str, c_int); 27] = [
     ("HUP", libc::SIGHUP),
     ("INT", libc::SIGINT),
     ("QUIT", libc::SIGQUIT),

--- a/rust_src/src/strings.rs
+++ b/rust_src/src/strings.rs
@@ -63,12 +63,14 @@ pub fn string_as_multibyte(string: LispStringRef) -> LispObject {
 
     let mut nchars = 0;
     let mut nbytes = 0;
-    multibyte::parse_str_as_multibyte(
-        string.const_data_ptr(),
-        string.len_bytes(),
-        &mut nchars,
-        &mut nbytes,
-    );
+    unsafe {
+        multibyte::parse_str_as_multibyte(
+            string.const_data_ptr(),
+            string.len_bytes(),
+            &mut nchars,
+            &mut nbytes,
+        )
+    };
 
     let new_string =
         unsafe { make_uninit_multibyte_string(nchars as EmacsInt, nbytes as EmacsInt) };
@@ -81,12 +83,14 @@ pub fn string_as_multibyte(string: LispStringRef) -> LispObject {
         );
     }
     if nbytes != string.len_bytes() {
-        multibyte::str_as_multibyte(
-            new_s.data_ptr(),
-            nbytes,
-            string.len_bytes(),
-            ptr::null_mut(),
-        );
+        unsafe {
+            multibyte::str_as_multibyte(
+                new_s.data_ptr(),
+                nbytes,
+                string.len_bytes(),
+                ptr::null_mut(),
+            )
+        };
     }
     new_string
 }
@@ -117,8 +121,9 @@ pub fn string_to_unibyte(string: LispStringRef) -> LispObject {
     if string.is_multibyte() {
         let size = string.len_bytes();
         let mut buffer: Vec<libc::c_uchar> = Vec::with_capacity(size as usize);
-        let converted_size =
-            multibyte::str_to_unibyte(string.const_data_ptr(), buffer.as_mut_ptr(), size);
+        let converted_size = unsafe {
+            multibyte::str_to_unibyte(string.const_data_ptr(), buffer.as_mut_ptr(), size)
+        };
 
         if converted_size < size {
             error!("Can't convert {}th character to unibyte", converted_size);

--- a/rust_src/src/vectors.rs
+++ b/rust_src/src/vectors.rs
@@ -181,7 +181,7 @@ macro_rules! impl_vectorlike_ref {
     ($type:ident, $itertype:ident, $size_mask:expr) => {
         impl $type {
             #[inline]
-            pub fn len(&self) -> usize {
+            pub fn len(self) -> usize {
                 (self.header.size & ($size_mask as isize)) as usize
             }
 
@@ -192,7 +192,7 @@ macro_rules! impl_vectorlike_ref {
             #[inline]
             pub fn as_slice(&self) -> &[LispObject] {
                 let l = self.len();
-                unsafe { &self.contents.as_slice(l) }
+                unsafe { self.contents.as_slice(l) }
             }
 
             #[inline]
@@ -202,13 +202,13 @@ macro_rules! impl_vectorlike_ref {
             }
 
             #[inline]
-            pub fn get(&self, idx: usize) -> LispObject {
+            pub fn get(self, idx: usize) -> LispObject {
                 assert!(idx < self.len());
                 unsafe { self.get_unchecked(idx) }
             }
 
             #[inline]
-            pub unsafe fn get_unchecked(&self, idx: usize) -> LispObject {
+            pub unsafe fn get_unchecked(self, idx: usize) -> LispObject {
                 self.as_slice()[idx]
             }
 
@@ -302,23 +302,23 @@ impl LispBoolVecRef {
     }
 
     #[inline]
-    pub fn len(&self) -> usize {
+    pub fn len(self) -> usize {
         self.size as usize
     }
 
     #[inline]
-    unsafe fn get_bit(&self, idx: usize) -> bool {
+    unsafe fn get_bit(self, idx: usize) -> bool {
         let limb = self.as_slice()[idx / BITS_PER_BITS_WORD as usize];
         limb & (1 << (idx % BITS_PER_BITS_WORD as usize)) != 0
     }
 
     #[inline]
-    pub fn get(&self, idx: usize) -> LispObject {
+    pub fn get(self, idx: usize) -> LispObject {
         assert!(idx < self.len());
         unsafe { self.get_unchecked(idx) }
     }
 
-    pub unsafe fn get_unchecked(&self, idx: usize) -> LispObject {
+    pub unsafe fn get_unchecked(self, idx: usize) -> LispObject {
         LispObject::from_bool(self.get_bit(idx))
     }
 

--- a/rust_src/src/vectors.rs
+++ b/rust_src/src/vectors.rs
@@ -36,17 +36,17 @@ impl LispVectorlikeRef {
     }
 
     #[inline]
-    pub fn as_vector(&self) -> Option<LispVectorRef> {
+    pub fn as_vector(self) -> Option<LispVectorRef> {
         if self.is_vector() {
-            Some(unsafe { mem::transmute::<_, LispVectorRef>(*self) })
+            Some(unsafe { mem::transmute::<_, LispVectorRef>(self) })
         } else {
             None
         }
     }
 
     #[inline]
-    pub unsafe fn as_vector_unchecked(&self) -> LispVectorRef {
-        mem::transmute::<_, LispVectorRef>(*self)
+    pub unsafe fn as_vector_unchecked(self) -> LispVectorRef {
+        mem::transmute::<_, LispVectorRef>(self)
     }
 
     #[inline]
@@ -72,105 +72,105 @@ impl LispVectorlikeRef {
     }
 
     #[inline]
-    pub fn as_bool_vector(&self) -> Option<LispBoolVecRef> {
+    pub fn as_bool_vector(self) -> Option<LispBoolVecRef> {
         if self.is_pseudovector(pvec_type::PVEC_BOOL_VECTOR) {
-            Some(unsafe { mem::transmute::<_, LispBoolVecRef>(*self) })
+            Some(unsafe { mem::transmute::<_, LispBoolVecRef>(self) })
         } else {
             None
         }
     }
 
     #[inline]
-    pub fn as_buffer(&self) -> Option<LispBufferRef> {
+    pub fn as_buffer(self) -> Option<LispBufferRef> {
         if self.is_pseudovector(pvec_type::PVEC_BUFFER) {
-            Some(unsafe { mem::transmute(*self) })
+            Some(unsafe { mem::transmute(self) })
         } else {
             None
         }
     }
 
     #[inline]
-    pub fn as_subr(&self) -> Option<LispSubrRef> {
+    pub fn as_subr(self) -> Option<LispSubrRef> {
         if self.is_pseudovector(pvec_type::PVEC_SUBR) {
-            Some(unsafe { mem::transmute(*self) })
+            Some(unsafe { mem::transmute(self) })
         } else {
             None
         }
     }
 
     #[inline]
-    pub fn as_window(&self) -> Option<LispWindowRef> {
+    pub fn as_window(self) -> Option<LispWindowRef> {
         if self.is_pseudovector(pvec_type::PVEC_WINDOW) {
-            Some(unsafe { mem::transmute(*self) })
+            Some(unsafe { mem::transmute(self) })
         } else {
             None
         }
     }
 
     #[inline]
-    pub fn as_frame(&self) -> Option<LispFrameRef> {
+    pub fn as_frame(self) -> Option<LispFrameRef> {
         if self.is_pseudovector(pvec_type::PVEC_FRAME) {
-            Some(unsafe { mem::transmute(*self) })
+            Some(unsafe { mem::transmute(self) })
         } else {
             None
         }
     }
 
     #[inline]
-    pub fn as_process(&self) -> Option<LispProcessRef> {
+    pub fn as_process(self) -> Option<LispProcessRef> {
         if self.is_pseudovector(pvec_type::PVEC_PROCESS) {
-            Some(unsafe { mem::transmute(*self) })
+            Some(unsafe { mem::transmute(self) })
         } else {
             None
         }
     }
 
     #[inline]
-    pub fn as_thread(&self) -> Option<ThreadStateRef> {
+    pub fn as_thread(self) -> Option<ThreadStateRef> {
         if self.is_pseudovector(pvec_type::PVEC_THREAD) {
-            Some(unsafe { mem::transmute(*self) })
+            Some(unsafe { mem::transmute(self) })
         } else {
             None
         }
     }
 
     #[inline]
-    pub fn as_char_table(&self) -> Option<LispCharTableRef> {
+    pub fn as_char_table(self) -> Option<LispCharTableRef> {
         if self.is_pseudovector(pvec_type::PVEC_CHAR_TABLE) {
-            Some(unsafe { mem::transmute(*self) })
+            Some(unsafe { mem::transmute(self) })
         } else {
             None
         }
     }
 
-    pub fn as_sub_char_table(&self) -> Option<LispSubCharTableRef> {
+    pub fn as_sub_char_table(self) -> Option<LispSubCharTableRef> {
         if self.is_pseudovector(pvec_type::PVEC_SUB_CHAR_TABLE) {
-            Some(unsafe { mem::transmute(*self) })
+            Some(unsafe { mem::transmute(self) })
         } else {
             None
         }
     }
 
-    pub fn as_sub_char_table_ascii(&self) -> Option<LispSubCharTableAsciiRef> {
+    pub fn as_sub_char_table_ascii(self) -> Option<LispSubCharTableAsciiRef> {
         if self.is_pseudovector(pvec_type::PVEC_SUB_CHAR_TABLE) {
-            Some(unsafe { mem::transmute(*self) })
+            Some(unsafe { mem::transmute(self) })
         } else {
             None
         }
     }
 
     #[inline]
-    pub fn as_compiled(&self) -> Option<LispVectorlikeSlotsRef> {
+    pub fn as_compiled(self) -> Option<LispVectorlikeSlotsRef> {
         if self.is_pseudovector(pvec_type::PVEC_COMPILED) {
-            Some(unsafe { mem::transmute(*self) })
+            Some(unsafe { mem::transmute(self) })
         } else {
             None
         }
     }
 
-    pub fn as_record(&self) -> Option<LispVectorlikeSlotsRef> {
+    pub fn as_record(self) -> Option<LispVectorlikeSlotsRef> {
         if self.is_pseudovector(pvec_type::PVEC_RECORD) {
-            Some(unsafe { mem::transmute(*self) })
+            Some(unsafe { mem::transmute(self) })
         } else {
             None
         }

--- a/rust_src/src/windows.rs
+++ b/rust_src/src/windows.rs
@@ -600,9 +600,7 @@ pub extern "C" fn CURRENT_MODE_LINE_FACE_ID_3(
     };
 
     unsafe {
-        if !globals.mode_line_in_non_selected_windows {
-            return face_id::MODE_LINE_FACE_ID;
-        } else if selw == current {
+        if !globals.mode_line_in_non_selected_windows || selw == current {
             return face_id::MODE_LINE_FACE_ID;
         } else if minibuf_level > 0 {
             if let Some(minibuf_window) = current_minibuf_window.as_window() {


### PR DESCRIPTION
Based on https://github.com/Wilfred/remacs/pull/913

As is evident, I take a pretty granular approach when it comes to commits for this kind of thing.

After this, there are just a few big classes of Clippy errors/warnings remaining. One of them has to do marking any function that dereferences a raw pointer as `unsafe`. Another one has to with changing `self` arguments to `&self`, or maybe the other way around. Those seem like bigger changes that should be discussed first, so I didn't do them.