### PR TITLE
Also .rustified_enum some more recently introduced enums from gnutls

### DIFF
--- a/rust_src/build.rs
+++ b/rust_src/build.rs
@@ -1081,9 +1081,12 @@ fn run_bindgen() {
                 .rustified_enum("gnutls_compression_method_t")
                 .rustified_enum("gnutls_connection_end_t")
                 .rustified_enum("gnutls_credentials_type_t")
+                .rustified_enum("gnutls_ctype_target_t")
                 .rustified_enum("gnutls_digest_algorithm_t")
                 .rustified_enum("gnutls_ecc_curve_t")
                 .rustified_enum("gnutls_ext_parse_type_t")
+                .rustified_enum("gnutls_fips_mode_t")
+                .rustified_enum("gnutls_gost_paramset_t")
                 .rustified_enum("gnutls_group_t")
                 .rustified_enum("gnutls_handshake_description_t")
                 .rustified_enum("gnutls_initstage_t")
@@ -1210,7 +1213,7 @@ fn run_bindgen() {
                 .generate()
                 .expect("Unable to generate bindings");
 
-            // https://github.com/servo/rust-bindgen/issues/839
+            // https://github.com/rust-lang-nursery/rust-bindgen/issues/839
             let source = bindings.to_string();
             let re = regex::Regex::new(
                 r"pub use self\s*::\s*gnutls_cipher_algorithm_t as gnutls_cipher_algorithm\s*;",


### PR DESCRIPTION
Hello! I'm a long time emacs user, familiar with C (though not yet expert at rust or emacs internals), and thought remacs was a very interesting idea, and thought perhaps I'd try to take a crack at porting some builtins.

While attempting to get it to build on my machine, I found I needed to add these `.rustified_enum` calls. Without them, the
```rust
                .default_enum_style(bindgen::EnumVariation::ModuleConsts)
```
in `build.rs` causes module wrappers for `gnutls_ctype_target_t` and `gnutls_fips_mode_t` and `gnutls_gost_paramset_t` to be created, e.g. the `bindgen`-generated `bindings.rs` contains
```rust
pub mod gnutls_ctype_target_t {
    pub type Type = u32;
    pub const GNUTLS_CTYPE_CLIENT: Type = 0;
    pub const GNUTLS_CTYPE_SERVER: Type = 1;
    pub const GNUTLS_CTYPE_OURS: Type = 2;
    pub const GNUTLS_CTYPE_PEERS: Type = 3;
}
```
and, strangely, references to these enum types later in `bindings.rs` erroneously refer to simply (for example) `gnutls_ctype_target_t` as opposed to `gnutls_ctype_target_t::Type`. I don't know whether this is a bug in `bindgen` or an unintended consequence of how it's configured and called from `build.rs`. For example,
```rust
extern "C" {
    pub fn gnutls_certificate_type_get2(
        session: gnutls_session_t,
        target: gnutls_ctype_target_t, // <- this should be gnutls_ctype_target_t::Type
    ) -> gnutls_certificate_type_t;
}
```
minus the comment I added, occurs in `bindings.rs`, and produces 

    error[E0573]: expected type, found module 'gnutls_ctype_target_t'