### PR TITLE
Delete toolkit scroll bar option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -348,7 +348,6 @@ OPTION_DEFAULT_ON([xft],[don't use XFT for anti aliased fonts])
 OPTION_DEFAULT_ON([libotf],[don't use libotf for OpenType font support])
 OPTION_DEFAULT_ON([m17n-flt],[don't use m17n-flt for text shaping])
 
-OPTION_DEFAULT_ON([toolkit-scroll-bars],[don't use Xaw3d scroll bars])
 OPTION_DEFAULT_ON([xim],[don't use X11 XIM])
 AC_ARG_WITH([ns],[AS_HELP_STRING([--with-ns],
 [use Nextstep (macOS Cocoa or GNUstep) windowing system.
@@ -1943,10 +1942,6 @@ ns_self_contained=no
 NS_OBJ=
 NS_OBJC_OBJ=
 if test "${HAVE_NS}" = yes; then
-  if test "$with_toolkit_scroll_bars" = "no"; then
-    AC_MSG_ERROR([Non-toolkit scroll bars are not implemented for Nextstep.])
-  fi
-
   window_system=nextstep
   # set up packaging dirs
   if test "${EN_NS_SELF_CONTAINED}" = yes; then
@@ -2042,9 +2037,6 @@ CM_OBJ="cm.o"
 XARGS_LIMIT=
 if test "${HAVE_W32}" = "yes"; then
   AC_DEFINE(HAVE_NTGUI, 1, [Define to use native MS Windows GUI.])
-  if test "$with_toolkit_scroll_bars" = "no"; then
-    AC_MSG_ERROR([Non-toolkit scroll bars are not implemented for w32 build.])
-  fi
   AC_CHECK_TOOL(WINDRES, [windres],
                 [AC_MSG_ERROR([No resource compiler found.])])
   W32_OBJ="w32fns.o w32menu.o w32reg.o w32font.o w32term.o"
@@ -2635,12 +2627,6 @@ AC_SUBST(GTK_OBJ)
 
 if test "${HAVE_GTK}" = "yes"; then
 
-  dnl  GTK scrollbars resemble toolkit scrollbars a lot, so to avoid
-  dnl  a lot if #ifdef:s, say we have toolkit scrollbars.
-  if test "$with_toolkit_scroll_bars" != no; then
-    with_toolkit_scroll_bars=yes
-  fi
-
   dnl  Check if we have the old file selection dialog declared and
   dnl  in the link library.  In 2.x it may be in the library,
   dnl  but not declared if deprecated featured has been selected out.
@@ -2990,26 +2976,6 @@ dnl tranle@intellicorp.com says libXmu.a can need XtMalloc in libXt.a to link.
 fi
 AC_SUBST(LIBXTR6)
 AC_SUBST(LIBXMU)
-
-dnl Use toolkit scroll bars if configured for GTK or X toolkit and either
-dnl using Xaw3d is available, and unless
-dnl --with-toolkit-scroll-bars=no was specified.
-
-AH_TEMPLATE(USE_TOOLKIT_SCROLL_BARS,
-	    [Define to 1 if we should use toolkit scroll bars.])dnl
-USE_TOOLKIT_SCROLL_BARS=no
-if test "${with_toolkit_scroll_bars}" != "no"; then
-  if test "${HAVE_GTK}" = "yes"; then
-    AC_DEFINE(USE_TOOLKIT_SCROLL_BARS)
-    USE_TOOLKIT_SCROLL_BARS=yes
-  elif test "${HAVE_NS}" = "yes"; then
-    AC_DEFINE(USE_TOOLKIT_SCROLL_BARS)
-    USE_TOOLKIT_SCROLL_BARS=yes
-  elif test "${HAVE_W32}" = "yes"; then
-    AC_DEFINE(USE_TOOLKIT_SCROLL_BARS)
-    USE_TOOLKIT_SCROLL_BARS=yes
-  fi
-fi
 
 dnl See if XIM is available.
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
@@ -5230,8 +5196,7 @@ End:
 
 #### Report on what we decided to do.
 #### Report GTK as a toolkit, even if it doesn't use Xt.
-#### It makes printing result more understandable as using GTK sets
-#### toolkit_scroll_bars to yes by default.
+#### It makes printing result more understandable.
 if test "${HAVE_GTK}" = "yes"; then
   USE_X_TOOLKIT="$USE_GTK_TOOLKIT"
 fi
@@ -5261,13 +5226,13 @@ optsep=
 emacs_config_features=
 for opt in XPM JPEG TIFF GIF PNG RSVG CAIRO IMAGEMAGICK SOUND GPM DBUS \
   GCONF GSETTINGS NOTIFY ACL LIBSELINUX GNUTLS LIBXML2 FREETYPE M17N_FLT \
-  LIBOTF XFT ZLIB TOOLKIT_SCROLL_BARS X_TOOLKIT OLDXMENU X11 NS MODULES \
+  LIBOTF XFT ZLIB X_TOOLKIT OLDXMENU X11 NS MODULES \
   XWIDGETS LIBSYSTEMD CANNOT_DUMP LCMS2; do
 
     case $opt in
       CANNOT_DUMP) eval val=\${$opt} ;;
       NOTIFY|ACL) eval val=\${${opt}_SUMMARY} ;;
-      TOOLKIT_SCROLL_BARS|X_TOOLKIT) eval val=\${USE_$opt} ;;
+      X_TOOLKIT) eval val=\${USE_$opt} ;;
       *) eval val=\${HAVE_$opt} ;;
     esac
     case x$val in
@@ -5312,7 +5277,6 @@ AS_ECHO(["  Does Emacs use -lXpm?                                   ${HAVE_XPM}
   Does Emacs use -lxft?                                   ${HAVE_XFT}
   Does Emacs use -lsystemd?                               ${HAVE_LIBSYSTEMD}
   Does Emacs have dynamic modules support?                ${HAVE_MODULES}
-  Does Emacs use toolkit scroll bars?                     ${USE_TOOLKIT_SCROLL_BARS}
   Does Emacs support Xwidgets (requires gtk3)?            ${HAVE_XWIDGETS}
   Does Emacs have threading support in lisp?              ${threads_enabled}
 "])

--- a/src/frame.c
+++ b/src/frame.c
@@ -5592,13 +5592,9 @@ Setting this variable does not affect existing frames, only new ones.  */);
   DEFVAR_LISP ("default-frame-scroll-bars", Vdefault_frame_scroll_bars,
 	       doc: /* Default position of vertical scroll bars on this window-system.  */);
 #ifdef HAVE_WINDOW_SYSTEM
-#if defined (HAVE_NTGUI) || defined (NS_IMPL_COCOA) || (defined (USE_GTK) && defined (USE_TOOLKIT_SCROLL_BARS))
   /* MS-Windows, macOS, and GTK have scroll bars on the right by
      default.  */
   Vdefault_frame_scroll_bars = Qright;
-#else
-  Vdefault_frame_scroll_bars = Qleft;
-#endif
 #else
   Vdefault_frame_scroll_bars = Qnil;
 #endif

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -3346,9 +3346,7 @@ readable_events (int flags)
   if (kbd_fetch_ptr != kbd_store_ptr)
     {
       if (flags & (READABLE_EVENTS_FILTER_EVENTS
-#ifdef USE_TOOLKIT_SCROLL_BARS
 		   | READABLE_EVENTS_IGNORE_SQUEEZABLES
-#endif
 		   ))
         {
           union buffered_input_event *event = kbd_fetch_ptr;
@@ -3358,17 +3356,13 @@ readable_events (int flags)
               if (event == kbd_buffer + KBD_BUFFER_SIZE)
                 event = kbd_buffer;
 	      if (!(
-#ifdef USE_TOOLKIT_SCROLL_BARS
 		    (flags & READABLE_EVENTS_FILTER_EVENTS) &&
-#endif
 		    event->kind == FOCUS_IN_EVENT)
-#ifdef USE_TOOLKIT_SCROLL_BARS
 		  && !((flags & READABLE_EVENTS_IGNORE_SQUEEZABLES)
 		       && (event->kind == SCROLL_BAR_CLICK_EVENT
 			   || event->kind == HORIZONTAL_SCROLL_BAR_CLICK_EVENT)
 		       && event->ie.part == scroll_bar_handle
 		       && event->ie.modifiers == 0)
-#endif
 		  && !((flags & READABLE_EVENTS_FILTER_EVENTS)
 		       && event->kind == BUFFER_SWITCH_EVENT))
 		return 1;
@@ -5581,10 +5575,6 @@ make_lispy_event (struct input_event *event)
 #ifdef HAVE_GPM
     case GPM_CLICK_EVENT:
 #endif
-#ifndef USE_TOOLKIT_SCROLL_BARS
-    case SCROLL_BAR_CLICK_EVENT:
-    case HORIZONTAL_SCROLL_BAR_CLICK_EVENT:
-#endif
       {
 	int button = event->code;
 	bool is_double;
@@ -5664,11 +5654,6 @@ make_lispy_event (struct input_event *event)
 	    position = make_lispy_position (f, event->x, event->y,
 					    event->timestamp);
 	  }
-#ifndef USE_TOOLKIT_SCROLL_BARS
-	else
-	  /* It's a scrollbar click.  */
-	  position = make_scroll_bar_position (event, Qvertical_scroll_bar);
-#endif /* not USE_TOOLKIT_SCROLL_BARS */
 
 	if (button >= ASIZE (button_down_location))
 	  {
@@ -5926,7 +5911,6 @@ make_lispy_event (struct input_event *event)
       }
 
 
-#ifdef USE_TOOLKIT_SCROLL_BARS
 
       /* We don't have down and up events if using toolkit scroll bars,
 	 so make this always a click event.  Store in the `part' of
@@ -5995,7 +5979,6 @@ make_lispy_event (struct input_event *event)
 	return list2 (head, position);
       }
 
-#endif /* USE_TOOLKIT_SCROLL_BARS */
 
     case DRAG_N_DROP_EVENT:
       {

--- a/src/window.h
+++ b/src/window.h
@@ -803,9 +803,7 @@ window_tool_bar_p(struct window *W);
   (WINDOW_HAS_VERTICAL_SCROLL_BAR_ON_LEFT (W)		\
    || WINDOW_HAS_VERTICAL_SCROLL_BAR_ON_RIGHT (W))
 
-#if (defined (HAVE_WINDOW_SYSTEM)					\
-     && ((defined (USE_TOOLKIT_SCROLL_BARS))	\
-	 || defined (HAVE_NTGUI)))
+#if defined (HAVE_WINDOW_SYSTEM)
 # define USE_HORIZONTAL_SCROLL_BARS true
 #else
 # define USE_HORIZONTAL_SCROLL_BARS false

--- a/src/xfns.c
+++ b/src/xfns.c
@@ -940,20 +940,6 @@ x_set_background_color (struct frame *f, Lisp_Object arg, Lisp_Object oldval)
 
       xg_set_background_color (f, bg);
 
-#ifndef USE_TOOLKIT_SCROLL_BARS /* Turns out to be annoying with
-				   toolkit scroll bars.  */
-      {
-	Lisp_Object bar;
-	for (bar = FRAME_SCROLL_BARS (f);
-	     !NILP (bar);
-	     bar = XSCROLL_BAR (bar)->next)
-	  {
-	    Window window = XSCROLL_BAR (bar)->x_window;
-	    XSetWindowBackground (dpy, window, bg);
-	  }
-      }
-#endif /* USE_TOOLKIT_SCROLL_BARS */
-
       unblock_input ();
       update_face_from_frame_parameter (f, Qbackground_color, arg);
 
@@ -1777,36 +1763,20 @@ void
 x_set_scroll_bar_default_width (struct frame *f)
 {
   int unit = FRAME_COLUMN_WIDTH (f);
-#ifdef USE_TOOLKIT_SCROLL_BARS
   int minw = xg_get_default_scrollbar_width (f);
   /* A minimum width of 14 doesn't look good for toolkit scroll bars.  */
   FRAME_CONFIG_SCROLL_BAR_COLS (f) = (minw + unit - 1) / unit;
   FRAME_CONFIG_SCROLL_BAR_WIDTH (f) = minw;
-#else
-  /* The width of a non-toolkit scrollbar is 14 pixels.  */
-  FRAME_CONFIG_SCROLL_BAR_COLS (f) = (14 + unit - 1) / unit;
-  FRAME_CONFIG_SCROLL_BAR_WIDTH (f)
-    = FRAME_CONFIG_SCROLL_BAR_COLS (f) * unit;
-#endif
 }
 
 void
 x_set_scroll_bar_default_height (struct frame *f)
 {
   int height = FRAME_LINE_HEIGHT (f);
-#ifdef USE_TOOLKIT_SCROLL_BARS
   int min_height = xg_get_default_scrollbar_height (f);
   /* A minimum height of 14 doesn't look good for toolkit scroll bars.  */
   FRAME_CONFIG_SCROLL_BAR_HEIGHT (f) = min_height;
   FRAME_CONFIG_SCROLL_BAR_LINES (f) = (min_height + height - 1) / height;
-#else
-  /* The height of a non-toolkit scrollbar is 14 pixels.  */
-  FRAME_CONFIG_SCROLL_BAR_LINES (f) = (14 + height - 1) / height;
-
-  /* Use all of that space (aside from required margins) for the
-     scroll bar.  */
-  FRAME_CONFIG_SCROLL_BAR_HEIGHT (f) = 14;
-#endif
 }
 
 
@@ -1827,7 +1797,6 @@ x_default_scroll_bar_color_parameter (struct frame *f,
   tem = x_get_arg (dpyinfo, alist, prop, xprop, xclass, RES_TYPE_STRING);
   if (EQ (tem, Qunbound))
     {
-#ifdef USE_TOOLKIT_SCROLL_BARS
 
       /* See if an X resource for the scroll bar color has been
 	 specified.  */
@@ -1848,12 +1817,6 @@ x_default_scroll_bar_color_parameter (struct frame *f,
 	     specified.  */
 	  tem = Qnil;
 	}
-
-#else /* not USE_TOOLKIT_SCROLL_BARS */
-
-      tem = Qnil;
-
-#endif /* not USE_TOOLKIT_SCROLL_BARS */
     }
 
   AUTO_FRAME_ARG (arg, prop, tem);
@@ -2938,11 +2901,7 @@ This function is an internal primitive--use `make-frame' instead.  */)
   x_default_parameter (f, parms, Qbottom_divider_width, make_number (0),
 		       NULL, NULL, RES_TYPE_NUMBER);
   x_default_parameter (f, parms, Qvertical_scroll_bars,
-#if defined (USE_TOOLKIT_SCROLL_BARS)
 		       Qright,
-#else
-		       Qleft,
-#endif
 		       "verticalScrollBars", "ScrollBars",
 		       RES_TYPE_SYMBOL);
   x_default_parameter (f, parms, Qhorizontal_scroll_bars, Qnil,

--- a/src/xterm.h
+++ b/src/xterm.h
@@ -880,11 +880,6 @@ struct scroll_bar
      being dragged, this is -1.  */
   int dragging;
 
-#if defined (USE_TOOLKIT_SCROLL_BARS) && !defined (USE_GTK)
-  /* Last value of whole for horizontal scrollbars.  */
-  int whole;
-#endif
-
   /* True if the scroll bar is horizontal.  */
   bool horizontal;
 };


### PR DESCRIPTION
Always use toolkit scrollbar in any GUI config. Simplify the code.

Depends on #919.