### PR TITLE
Silence some byte-compiler warnings on eval-tests

### DIFF
--- a/test/rust_src/src/eval-tests.el
+++ b/test/rust_src/src/eval-tests.el
@@ -271,4 +271,8 @@
 
   (should-error (funcall (lambda)) :type 'invalid-function))
 
+;; Local Variables:
+;; byte-compile-warnings: (not lexical free-vars unresolved)
+;; End:
+
 ;;; eval-tests.el ends here


### PR DESCRIPTION
Setting global variables is untidy, but we're testing core elisp
functionality in this file. Just silence the warnings.