### PR TITLE
Replace C style hash::lookup implementation with a more idiomatic Rust version.

### DIFF
--- a/rust_src/src/hashtable.rs
+++ b/rust_src/src/hashtable.rs
@@ -21,6 +21,7 @@ pub enum HashLookupResult {
     Missing(EmacsUint),
     Found(isize),
 }
+use self::HashLookupResult::{Found, Missing};
 
 impl LispHashTableRef {
     pub fn allocate() -> LispHashTableRef {
@@ -87,13 +88,14 @@ impl LispHashTableRef {
     }
 
     pub fn lookup(self, key: LispObject) -> HashLookupResult {
+        // This allows `self` to be immutable.
         let mutself = self.as_ptr() as *mut Lisp_Hash_Table;
         let mut hash = 0;
         let idx = unsafe { hash_lookup(mutself, key, &mut hash) };
         if idx < 0 {
-            HashLookupResult::Missing(hash)
+            Missing(hash)
         } else {
-            HashLookupResult::Found(idx)
+            Found(idx)
         }
     }
 

--- a/rust_src/src/hashtable.rs
+++ b/rust_src/src/hashtable.rs
@@ -234,7 +234,7 @@ pub fn gethash(key: LispObject, hash_table: LispHashTableRef, dflt: LispObject) 
 pub fn puthash(key: LispObject, value: LispObject, hash_table: LispHashTableRef) -> LispObject {
     hash_table.check_impure(hash_table);
 
-    match hash_table.lookup(value) {
+    match hash_table.lookup(key) {
         Found(idx) => {
             hash_table.set_hash_value(idx, value);
         }

--- a/rust_src/src/hashtable.rs
+++ b/rust_src/src/hashtable.rs
@@ -16,6 +16,12 @@ use lists::{list, put};
 
 pub type LispHashTableRef = ExternalPtr<Lisp_Hash_Table>;
 
+#[derive(Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Debug)]
+pub enum HashLookupResult {
+    Missing(EmacsUint),
+    Found(isize),
+}
+
 impl LispHashTableRef {
     pub fn allocate() -> LispHashTableRef {
         let vec_ptr = allocate_pseudovector!(Lisp_Hash_Table, count, pvec_type::PVEC_HASH_TABLE);
@@ -80,9 +86,15 @@ impl LispHashTableRef {
         unsafe { gc_aset(self.key_and_value, 2 * idx + 1, value) };
     }
 
-    pub fn lookup(self, key: LispObject, hashptr: *mut EmacsUint) -> isize {
+    pub fn lookup(self, key: LispObject) -> HashLookupResult {
         let mutself = self.as_ptr() as *mut Lisp_Hash_Table;
-        unsafe { hash_lookup(mutself, key, hashptr) }
+        let mut hash = 0;
+        let idx = unsafe { hash_lookup(mutself, key, &mut hash) };
+        if idx < 0 {
+            HashLookupResult::Missing(hash)
+        } else {
+            HashLookupResult::Found(idx)
+        }
     }
 
     pub fn put(mut self, key: LispObject, value: LispObject, hash: EmacsUint) -> isize {
@@ -207,12 +219,9 @@ pub fn copy_hash_table(mut table: LispHashTableRef) -> LispHashTableRef {
 /// If KEY is not found, return DFLT which defaults to nil.
 #[lisp_fn(min = "2")]
 pub fn gethash(key: LispObject, hash_table: LispHashTableRef, dflt: LispObject) -> LispObject {
-    let idx = hash_table.lookup(key, ptr::null_mut());
-
-    if idx >= 0 {
-        hash_table.get_hash_value(idx)
-    } else {
-        dflt
+    match hash_table.lookup(key) {
+        Found(idx) => hash_table.get_hash_value(idx),
+        Missing(_) => dflt,
     }
 }
 
@@ -223,13 +232,13 @@ pub fn gethash(key: LispObject, hash_table: LispHashTableRef, dflt: LispObject) 
 pub fn puthash(key: LispObject, value: LispObject, hash_table: LispHashTableRef) -> LispObject {
     hash_table.check_impure(hash_table);
 
-    let mut hash: EmacsUint = 0;
-    let idx = hash_table.lookup(key, &mut hash);
-
-    if idx >= 0 {
-        hash_table.set_hash_value(idx, value);
-    } else {
-        hash_table.put(key, value, hash);
+    match hash_table.lookup(value) {
+        Found(idx) => {
+            hash_table.set_hash_value(idx, value);
+        }
+        Missing(hash) => {
+            hash_table.put(key, value, hash);
+        }
     }
 
     value


### PR DESCRIPTION
Add a `HashLookupResult` which defines `Missing` and `Found`.