### PR TITLE
Port default-value and default-boundp

### DIFF
--- a/rust_src/Cargo.lock
+++ b/rust_src/Cargo.lock
@@ -173,7 +173,7 @@ version = "0.0.206"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cargo_metadata 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "if_chain 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "if_chain 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -352,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "if_chain"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -588,6 +588,7 @@ dependencies = [
  "clippy 0.0.206 (registry+https://github.com/rust-lang/crates.io-index)",
  "field-offset 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "if_chain 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "md5 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -963,7 +964,7 @@ dependencies = [
 "checksum humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0484fda3e7007f2a4a0d9c3a703ca38c71c54c55602ce4660c419fd32e188c9e"
 "checksum ident_case 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c9826188e666f2ed92071d2dadef6edc430b11b158b5b2b3f4babbcc891eaaa"
 "checksum idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "014b298351066f1512874135335d62a789ffe78a9974f94b43ed5621951eaf7d"
-"checksum if_chain 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "61bb90bdd39e3af69b0172dfc6130f6cd6332bf040fbb9bdd4401d37adbd48b8"
+"checksum if_chain 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4bac95d9aa0624e7b78187d6fb8ab012b41d9f6f54b1bcb61e61c4845f8357ec"
 "checksum itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "f58856976b776fedd95533137617a02fb25719f40e7d9b01c7043cd65474f450"
 "checksum itoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c069bbec61e1ca5a596166e55dfe4773ff745c3d16b700013bcaff9a6df2c682"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"

--- a/rust_src/Cargo.toml
+++ b/rust_src/Cargo.toml
@@ -21,6 +21,7 @@ sha1 = "0.2.0"
 sha2 = "0.4.2"
 field-offset = "0.1.1"
 flate2 = "1.0.1"
+if_chain = "0.1.3"
 
 # Only want this local crate as dependency on Mac OS X
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/rust_src/src/eval_macros.rs
+++ b/rust_src/src/eval_macros.rs
@@ -297,6 +297,6 @@ macro_rules! verify_lisp_type {
 macro_rules! per_buffer_var_idx {
     ($field: ident) => {
         #[allow(unused_unsafe)]
-        (unsafe { buffer_local_flags.$field }).as_natnum_or_error() as usize
+        (unsafe { ::remacs_sys::buffer_local_flags.$field }).as_natnum_or_error() as usize
     };
 }

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -21,6 +21,8 @@
 #![feature(const_fn_union)]
 
 #[macro_use]
+extern crate if_chain;
+#[macro_use]
 extern crate lazy_static;
 
 extern crate base64 as base64_crate;

--- a/rust_src/src/syntax.rs
+++ b/rust_src/src/syntax.rs
@@ -1,6 +1,6 @@
 //! Functions related to syntax
 use remacs_macros::lisp_fn;
-use remacs_sys::{buffer_local_flags, scan_lists};
+use remacs_sys::scan_lists;
 use remacs_sys::{EmacsInt, Qsyntax_table, Qsyntax_table_p};
 
 use chartable::LispCharTableRef;


### PR DESCRIPTION
Closes #798 and #809. Two tests had unexpected failures locally, but they seem unrelated.

This introduces [if_chain](https://docs.rs/if_chain/0.1.3/if_chain/) as a direct dependency (it was already pulled in transitively) to maintain some more Rustic expression flow in the match, but if that doesn't look like something that'll probably be used elsewhere, it can be dropped and either an early return or duplication of the `else` arm can be used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wilfred/remacs/960)
<!-- Reviewable:end -->
