### PR TITLE
More #[repr(transparent)] coverage

### DIFF
--- a/rust_src/src/chartable.rs
+++ b/rust_src/src/chartable.rs
@@ -13,6 +13,7 @@ use lisp::{ExternalPtr, LispObject};
 
 pub type LispCharTableRef = ExternalPtr<Lisp_Char_Table>;
 pub type LispSubCharTableRef = ExternalPtr<Lisp_Sub_Char_Table>;
+#[repr(transparent)]
 pub struct LispSubCharTableAsciiRef(ExternalPtr<Lisp_Sub_Char_Table>);
 
 impl LispObject {

--- a/rust_src/src/fonts.rs
+++ b/rust_src/src/fonts.rs
@@ -12,6 +12,7 @@ use vectors::LispVectorlikeRef;
 // A font is not a type in and of itself, it's just a group of three kinds of
 // pseudovector. This newtype allows us to define methods that yield the actual
 // font types: Spec, Entity, and Object.
+#[repr(transparent)]
 pub struct LispFontRef(LispVectorlikeRef);
 
 impl LispFontRef {

--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -42,7 +42,7 @@ use vectors::LispBoolVecRef;
 ///
 /// Their definition are determined in a way consistent with Emacs C.
 /// Under casual systems, they're the type isize and usize respectively.
-#[repr(C)]
+#[repr(transparent)]
 #[derive(PartialEq, Eq, Clone, Copy)]
 pub struct LispObject(pub EmacsInt);
 
@@ -182,7 +182,7 @@ impl LispObject {
 // directly creating and moving or copying this struct is simply wrong!
 // If needed, we can calculate all variants size and allocate properly.
 
-#[repr(C)]
+#[repr(transparent)]
 #[derive(Debug)]
 pub struct ExternalPtr<T>(*mut T);
 

--- a/rust_src/src/lists.rs
+++ b/rust_src/src/lists.rs
@@ -14,6 +14,7 @@ use symbols::LispSymbolRef;
 // Cons support (LispType == 6 | 3)
 
 /// A newtype for objects we know are conses.
+#[repr(transparent)]
 #[derive(Clone, Copy)]
 pub struct LispCons(LispObject);
 

--- a/rust_src/src/obarray.rs
+++ b/rust_src/src/obarray.rs
@@ -11,6 +11,7 @@ use lisp::defsubr;
 use lisp::LispObject;
 
 /// A lisp object containing an `obarray`.
+#[repr(transparent)]
 pub struct LispObarrayRef(LispObject);
 
 impl LispObarrayRef {


### PR DESCRIPTION
Followup to #708. Makes most single-item tuple structs using `#[repr(C)]` use `transparent` instead to guarantee C interop in function signatures or structs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wilfred/remacs/967)
<!-- Reviewable:end -->
