### PR TITLE
add default.nix expression to assist development using nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,20 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+with pkgs;
+
+stdenv.mkDerivation rec {
+  version = "27.0.1";
+
+  name = "remacs-${version}";
+
+  buildInputs = [
+    systemd texinfo libjpeg libtiff giflib xorg.libXpm gtk3
+    gnutls ncurses libxml2 xorg.libXt imagemagick librsvg gpm dbus
+    libotf clang_6 pkgconfig
+  ];
+
+  shellHook = ''
+    export NIX_PATH="nixpkgs=${toString <nixpkgs>}"
+    export LIBCLANG_PATH="${llvmPackages_6.libclang.lib}/lib";
+  '';
+}


### PR DESCRIPTION
This PR adds a nix expression, which can used to set up a shell environment for development.