### PR TITLE
Cut unnecessary nil returns

### DIFF
--- a/rust_src/src/buffers.rs
+++ b/rust_src/src/buffers.rs
@@ -950,11 +950,11 @@ pub extern "C" fn build_overlay(
 
 /// Delete the overlay OVERLAY from its buffer.
 #[lisp_fn]
-pub fn delete_overlay(overlay: LispObject) -> LispObject {
+pub fn delete_overlay(overlay: LispObject) {
     let mut ov_ref = overlay.as_overlay_or_error();
     let mut buf_ref = match marker_buffer(ov_ref.start.as_marker_or_error()) {
         Some(b) => b,
-        None => return Qnil,
+        None => return,
     };
     let count = c_specpdl_index();
 
@@ -975,22 +975,20 @@ pub fn delete_overlay(overlay: LispObject) -> LispObject {
     }
 
     unsafe { unbind_to(count, Qnil) };
-    Qnil
 }
 
 /// Delete all overlays of BUFFER.
 /// BUFFER omitted or nil means delete all overlays of the current buffer.
 #[lisp_fn(min = "0", name = "delete-all-overlays")]
-pub fn delete_all_overlays_lisp(buffer: LispObject) -> LispObject {
+pub fn delete_all_overlays_lisp(buffer: LispObject) {
     unsafe { delete_all_overlays(buffer.as_buffer_or_current_buffer().as_mut()) };
-    Qnil
 }
 
 /// Delete the entire contents of the current buffer.
 /// Any narrowing restriction in effect (see `narrow-to-region') is removed,
 /// so the buffer is truly empty after this.
 #[lisp_fn]
-pub fn erase_buffer() -> LispObject {
+pub fn erase_buffer() {
     unsafe {
         Fwiden();
 
@@ -1004,7 +1002,6 @@ pub fn erase_buffer() -> LispObject {
         // implies that the future text is not really related to the past text.
         cur_buf.save_length_ = LispObject::from(0);
     }
-    Qnil
 }
 
 #[no_mangle]

--- a/rust_src/src/casefiddle.rs
+++ b/rust_src/src/casefiddle.rs
@@ -16,7 +16,7 @@ use threads::ThreadState;
 use obarray::intern;
 use symbols::symbol_value;
 
-fn casify_word(flag: case_action, words: EmacsInt) -> LispObject {
+fn casify_word(flag: case_action, words: EmacsInt) {
     let buffer_ref = ThreadState::current_buffer();
 
     let far_end = match unsafe { scan_words(buffer_ref.pt, words) } {
@@ -39,7 +39,6 @@ fn casify_word(flag: case_action, words: EmacsInt) -> LispObject {
     };
 
     unsafe { set_point(new_pos) };
-    Qnil
 }
 
 /// Convert argument to capitalized form and return that.
@@ -74,8 +73,8 @@ pub fn capitalize_region(beg: LispObject, end: LispObject) -> LispObject {
 ///
 /// With negative argument, capitalize previous words but do not move.
 #[lisp_fn(intspec = "p")]
-pub fn capitalize_word(words: EmacsInt) -> LispObject {
-    casify_word(case_action::CASE_CAPITALIZE, words)
+pub fn capitalize_word(words: EmacsInt) {
+    casify_word(case_action::CASE_CAPITALIZE, words);
 }
 
 /// Convert argument to lower case and return that.
@@ -109,8 +108,8 @@ pub fn downcase_region(
 ///
 /// With negative argument, convert previous words but do not move.
 #[lisp_fn(intspec = "p")]
-pub fn downcase_word(words: EmacsInt) -> LispObject {
-    casify_word(case_action::CASE_DOWN, words)
+pub fn downcase_word(words: EmacsInt) {
+    casify_word(case_action::CASE_DOWN, words);
 }
 
 /// Convert argument to upper case and return that.
@@ -175,8 +174,8 @@ pub fn upcase_region(
 /// With negative argument, convert previous words but do not move.
 /// See also `capitalize-word'.
 #[lisp_fn(intspec = "p")]
-pub fn upcase_word(words: EmacsInt) -> LispObject {
-    casify_word(case_action::CASE_UP, words)
+pub fn upcase_word(words: EmacsInt) {
+    casify_word(case_action::CASE_UP, words);
 }
 
 // Fiddle with the case of a whole region. Used as a helper by

--- a/rust_src/src/editfns.rs
+++ b/rust_src/src/editfns.rs
@@ -858,7 +858,7 @@ pub fn insert_buffer_substring(
     buffer: LispBufferOrName,
     beg: Option<LispNumber>,
     end: Option<LispNumber>,
-) -> LispObject {
+) {
     let mut buf_ref = LispBufferRef::from(buffer)
         .as_live()
         .unwrap_or_else(|| error!("Selecting deleted buffer"));
@@ -883,7 +883,6 @@ pub fn insert_buffer_substring(
         set_buffer_internal_1(cur_buf.as_mut());
         insert_from_buffer(buf_ref.as_mut(), b, e - b, false)
     };
-    Qnil
 }
 
 /// Display a message, in a dialog box if possible.

--- a/rust_src/src/eval.rs
+++ b/rust_src/src/eval.rs
@@ -461,7 +461,7 @@ pub fn lisp_let(args: LispCons) -> LispObject {
 /// until TEST returns nil.
 /// usage: (while TEST BODY...)
 #[lisp_fn(name = "while", c_name = "while", min = "1", unevalled = "true")]
-pub fn lisp_while(args: LispCons) -> LispObject {
+pub fn lisp_while(args: LispCons) {
     let (test, body) = args.as_tuple();
 
     while unsafe { eval_sub(test) } != Qnil {
@@ -469,8 +469,6 @@ pub fn lisp_while(args: LispCons) -> LispObject {
 
         progn(body);
     }
-
-    Qnil
 }
 
 /// Return result of expanding macros at top level of FORM.

--- a/rust_src/src/lread.rs
+++ b/rust_src/src/lread.rs
@@ -202,7 +202,7 @@ pub fn eval_region(
     end: LispObject,
     printflag: LispObject,
     read_function: LispObject,
-) -> LispObject {
+) {
     // FIXME: Do the eval-sexp-add-defvars dance!
     let count = c_specpdl_index();
     let cur_buf = ThreadState::current_buffer();
@@ -233,7 +233,6 @@ pub fn eval_region(
         );
         unbind_to(count, Qnil);
     }
-    Qnil
 }
 
 include!(concat!(env!("OUT_DIR"), "/lread_exports.rs"));

--- a/rust_src/src/windows.rs
+++ b/rust_src/src/windows.rs
@@ -1046,9 +1046,8 @@ pub fn scroll_right(arg: LispObject, set_minimum: LispObject) -> LispObject {
 /// If ARG is the atom `-', scroll downward by nearly full screen.
 /// When calling from a program, supply as argument a number, nil, or `-'.
 #[lisp_fn(min = "0", intspec = "^P")]
-pub fn scroll_up(arg: LispObject) -> LispObject {
+pub fn scroll_up(arg: LispObject) {
     unsafe { scroll_command(arg, 1) };
-    Qnil
 }
 
 /// Scroll text of selected window down ARG lines.
@@ -1058,9 +1057,8 @@ pub fn scroll_up(arg: LispObject) -> LispObject {
 /// If ARG is the atom `-', scroll upward by nearly full screen.
 /// When calling from a program, supply as argument a number, nil, or `-'.
 #[lisp_fn(min = "0", intspec = "^P")]
-pub fn scroll_down(arg: LispObject) -> LispObject {
+pub fn scroll_down(arg: LispObject) {
     unsafe { scroll_command(arg, -1) };
-    Qnil
 }
 
 /// Return the new total size of window WINDOW.


### PR DESCRIPTION
As I understand it, the lisp_fn macro converts Rust return values to
Lisp values. In particular, the unit () is converted to nil. Thus a
function that returns only Qnil might as well return nothing at all,
since the ultimate Lisp function will return nil anyway.