### PR TITLE
Revert "don't use bool for lisp_fn arguments"

### DIFF
--- a/rust_src/src/dispnew.rs
+++ b/rust_src/src/dispnew.rs
@@ -114,12 +114,12 @@ pub extern "C" fn set_window_update_flags(w: LispWindowRef, on_p: bool) {
 /// show a cursor in WINDOW in the next redisplay.  SHOW nil means
 /// don't show a cursor.
 #[lisp_fn]
-pub fn internal_show_cursor(window: LispWindowOrSelected, show: LispObject) {
+pub fn internal_show_cursor(window: LispWindowOrSelected, show: bool) {
     let mut win: LispWindowRef = window.into();
     // Don't change cursor state while redisplaying.  This could confuse
     // output routines.
     if !unsafe { redisplaying_p } {
-        win.set_cursor_off_p(show.is_nil())
+        win.set_cursor_off_p(show)
     }
 }
 

--- a/rust_src/src/dispnew.rs
+++ b/rust_src/src/dispnew.rs
@@ -119,7 +119,7 @@ pub fn internal_show_cursor(window: LispWindowOrSelected, show: bool) {
     // Don't change cursor state while redisplaying.  This could confuse
     // output routines.
     if !unsafe { redisplaying_p } {
-        win.set_cursor_off_p(show)
+        win.set_cursor_off_p(!show)
     }
 }
 


### PR DESCRIPTION
Reverts Wilfred/remacs#1030

The problem was I did not invert the boolean. Tossing out the bool and going back to LispObject solves the problem but is heavy handed.