### PR TITLE
Port set, set-default

### DIFF
--- a/rust_src/src/cmds.rs
+++ b/rust_src/src/cmds.rs
@@ -10,12 +10,13 @@ use remacs_sys::{bitch_at_user, concat2, current_column, del_range, frame_make_p
                  globals, initial_define_key, insert_and_inherit, memory_full, replace_range,
                  run_hook, scan_newline_from_point, set_point, set_point_both, syntax_property,
                  syntaxcode, translate_char};
-use remacs_sys::{Fchar_width, Fget, Fmake_string, Fmove_to_column, Fset};
+use remacs_sys::{Fchar_width, Fget, Fmake_string, Fmove_to_column};
 use remacs_sys::{Qbeginning_of_buffer, Qend_of_buffer, Qexpand_abbrev, Qinternal_auto_fill,
                  Qkill_forward_chars, Qnil, Qoverwrite_mode_binary, Qpost_self_insert_hook,
                  Qundo_auto__this_command_amalgamating, Qundo_auto_amalgamate};
 
 use character::{self, characterp};
+use data::set;
 use editfns::{line_beginning_position, line_end_position, preceding_char};
 use frames::selected_frame;
 use keymap::{current_global_map, Ctl};
@@ -263,7 +264,10 @@ pub fn self_insert_command(n: EmacsInt) {
         };
         let val = internal_self_insert(character as Codepoint, n as usize);
         if val == 2 {
-            unsafe { Fset(Qundo_auto__this_command_amalgamating, Qnil) };
+            set(
+                Qundo_auto__this_command_amalgamating.as_symbol_or_error(),
+                Qnil,
+            );
         }
         unsafe { frame_make_pointer_invisible(selected_frame().as_frame_or_error().as_mut()) };
     }

--- a/rust_src/src/data.rs
+++ b/rust_src/src/data.rs
@@ -5,9 +5,10 @@ use libc::c_int;
 use remacs_macros::lisp_fn;
 use remacs_sys;
 use remacs_sys::{aset_multibyte_string, bool_vector_binop_driver, buffer_defaults, build_string,
-                 emacs_abort, globals, wrong_choice, wrong_range, CHAR_TABLE_SET, CHECK_IMPURE};
+                 emacs_abort, globals, set_default_internal, set_internal, wrong_choice,
+                 wrong_range, CHAR_TABLE_SET, CHECK_IMPURE};
 use remacs_sys::{buffer_local_flags, per_buffer_default, symbol_redirect};
-use remacs_sys::{pvec_type, BoolVectorOp, EmacsInt, Lisp_Misc_Type, Lisp_Type};
+use remacs_sys::{pvec_type, BoolVectorOp, EmacsInt, Lisp_Misc_Type, Lisp_Type, Set_Internal_Bind};
 use remacs_sys::{Fcons, Ffset, Fget, Fpurecopy};
 use remacs_sys::{Lisp_Buffer, Lisp_Subr_Lang};
 use remacs_sys::{Qargs_out_of_range, Qarrayp, Qautoload, Qbool_vector, Qbuffer, Qchar_table,
@@ -657,6 +658,35 @@ pub fn bool_vector_set_difference(a: LispObject, b: LispObject, c: LispObject) -
 #[lisp_fn]
 pub fn bool_vector_subsetp(a: LispObject, b: LispObject) -> LispObject {
     unsafe { bool_vector_binop_driver(a, b, b, BoolVectorOp::BoolVectorSubsetp) }
+}
+
+/// Set SYMBOL's value to NEWVAL, and return NEWVAL.
+#[lisp_fn]
+pub fn set(symbol: LispSymbolRef, newval: LispObject) -> LispObject {
+    unsafe {
+        set_internal(
+            LispObject::from(symbol),
+            newval,
+            Qnil,
+            Set_Internal_Bind::SET_INTERNAL_SET,
+        )
+    };
+    newval
+}
+
+/// Set SYMBOL's default value to VALUE.  SYMBOL and VALUE are evaluated.
+/// The default value is seen in buffers that do not have their own
+/// values for this variable.
+#[lisp_fn]
+pub fn set_default(symbol: LispSymbolRef, value: LispObject) -> LispObject {
+    unsafe {
+        set_default_internal(
+            LispObject::from(symbol),
+            value,
+            Set_Internal_Bind::SET_INTERNAL_SET,
+        )
+    };
+    value
 }
 
 include!(concat!(env!("OUT_DIR"), "/data_exports.rs"));

--- a/rust_src/src/eval.rs
+++ b/rust_src/src/eval.rs
@@ -8,7 +8,7 @@ use remacs_sys::{backtrace_debug_on_exit, build_string, call_debugger, check_con
                  globals, list2, maybe_gc, maybe_quit, record_in_backtrace, record_unwind_protect,
                  record_unwind_save_match_data, specbind, unbind_to, COMPILEDP, MODULE_FUNCTIONP};
 use remacs_sys::{pvec_type, EmacsInt, Lisp_Compiled};
-use remacs_sys::{Fapply, Fcons, Fdefault_value, Ffset, Fload, Fpurecopy, Fset, Fset_default};
+use remacs_sys::{Fapply, Fcons, Fdefault_value, Ffset, Fload, Fpurecopy};
 use remacs_sys::{QCdocumentation, Qautoload, Qclosure, Qerror, Qexit, Qfunction, Qinteractive,
                  Qinteractive_form, Qinternal_interpreter_environment, Qinvalid_function, Qlambda,
                  Qmacro, Qnil, Qrisky_local_variable, Qsetq, Qt, Qunbound,
@@ -16,7 +16,7 @@ use remacs_sys::{QCdocumentation, Qautoload, Qclosure, Qerror, Qexit, Qfunction,
 
 use remacs_sys::{Vautoload_queue, Vrun_hooks};
 
-use data::{defalias, indirect_function, indirect_function_lisp};
+use data::{defalias, indirect_function, indirect_function_lisp, set, set_default};
 use lisp::{defsubr, is_autoload};
 use lisp::{LispObject, LispSubrRef};
 use lists::{assq, car, cdr, get, memq, nth, put, Fcar, Fcdr, LispCons};
@@ -193,7 +193,7 @@ pub fn setq(args: LispObject) -> LispObject {
         }
 
         if !lexical {
-            unsafe { Fset(sym, val) }; /* SYM is dynamically bound. */
+            set(sym.as_symbol_or_error(), val); /* SYM is dynamically bound. */
         }
     }
 
@@ -302,8 +302,8 @@ pub fn defconst(args: LispObject) -> LispSymbolRef {
     if unsafe { globals.Vpurify_flag } != Qnil {
         tem = unsafe { Fpurecopy(tem) };
     }
-    unsafe { Fset_default(sym, tem) };
     let sym_ref = sym.as_symbol_or_error();
+    set_default(sym_ref, tem);
     sym_ref.set_declared_special(true);
     if docstring.is_not_nil() {
         if unsafe { globals.Vpurify_flag } != Qnil {

--- a/rust_src/src/keymap.rs
+++ b/rust_src/src/keymap.rs
@@ -9,10 +9,10 @@ use remacs_macros::lisp_fn;
 use remacs_sys::{access_keymap, make_save_funcptr_ptr_obj, map_char_table, map_keymap_call,
                  map_keymap_char_table_item, map_keymap_function_t, map_keymap_item, maybe_quit};
 use remacs_sys::{char_bits, current_global_map as _current_global_map, globals, EmacsInt};
-use remacs_sys::{Fcons, Fevent_convert_list, Ffset, Fmake_char_table, Fpurecopy, Fset};
+use remacs_sys::{Fcons, Fevent_convert_list, Ffset, Fmake_char_table, Fpurecopy};
 use remacs_sys::{Qautoload, Qkeymap, Qkeymapp, Qnil, Qt};
 
-use data::{aref, indirect_function};
+use data::{aref, indirect_function, set};
 use eval::autoload_do_load;
 use keyboard::lucid_event_type_list_p;
 use lisp::{defsubr, LispObject};
@@ -536,9 +536,9 @@ pub fn define_prefix_command(
     let map = make_sparse_keymap(name);
     unsafe { Ffset(command, map) };
     if mapvar.is_not_nil() {
-        unsafe { Fset(mapvar, map) };
+        set(mapvar.as_symbol_or_error(), map);
     } else {
-        unsafe { Fset(command, map) };
+        set(command.as_symbol_or_error(), map);
     }
     command
 }

--- a/rust_src/src/symbols.rs
+++ b/rust_src/src/symbols.rs
@@ -1,7 +1,6 @@
 //! symbols support
 
 use remacs_macros::lisp_fn;
-use remacs_sys::Fset;
 use remacs_sys::{find_symbol_value, get_symbol_declared_special, get_symbol_redirect,
                  make_lisp_symbol, set_symbol_declared_special, set_symbol_redirect,
                  swap_in_symval_forwarding, symbol_interned, symbol_redirect, symbol_trapped_write};
@@ -10,8 +9,8 @@ use remacs_sys::{Qcyclic_variable_indirection, Qnil, Qsetting_constant, Qsymbolp
                  Qvoid_variable};
 
 use buffers::LispBufferLocalValueRef;
-use data::indirect_function;
 use data::Lisp_Fwd;
+use data::{indirect_function, set};
 use lisp::defsubr;
 use lisp::{ExternalPtr, LispObject};
 use multibyte::LispStringRef;
@@ -364,9 +363,7 @@ pub fn makunbound(symbol: LispObject) -> LispSymbolRef {
     if sym.is_constant() {
         xsignal!(Qsetting_constant, symbol);
     }
-    unsafe {
-        Fset(symbol, Qunbound);
-    }
+    set(sym, Qunbound);
     sym
 }
 

--- a/src/data.c
+++ b/src/data.c
@@ -364,14 +364,6 @@ find_symbol_value (Lisp_Object symbol)
     }
 }
 
-DEFUN ("set", Fset, Sset, 2, 2, 0,
-       doc: /* Set SYMBOL's value to NEWVAL, and return NEWVAL.  */)
-  (register Lisp_Object symbol, Lisp_Object newval)
-{
-  set_internal (symbol, newval, Qnil, SET_INTERNAL_SET);
-  return newval;
-}
-
 /* Store the value NEWVAL into SYMBOL.
    If buffer-locality is an issue, WHERE specifies which context to use.
    (nil stands for the current buffer/frame).
@@ -735,16 +727,6 @@ set_default_internal (Lisp_Object symbol, Lisp_Object value,
       }
     default: emacs_abort ();
     }
-}
-
-DEFUN ("set-default", Fset_default, Sset_default, 2, 2, 0,
-       doc: /* Set SYMBOL's default value to VALUE.  SYMBOL and VALUE are evaluated.
-The default value is seen in buffers that do not have their own values
-for this variable.  */)
-  (Lisp_Object symbol, Lisp_Object value)
-{
-  set_default_internal (symbol, value, SET_INTERNAL_SET);
-  return value;
 }
 
 DEFUN ("setq-default", Fsetq_default, Ssetq_default, 0, UNEVALLED, 0,
@@ -2279,8 +2261,6 @@ syms_of_data (void)
   defsubr (&Sinteractive_form);
   defsubr (&Smodule_function_p);
   defsubr (&Sfset);
-  defsubr (&Sset);
-  defsubr (&Sset_default);
   defsubr (&Ssetq_default);
   defsubr (&Smake_variable_buffer_local);
   defsubr (&Smake_local_variable);


### PR DESCRIPTION
Nothing special here, just trying out @shaleh 's porting script. I set the inputs types of these functions to `LispSymbolRef`, which required a few changes in other places.