### PR TITLE
Ensure that \n is treated as a newline

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -176,7 +176,7 @@ if [ -n $rust_toolchain_vers_path ] ; then
 	   echo >&2 "Run 'rustup install $remacs_version'."
 	   exit 1 ;;
         2) echo >&2 "Remacs currently requires Rust toolchain version $remacs_version."
-	   echo >&2 "The active version is not the required one and is set via directory override:\n\t$rustup_active_version"
+	   echo >&2 -e "The active version is not the required one and is set via directory override:\n\t$rustup_active_version"
 	   echo >&2 "Run 'rustup override unset' in this directory."
 	   exit 1 ;;
         *) # /should/ not happen


### PR DESCRIPTION
Before:

    The active version is not the required one and is set via directory override:\n\tnightly-2018-11-02-x86_64-unknown-linux-gnu (directory override for '/home/wilfred/projects/remacs')Run 'rustup override unset' in this directory.

After:

    The active version is not the required one and is set via directory override:
            nightly-2018-11-02-x86_64-unknown-linux-gnu (directory override for '/home/wilfred/projects/remacs')
    Run 'rustup override unset' in this directory.