### PR TITLE
Clean up earlier porting efforts.

### DIFF
--- a/rust_src/src/base64.rs
+++ b/rust_src/src/base64.rs
@@ -78,26 +78,25 @@ pub unsafe extern "C" fn base64_decode_1(
     let decoded = slice::from_raw_parts_mut(to as *mut u8, out_length as usize);
 
     // Use the MIME config to allow embedded newlines.
-    if let Ok(decoded_length) =
-        base64_crate::decode_config_slice(encoded, base64_crate::MIME, decoded)
-    {
-        if !nchars_return.is_null() {
-            *nchars_return = decoded_length as isize;
+    match base64_crate::decode_config_slice(encoded, base64_crate::MIME, decoded) {
+        Ok(decoded_length) => {
+            if !nchars_return.is_null() {
+                *nchars_return = decoded_length as isize;
+            }
+            if multibyte {
+                // Decode non-ASCII bytes into UTF-8 pairs.
+                let s: String = decoded[..decoded_length]
+                    .iter()
+                    .map(|&byte| byte as char)
+                    .collect();
+                let s_len = s.len();
+                ptr::copy_nonoverlapping(s.as_ptr(), to as *mut u8, s_len);
+                s.len() as isize
+            } else {
+                decoded_length as isize
+            }
         }
-        if multibyte {
-            // Decode non-ASCII bytes into UTF-8 pairs.
-            let s: String = decoded[..decoded_length]
-                .iter()
-                .map(|&byte| byte as char)
-                .collect();
-            let s_len = s.len();
-            ptr::copy_nonoverlapping(s.as_ptr(), to as *mut u8, s_len);
-            s.len() as isize
-        } else {
-            decoded_length as isize
-        }
-    } else {
-        -1
+        _ => -1,
     }
 }
 

--- a/rust_src/src/buffers.rs
+++ b/rust_src/src/buffers.rs
@@ -28,8 +28,8 @@ use crate::{
         Lisp_Type, Vbuffer_alist,
     },
     remacs_sys::{
-        windows_or_buffers_changed, Fcons, Fcopy_sequence, Fexpand_file_name,
-        Ffind_file_name_handler, Fget_text_property, Fnconc, Fnreverse, Foverlay_get, Fwiden,
+        windows_or_buffers_changed, Fcopy_sequence, Fexpand_file_name, Ffind_file_name_handler,
+        Fget_text_property, Fnconc, Fnreverse, Foverlay_get, Fwiden,
     },
     remacs_sys::{
         Qafter_string, Qbefore_string, Qbuffer_read_only, Qbufferp, Qget_file_buffer,
@@ -527,11 +527,7 @@ impl LispBufferOrName {
 
     pub fn as_buffer_or_current_buffer(self) -> Option<LispBufferRef> {
         let obj = LispObject::from(self);
-        if obj.is_nil() {
-            Some(ThreadState::current_buffer())
-        } else {
-            self.as_buffer()
-        }
+        obj.map_or_else(|| Some(ThreadState::current_buffer()), |o| o.as_buffer())
     }
 }
 
@@ -649,10 +645,9 @@ fn assoc_ignore_text_properties(key: LispObject, list: LispObject) -> LispObject
     let result = list
         .iter_tails_safe()
         .find(|&item| string_equal(car(item.car()), key));
-    if let Some(elt) = result {
-        elt.car()
-    } else {
-        Qnil
+    match result {
+        Some(elt) => elt.car(),
+        None => Qnil,
     }
 }
 
@@ -683,8 +678,8 @@ pub fn buffer_file_name(buffer: LispBufferOrCurrent) -> LispObject {
 /// Return t if BUFFER was modified since its file was last read or saved.
 /// No argument or nil as argument means use current buffer as BUFFER.
 #[lisp_fn(min = "0")]
-pub fn buffer_modified_p(buffer: LispObject) -> bool {
-    let buf = buffer.as_buffer_or_current_buffer();
+pub fn buffer_modified_p(buffer: LispBufferOrCurrent) -> bool {
+    let buf = buffer.unwrap();
     buf.modifications_since_save() < buf.modifications()
 }
 
@@ -692,8 +687,9 @@ pub fn buffer_modified_p(buffer: LispObject) -> bool {
 /// BUFFER defaults to the current buffer.
 /// Return nil if BUFFER has been killed.
 #[lisp_fn(min = "0")]
-pub fn buffer_name(buffer: LispObject) -> LispObject {
-    buffer.as_buffer_or_current_buffer().name_
+pub fn buffer_name(buffer: LispBufferOrCurrent) -> LispObject {
+    let buf = buffer.unwrap();
+    buf.name_
 }
 
 /// Return BUFFER's tick counter, incremented for each change in text.
@@ -701,8 +697,9 @@ pub fn buffer_name(buffer: LispObject) -> LispObject {
 /// text in that buffer is changed.  It wraps around occasionally.
 /// No argument or nil as argument means use current buffer as BUFFER.
 #[lisp_fn(min = "0")]
-pub fn buffer_modified_tick(buffer: LispObject) -> EmacsInt {
-    buffer.as_buffer_or_current_buffer().modifications()
+pub fn buffer_modified_tick(buffer: LispBufferOrCurrent) -> EmacsInt {
+    let buf = buffer.unwrap();
+    buf.modifications()
 }
 
 /// Return BUFFER's character-change tick counter.
@@ -714,8 +711,9 @@ pub fn buffer_modified_tick(buffer: LispObject) -> EmacsInt {
 /// between these calls.  No argument or nil as argument means use current
 /// buffer as BUFFER.
 #[lisp_fn(min = "0")]
-pub fn buffer_chars_modified_tick(buffer: LispObject) -> EmacsInt {
-    buffer.as_buffer_or_current_buffer().char_modifications()
+pub fn buffer_chars_modified_tick(buffer: LispBufferOrCurrent) -> EmacsInt {
+    let buf = buffer.unwrap();
+    buf.char_modifications()
 }
 
 /// Return the position at which OVERLAY starts.
@@ -804,11 +802,9 @@ pub fn barf_if_buffer_read_only(position: Option<EmacsInt>) -> () {
 /// No such buffer error.
 #[no_mangle]
 pub extern "C" fn nsberror(spec: LispObject) -> ! {
-    let spec = spec;
-    if let Some(s) = spec.as_string() {
-        error!("No buffer named {}", s);
-    } else {
-        error!("Invalid buffer argument");
+    match spec.as_string() {
+        Some(s) => error!("No buffer named {}", s),
+        None => error!("Invalid buffer argument"),
     }
 }
 
@@ -824,13 +820,13 @@ pub extern "C" fn nsberror(spec: LispObject) -> ! {
 pub fn overlay_lists() -> LispObject {
     let list_overlays = |ol: LispOverlayRef| -> LispObject {
         ol.iter()
-            .fold(Qnil, |accum, n| unsafe { Fcons(n.as_lisp_obj(), accum) })
+            .fold(Qnil, |accum, n| LispObject::cons(n.as_lisp_obj(), accum))
     };
 
     let cur_buf = ThreadState::current_buffer();
     let before = cur_buf.overlays_before().map_or(Qnil, &list_overlays);
     let after = cur_buf.overlays_after().map_or(Qnil, &list_overlays);
-    unsafe { Fcons(Fnreverse(before), Fnreverse(after)) }
+    unsafe { LispObject::cons(Fnreverse(before), Fnreverse(after)) }
 }
 
 fn get_truename_buffer_1(filename: LispObject) -> LispObject {
@@ -842,7 +838,6 @@ fn get_truename_buffer_1(filename: LispObject) -> LispObject {
         .into()
 }
 
-// to be removed once all references in C are ported
 #[no_mangle]
 pub extern "C" fn get_truename_buffer(filename: LispObject) -> LispObject {
     get_truename_buffer_1(filename)
@@ -936,8 +931,9 @@ pub fn buffer_local_value_lisp(variable: LispObject, buffer: LispObject) -> Lisp
 /// If BUFFER is not indirect, return nil.
 /// BUFFER defaults to the current buffer.
 #[lisp_fn(min = "0")]
-pub fn buffer_base_buffer(buffer: LispObject) -> Option<LispBufferRef> {
-    buffer.as_buffer_or_current_buffer().base_buffer()
+pub fn buffer_base_buffer(buffer: LispBufferOrCurrent) -> Option<LispBufferRef> {
+    let buf = buffer.unwrap();
+    buf.base_buffer()
 }
 
 /// Force redisplay of the current buffer's mode line and header line.
@@ -945,9 +941,9 @@ pub fn buffer_base_buffer(buffer: LispObject) -> Option<LispBufferRef> {
 /// header lines.  This function also forces recomputation of the
 /// menu bar menus and the frame title.
 #[lisp_fn(min = "0")]
-pub fn force_mode_line_update(all: LispObject) -> LispObject {
+pub fn force_mode_line_update(all: bool) -> bool {
     let mut current_buffer = ThreadState::current_buffer();
-    if all.is_not_nil() {
+    if all {
         unsafe {
             update_mode_lines = 10;
         }
@@ -1013,8 +1009,8 @@ pub fn delete_overlay(overlay: LispObject) {
 /// Delete all overlays of BUFFER.
 /// BUFFER omitted or nil means delete all overlays of the current buffer.
 #[lisp_fn(min = "0", name = "delete-all-overlays")]
-pub fn delete_all_overlays_lisp(buffer: LispObject) {
-    unsafe { delete_all_overlays(buffer.as_buffer_or_current_buffer().as_mut()) };
+pub fn delete_all_overlays_lisp(buffer: LispBufferOrCurrent) {
+    unsafe { delete_all_overlays(buffer.unwrap().as_mut()) };
 }
 
 /// Delete the entire contents of the current buffer.

--- a/rust_src/src/category.rs
+++ b/rust_src/src/category.rs
@@ -1,6 +1,7 @@
 //! Routines to deal with category tables.
 
 use crate::{
+    chartable::LispCharTableRef,
     lisp::{defsubr, LispObject},
     remacs_sys::Qcategory_table,
     threads::ThreadState,
@@ -10,9 +11,8 @@ use remacs_macros::lisp_fn;
 
 /// Return t if ARG is a category table.
 #[lisp_fn]
-pub fn category_table_p(arg: LispObject) -> bool {
-    arg.as_char_table()
-        .map_or(false, |table| table.purpose.eq(Qcategory_table))
+pub fn category_table_p(arg: Option<LispCharTableRef>) -> bool {
+    arg.map_or(false, |table| table.purpose.eq(Qcategory_table))
 }
 
 /// Return the current category table.


### PR DESCRIPTION
Add a unchecked tails and cars iterator which directly maps to
```
while CONSP(obj)
  {
    // use obj
    obj = XCDR(obj);
  }
```