### PR TITLE
Remove exported C 'find_field'. Replace with updated Rust version.

### DIFF
--- a/rust_src/src/editfns.rs
+++ b/rust_src/src/editfns.rs
@@ -566,7 +566,7 @@ pub fn field_beginning(
     escape_from_edge: bool,
     limit: Option<EmacsInt>,
 ) -> EmacsInt {
-    let (beg, _) = find_field(pos.map(LispNumber::from), escape_from_edge, limit, None);
+    let (beg, _) = find_field(pos, escape_from_edge, limit, None);
 
     beg as EmacsInt
 }
@@ -584,7 +584,7 @@ pub fn field_end(
     escape_from_edge: bool,
     limit: Option<EmacsInt>,
 ) -> EmacsInt {
-    let (_, end) = find_field(pos.map(LispNumber::from), escape_from_edge, None, limit);
+    let (_, end) = find_field(pos, escape_from_edge, None, limit);
 
     end as EmacsInt
 }
@@ -1027,13 +1027,13 @@ pub fn save_restriction(body: LispObject) -> LispObject {
 // finding the beginning and ending of the "merged" field.
 
 pub fn find_field(
-    pos: Option<LispNumber>,
+    pos: Option<EmacsInt>,
     merge_at_boundary: bool,
     beg_limit: Option<EmacsInt>,
     end_limit: Option<EmacsInt>,
 ) -> (ptrdiff_t, ptrdiff_t) {
     let current_buffer = ThreadState::current_buffer();
-    let pos = pos.map_or(current_buffer.pt, |p| p.to_fixnum() as isize);
+    let pos = pos.unwrap_or(current_buffer.pt) as isize;
 
     // Fields right before and after the point.
     let after_field =
@@ -1138,8 +1138,8 @@ pub fn find_field(
 /// A field is a region of text with the same `field' property.
 /// If POS is nil, the value of point is used for POS.
 #[lisp_fn(min = "0")]
-pub fn delete_field(pos: LispNumber) {
-    let (beg, end) = find_field(Some(pos), false, None, None);
+pub fn delete_field(pos: Option<EmacsInt>) {
+    let (beg, end) = find_field(pos, false, None, None);
     if beg != end {
         unsafe { del_range(beg, end) };
     }
@@ -1149,8 +1149,8 @@ pub fn delete_field(pos: LispNumber) {
 /// A field is a region of text with the same `field' property.
 /// If POS is nil, the value of point is used for POS.
 #[lisp_fn(min = "0")]
-pub fn field_string(pos: LispNumber) -> LispObject {
-    let (beg, end) = find_field(Some(pos), false, None, None);
+pub fn field_string(pos: Option<EmacsInt>) -> LispObject {
+    let (beg, end) = find_field(pos, false, None, None);
     unsafe { make_buffer_string(beg, end, true) }
 }
 
@@ -1158,8 +1158,8 @@ pub fn field_string(pos: LispNumber) -> LispObject {
 /// A field is a region of text with the same `field' property.
 /// If POS is nil, the value of point is used for POS.
 #[lisp_fn(min = "0")]
-pub fn field_string_no_properties(pos: LispNumber) -> LispObject {
-    let (beg, end) = find_field(Some(pos), false, None, None);
+pub fn field_string_no_properties(pos: Option<EmacsInt>) -> LispObject {
+    let (beg, end) = find_field(pos, false, None, None);
     unsafe { make_buffer_string(beg, end, false) }
 }
 

--- a/rust_src/src/editfns.rs
+++ b/rust_src/src/editfns.rs
@@ -1033,12 +1033,12 @@ pub fn find_field(
     end_limit: Option<EmacsInt>,
 ) -> (ptrdiff_t, ptrdiff_t) {
     let current_buffer = ThreadState::current_buffer();
-    let pos = pos.map_or(current_buffer.pt as EmacsInt, |p| p.to_fixnum());
+    let pos = pos.map_or(current_buffer.pt, |p| p.to_fixnum() as ptrdiff_t);
 
     // Fields right before and after the point.
     let after_field =
         unsafe { get_char_property_and_overlay(pos.into(), Qfield, Qnil, ptr::null_mut()) };
-    let before_field = if pos > current_buffer.begv as EmacsInt {
+    let before_field = if pos > current_buffer.begv {
         unsafe { get_char_property_and_overlay((pos - 1).into(), Qfield, Qnil, ptr::null_mut()) }
     } else {
         // Using nil here would be a more obvious choice, but it would
@@ -1101,7 +1101,7 @@ pub fn find_field(
         let beg = if at_field_start {
             // POS is at the edge of a field, and we should consider it as
             // the beginning of the following field.
-            pos as isize
+            pos
         } else {
             let mut p = pos.into();
             let limit = beg_limit.into();
@@ -1117,7 +1117,7 @@ pub fn find_field(
         let end = if at_field_end {
             // POS is at the edge of a field, and we should consider it as
             // the end of the previous field.
-            pos as isize
+            pos
         } else {
             let mut p = pos.into();
             let limit = end_limit.into();

--- a/rust_src/src/editfns.rs
+++ b/rust_src/src/editfns.rs
@@ -1033,7 +1033,7 @@ pub fn find_field(
     end_limit: Option<EmacsInt>,
 ) -> (ptrdiff_t, ptrdiff_t) {
     let current_buffer = ThreadState::current_buffer();
-    let pos = pos.unwrap_or(current_buffer.pt) as isize;
+    let pos = pos.unwrap_or(current_buffer.pt as EmacsInt);
 
     // Fields right before and after the point.
     let after_field =
@@ -1101,7 +1101,7 @@ pub fn find_field(
         let beg = if at_field_start {
             // POS is at the edge of a field, and we should consider it as
             // the beginning of the following field.
-            pos
+            pos as isize
         } else {
             let mut p = pos.into();
             let limit = beg_limit.into();
@@ -1117,7 +1117,7 @@ pub fn find_field(
         let end = if at_field_end {
             // POS is at the edge of a field, and we should consider it as
             // the end of the previous field.
-            pos
+            pos as isize
         } else {
             let mut p = pos.into();
             let limit = end_limit.into();

--- a/rust_src/src/editfns.rs
+++ b/rust_src/src/editfns.rs
@@ -1038,7 +1038,7 @@ pub fn find_field(
     // Fields right before and after the point.
     let after_field =
         unsafe { get_char_property_and_overlay(pos.into(), Qfield, Qnil, ptr::null_mut()) };
-    let before_field = if pos > current_buffer.begv {
+    let before_field = if pos > current_buffer.begv as EmacsInt {
         unsafe { get_char_property_and_overlay((pos - 1).into(), Qfield, Qnil, ptr::null_mut()) }
     } else {
         // Using nil here would be a more obvious choice, but it would

--- a/rust_src/src/editfns.rs
+++ b/rust_src/src/editfns.rs
@@ -683,10 +683,11 @@ pub fn constrain_to_field(
     // It is possible that NEW_POS is not within the same field as
     // OLD_POS; try to move NEW_POS so that it is.
     {
+        let tmp: LispNumber = old_pos.into();
         let field_bound = if fwd {
-            field_end(Some(old_pos), escape_from_edge, Some(new_pos))
+            field_end(Some(tmp), escape_from_edge, Some(new_pos))
         } else {
-            field_beginning(Some(old_pos), escape_from_edge, Some(new_pos))
+            field_beginning(Some(tmp), escape_from_edge, Some(new_pos))
         };
 
         let should_constrain = if field_bound < new_pos { fwd } else { !fwd };

--- a/rust_src/src/editfns.rs
+++ b/rust_src/src/editfns.rs
@@ -562,7 +562,7 @@ pub fn line_end_position(n: Option<EmacsInt>) -> EmacsInt {
 /// is before LIMIT, then LIMIT will be returned instead.
 #[lisp_fn(min = "0")]
 pub fn field_beginning(
-    pos: Option<EmacsInt>,
+    pos: Option<LispNumber>,
     escape_from_edge: bool,
     limit: Option<EmacsInt>,
 ) -> EmacsInt {
@@ -580,7 +580,7 @@ pub fn field_beginning(
 /// is after LIMIT, then LIMIT will be returned instead.
 #[lisp_fn(min = "0")]
 pub fn field_end(
-    pos: Option<EmacsInt>,
+    pos: Option<LispNumber>,
     escape_from_edge: bool,
     limit: Option<EmacsInt>,
 ) -> EmacsInt {
@@ -1027,13 +1027,13 @@ pub fn save_restriction(body: LispObject) -> LispObject {
 // finding the beginning and ending of the "merged" field.
 
 pub fn find_field(
-    pos: Option<EmacsInt>,
+    pos: Option<LispNumber>,
     merge_at_boundary: bool,
     beg_limit: Option<EmacsInt>,
     end_limit: Option<EmacsInt>,
 ) -> (ptrdiff_t, ptrdiff_t) {
     let current_buffer = ThreadState::current_buffer();
-    let pos = pos.unwrap_or(current_buffer.pt as EmacsInt);
+    let pos = pos.map_or(current_buffer.pt as EmacsInt, |p| p.to_fixnum());
 
     // Fields right before and after the point.
     let after_field =
@@ -1138,7 +1138,7 @@ pub fn find_field(
 /// A field is a region of text with the same `field' property.
 /// If POS is nil, the value of point is used for POS.
 #[lisp_fn(min = "0")]
-pub fn delete_field(pos: Option<EmacsInt>) {
+pub fn delete_field(pos: Option<LispNumber>) {
     let (beg, end) = find_field(pos, false, None, None);
     if beg != end {
         unsafe { del_range(beg, end) };
@@ -1149,7 +1149,7 @@ pub fn delete_field(pos: Option<EmacsInt>) {
 /// A field is a region of text with the same `field' property.
 /// If POS is nil, the value of point is used for POS.
 #[lisp_fn(min = "0")]
-pub fn field_string(pos: Option<EmacsInt>) -> LispObject {
+pub fn field_string(pos: Option<LispNumber>) -> LispObject {
     let (beg, end) = find_field(pos, false, None, None);
     unsafe { make_buffer_string(beg, end, true) }
 }
@@ -1158,7 +1158,7 @@ pub fn field_string(pos: Option<EmacsInt>) -> LispObject {
 /// A field is a region of text with the same `field' property.
 /// If POS is nil, the value of point is used for POS.
 #[lisp_fn(min = "0")]
-pub fn field_string_no_properties(pos: Option<EmacsInt>) -> LispObject {
+pub fn field_string_no_properties(pos: Option<LispNumber>) -> LispObject {
     let (beg, end) = find_field(pos, false, None, None);
     unsafe { make_buffer_string(beg, end, false) }
 }

--- a/rust_src/src/minibuf.rs
+++ b/rust_src/src/minibuf.rs
@@ -82,7 +82,7 @@ pub fn minibuffer_prompt_end() -> EmacsInt {
         return beg;
     }
 
-    let end = field_end(Some(beg), false, None);
+    let end = field_end(Some(beg.into()), false, None);
     let buffer_end = buffer.zv as EmacsInt;
     if end == buffer_end && get_char_property(beg, Qfield, Qnil).is_nil() {
         beg

--- a/src/editfns.c
+++ b/src/editfns.c
@@ -460,41 +460,6 @@ at POSITION.  */)
 }
 
 
-DEFUN ("delete-field", Fdelete_field, Sdelete_field, 0, 1, 0,
-       doc: /* Delete the field surrounding POS.
-A field is a region of text with the same `field' property.
-If POS is nil, the value of point is used for POS.  */)
-  (Lisp_Object pos)
-{
-  ptrdiff_t beg, end;
-  find_field (pos, Qnil, Qnil, &beg, Qnil, &end);
-  if (beg != end)
-    del_range (beg, end);
-  return Qnil;
-}
-
-DEFUN ("field-string", Ffield_string, Sfield_string, 0, 1, 0,
-       doc: /* Return the contents of the field surrounding POS as a string.
-A field is a region of text with the same `field' property.
-If POS is nil, the value of point is used for POS.  */)
-  (Lisp_Object pos)
-{
-  ptrdiff_t beg, end;
-  find_field (pos, Qnil, Qnil, &beg, Qnil, &end);
-  return make_buffer_string (beg, end, 1);
-}
-
-DEFUN ("field-string-no-properties", Ffield_string_no_properties, Sfield_string_no_properties, 0, 1, 0,
-       doc: /* Return the contents of the field around POS, without text properties.
-A field is a region of text with the same `field' property.
-If POS is nil, the value of point is used for POS.  */)
-  (Lisp_Object pos)
-{
-  ptrdiff_t beg, end;
-  find_field (pos, Qnil, Qnil, &beg, Qnil, &end);
-  return make_buffer_string (beg, end, 0);
-}
-
 
 /* Restore saved buffer before leaving `save-excursion' special form.  */
 
@@ -4083,10 +4048,6 @@ functions if all the text being accessed has this property.  */);
 
   /* A special value for Qfield properties.  */
   DEFSYM (Qboundary, "boundary");
-
-  defsubr (&Sfield_string);
-  defsubr (&Sfield_string_no_properties);
-  defsubr (&Sdelete_field);
 
   defsubr (&Sinsert);
   defsubr (&Sinsert_before_markers);


### PR DESCRIPTION
Return a tuple instead of using C style pointer returns.