### PR TITLE
Allow unsafe in functions.

### DIFF
--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::cyclomatic_complexity)]
 #![allow(clippy::wrong_self_convention)]
 #![allow(clippy::too_many_arguments)]
+#![allow(clippy::not_unsafe_ptr_arg_deref)]
 #![feature(const_fn)]
 #![allow(non_upper_case_globals)]
 #![allow(non_snake_case)]


### PR DESCRIPTION
This resolves the clippy failure.