### PR TITLE
Port `window-new-normal` to Rust

### DIFF
--- a/rust_src/src/windows.rs
+++ b/rust_src/src/windows.rs
@@ -1058,6 +1058,18 @@ pub fn scroll_down(arg: LispObject) {
     unsafe { scroll_command(arg, -1) };
 }
 
+/// Return new normal size of window WINDOW.
+/// WINDOW must be a valid window and defaults to the selected one.
+///
+/// The new normal size of WINDOW is the value set by the last call of
+/// `set-window-new-normal' for WINDOW.  If valid, it will be shortly
+/// installed as WINDOW's normal size (see `window-normal-size').
+#[lisp_fn(min = "0")]
+pub fn window_new_normal(window: LispWindowValidOrSelected) -> LispObject {
+    let win: LispWindowRef = window.into();
+    win.new_normal
+}
+
 /// Return the new total size of window WINDOW.
 /// WINDOW must be a valid window and defaults to the selected one.
 ///

--- a/src/window.c
+++ b/src/window.c
@@ -510,18 +510,6 @@ re-enlarged to its previous size.  */)
   return NILP (horizontal) ? w->normal_lines : w->normal_cols;
 }
 
-DEFUN ("window-new-normal", Fwindow_new_normal, Swindow_new_normal, 0, 1, 0,
-       doc: /* Return new normal size of window WINDOW.
-WINDOW must be a valid window and defaults to the selected one.
-
-The new normal size of WINDOW is the value set by the last call of
-`set-window-new-normal' for WINDOW.  If valid, it will be shortly
-installed as WINDOW's normal size (see `window-normal-size').  */)
-  (Lisp_Object window)
-{
-  return decode_valid_window (window)->new_normal;
-}
-
 DEFUN ("window-new-pixel", Fwindow_new_pixel, Swindow_new_pixel, 0, 1, 0,
        doc: /* Return new pixel size of window WINDOW.
 WINDOW must be a valid window and defaults to the selected one.
@@ -6896,8 +6884,7 @@ displayed after a scrolling operation to be somewhat inaccurate.  */);
   defsubr (&Swindow_pixel_width_before_size_change);
   defsubr (&Swindow_pixel_height_before_size_change);
   defsubr (&Swindow_normal_size);
-  defsubr (&Swindow_new_pixel);
-  defsubr (&Swindow_new_normal);
+  defsubr (&Swindow_new_pixel); 
   defsubr (&Swindow_pixel_left);
   defsubr (&Swindow_pixel_top);
   defsubr (&Swindow_left_column);

--- a/test/rust_src/src/windows-tests.el
+++ b/test/rust_src/src/windows-tests.el
@@ -43,10 +43,25 @@
   (should (eq (window-new-total (selected-window)) (window-total-height))))
 
 (ert-deftest window-new-normal ()
+  "Effectively tests both `window-new-normal' (the getter) and
+`set-window-new-normal' (the setter)."
+  ;; Can we change normal on this window?
   (set-window-new-normal nil 1.0)
   (should (= (window-new-normal) 1.0))
   (set-window-new-normal nil 0.23)
-  (should (= (window-new-normal) 0.23)))
+  (should (= (window-new-normal) 0.23))
+
+  ;; Can we correctly get the value of a different window?
+  (let ((current-window-expected-normal 1.0)
+        (other-window-expected-normal 0.5)
+        (current-window (selected-window))
+        (other-window (split-window)))
+    (set-window-new-normal current-window current-window-expected-normal)
+    (set-window-new-normal other-window other-window-expected-normal)
+    ;; Normal for current-window should be the same
+    (should (= (window-new-normal) current-window-expected-normal))
+    (select-window other-window)
+    (should (= (window-new-normal) other-window-expected-normal))))
 
 (ert-deftest window-use-time ()
   (let ((use-time (window-use-time)))

--- a/test/rust_src/src/windows-tests.el
+++ b/test/rust_src/src/windows-tests.el
@@ -42,6 +42,12 @@
   (should (eq (window-new-total) (window-total-height)))
   (should (eq (window-new-total (selected-window)) (window-total-height))))
 
+(ert-deftest window-new-normal ()
+  (set-window-new-normal nil 1.0)
+  (should (= (window-new-normal) 1.0))
+  (set-window-new-normal nil 0.23)
+  (should (= (window-new-normal) 0.23)))
+
 (ert-deftest window-use-time ()
   (let ((use-time (window-use-time)))
     (should (eq 'integer (type-of use-time)))

--- a/test/rust_src/src/windows-tests.el
+++ b/test/rust_src/src/windows-tests.el
@@ -61,7 +61,9 @@
     ;; Normal for current-window should be the same
     (should (= (window-new-normal) current-window-expected-normal))
     (select-window other-window)
-    (should (= (window-new-normal) other-window-expected-normal))))
+    (should (= (window-new-normal) other-window-expected-normal))
+    (delete-window other-window)
+    ))
 
 (ert-deftest window-use-time ()
   (let ((use-time (window-use-time)))


### PR DESCRIPTION
Commit includes a Rust implementation of `window-new-normal`, removal
of the old C function and defsubr for same, and a test to assure
`windows-new-normal` correctly returns the value set by
`set-window-new-normal`.

Closes #1048