### PR TITLE
Run rustfmt on windows.rs

### DIFF
--- a/rust_src/src/windows.rs
+++ b/rust_src/src/windows.rs
@@ -180,12 +180,11 @@ impl LispWindowRef {
             && !self.is_minibuffer()
             && !self.is_pseudo()
             && !window_mode_line_format.eq(Qnone)
-            && (window_mode_line_format.is_not_nil()
-                || self
-                    .contents
-                    .as_buffer_or_error()
-                    .mode_line_format_
-                    .is_not_nil())
+            && (window_mode_line_format.is_not_nil() || self
+                .contents
+                .as_buffer_or_error()
+                .mode_line_format_
+                .is_not_nil())
             && self.pixel_height > self.frame.as_frame_or_error().line_height
     }
 


### PR DESCRIPTION
I was porting a function in a different PR, and noticed `rustfmt` wanted to make changes outside the scope of the function I was porting. So! Here's a whitespace-and-minor-formats-only PR. 