### PR TITLE
Port misc equal to Rust.

### DIFF
--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -158,6 +158,24 @@ impl LispMiscRef {
     pub fn get_type(self) -> Lisp_Misc_Type {
         self.type_()
     }
+
+    pub fn equal(
+        self,
+        other: LispMiscRef,
+        kind: equal_kind::Type,
+        depth: i32,
+        ht: LispObject,
+    ) -> bool {
+        if self.get_type() != other.get_type() {
+            false
+        } else if let (Some(ov1), Some(ov2)) = (self.as_overlay(), other.as_overlay()) {
+            ov1.equal(ov2, kind, depth, ht)
+        } else if let (Some(marker1), Some(marker2)) = (self.as_marker(), other.as_marker()) {
+            marker1.equal(marker2, kind, depth, ht)
+        } else {
+            false
+        }
+    }
 }
 
 impl LispObject {

--- a/rust_src/src/marker.rs
+++ b/rust_src/src/marker.rs
@@ -8,10 +8,10 @@ use remacs_macros::lisp_fn;
 
 use crate::{
     buffers::{current_buffer, LispBufferRef},
-    lisp::{defsubr, ExternalPtr, LispObject},
+    lisp::{defsubr, ExternalPtr, LispMiscRef, LispObject},
     multibyte::multibyte_chars_in_text,
     remacs_sys::{allocate_misc, set_point_both, Fmake_marker},
-    remacs_sys::{EmacsInt, Lisp_Buffer, Lisp_Marker, Lisp_Misc_Type},
+    remacs_sys::{equal_kind, EmacsInt, Lisp_Buffer, Lisp_Marker, Lisp_Misc_Type},
     remacs_sys::{Qinteger_or_marker_p, Qmarkerp, Qnil},
     threads::ThreadState,
     util::clip_to_bounds,
@@ -87,6 +87,16 @@ impl LispMarkerRef {
     pub fn set_next(mut self, m: *mut Lisp_Marker) {
         self.next = m;
     }
+
+    pub fn equal(
+        self,
+        other: LispMarkerRef,
+        _kind: equal_kind::Type,
+        _depth: i32,
+        _ht: LispObject,
+    ) -> bool {
+        self.buffer == other.buffer && (self.buffer.is_null() || self.bytepos == other.bytepos)
+    }
 }
 
 impl From<LispObject> for LispMarkerRef {
@@ -114,18 +124,22 @@ impl LispObject {
     }
 
     pub fn as_marker(self) -> Option<LispMarkerRef> {
-        self.as_misc().and_then(|m| {
-            if m.get_type() == Lisp_Misc_Type::Lisp_Misc_Marker {
-                unsafe { Some(mem::transmute(m)) }
-            } else {
-                None
-            }
-        })
+        self.as_misc().and_then(|m| m.as_marker())
     }
 
     pub fn as_marker_or_error(self) -> LispMarkerRef {
         self.as_marker()
             .unwrap_or_else(|| wrong_type!(Qmarkerp, self))
+    }
+}
+
+impl LispMiscRef {
+    pub fn as_marker(self) -> Option<LispMarkerRef> {
+        if self.get_type() == Lisp_Misc_Type::Lisp_Misc_Marker {
+            unsafe { Some(mem::transmute(self)) }
+        } else {
+            None
+        }
     }
 }
 

--- a/rust_src/src/marker.rs
+++ b/rust_src/src/marker.rs
@@ -95,7 +95,13 @@ impl LispMarkerRef {
         _depth: i32,
         _ht: LispObject,
     ) -> bool {
-        self.buffer == other.buffer && (self.buffer.is_null() || self.bytepos == other.bytepos)
+        if self.buffer != other.buffer {
+            false
+        } else if self.buffer.is_null() {
+            true
+        } else {
+            self.bytepos == other.bytepos
+        }
     }
 }
 

--- a/rust_src/src/multibyte.rs
+++ b/rust_src/src/multibyte.rs
@@ -41,8 +41,8 @@ use libc::{c_char, c_int, c_uchar, c_uint, c_void, memset, ptrdiff_t, size_t};
 use crate::{
     lisp::{ExternalPtr, LispObject},
     remacs_sys::Qstringp,
-    remacs_sys::{char_bits, EmacsDouble, EmacsInt, Lisp_String, Lisp_Type},
-    remacs_sys::{emacs_abort, empty_unibyte_string},
+    remacs_sys::{char_bits, equal_kind, EmacsDouble, EmacsInt, Lisp_String, Lisp_Type},
+    remacs_sys::{compare_string_intervals, emacs_abort, empty_unibyte_string},
 };
 
 pub type LispStringRef = ExternalPtr<Lisp_String>;
@@ -165,6 +165,20 @@ impl LispStringRef {
 
     pub fn set_byte(&mut self, idx: ptrdiff_t, elt: c_uchar) {
         unsafe { ptr::write(self.data_ptr().offset(idx), elt) };
+    }
+
+    pub fn equal(
+        self,
+        other: LispStringRef,
+        kind: equal_kind::Type,
+        depth: i32,
+        ht: LispObject,
+    ) -> bool {
+        self.len_chars() == other.len_chars()
+            && self.len_bytes() == other.len_bytes()
+            && self.as_slice() == other.as_slice()
+            && (kind != equal_kind::EQUAL_INCLUDING_PROPERTIES
+                || unsafe { compare_string_intervals(self.into(), other.into()) })
     }
 }
 

--- a/rust_src/src/multibyte.rs
+++ b/rust_src/src/multibyte.rs
@@ -171,8 +171,8 @@ impl LispStringRef {
         self,
         other: LispStringRef,
         kind: equal_kind::Type,
-        depth: i32,
-        ht: LispObject,
+        _depth: i32,
+        _ht: LispObject,
     ) -> bool {
         self.len_chars() == other.len_chars()
             && self.len_bytes() == other.len_bytes()

--- a/src/fns.c
+++ b/src/fns.c
@@ -1414,27 +1414,7 @@ internal_equal (Lisp_Object o1, Lisp_Object o2, enum equal_kind equal_kind,
       goto tail_recurse;
 
     case Lisp_Misc:
-      if (XMISCTYPE (o1) != XMISCTYPE (o2))
-	return false;
-      if (OVERLAYP (o1))
-	{
-	  if (!internal_equal (OVERLAY_START (o1), OVERLAY_START (o2),
-			       equal_kind, depth + 1, ht)
-	      || !internal_equal (OVERLAY_END (o1), OVERLAY_END (o2),
-				  equal_kind, depth + 1, ht))
-	    return false;
-	  o1 = XOVERLAY (o1)->plist;
-	  o2 = XOVERLAY (o2)->plist;
-	  depth++;
-	  goto tail_recurse;
-	}
-      if (MARKERP (o1))
-	{
-	  return (XMARKER (o1)->buffer == XMARKER (o2)->buffer
-		  && (XMARKER (o1)->buffer == 0
-		      || XMARKER (o1)->bytepos == XMARKER (o2)->bytepos));
-	}
-      break;
+      return internal_equal_misc(o1, o2,  equal_kind, depth, ht);
 
     case Lisp_Vectorlike:
       {

--- a/src/fns.c
+++ b/src/fns.c
@@ -1465,7 +1465,7 @@ internal_equal (Lisp_Object o1, Lisp_Object o2, enum equal_kind equal_kind,
       break;
 
     case Lisp_String:
-      return internal_equal_string(o1, o2, equal_kind);
+      return internal_equal_string(o1, o2, equal_kind, depth, ht);
 
     default:
       break;

--- a/src/lisp.h
+++ b/src/lisp.h
@@ -4897,7 +4897,8 @@ void do_debug_on_call (Lisp_Object code, ptrdiff_t count);
 
 enum equal_kind { EQUAL_NO_QUIT, EQUAL_PLAIN, EQUAL_INCLUDING_PROPERTIES };
 extern bool internal_equal (Lisp_Object, Lisp_Object, enum equal_kind, int, Lisp_Object);
-extern bool internal_equal_string (Lisp_Object, Lisp_Object, enum equal_kind);
+extern bool internal_equal_misc (Lisp_Object, Lisp_Object, enum equal_kind, int, Lisp_Object);
+extern bool internal_equal_string (Lisp_Object, Lisp_Object, enum equal_kind, int, Lisp_Object);
 
 INLINE_HEADER_END
 


### PR DESCRIPTION
Move to local equal methods. Add `equal` for Overlay and Marker.

`LispMarkerRef` now owns the transition to its subtypes similar to how `LispVectorlike` works. The original `LispObject` calls still exist but they delegate down.