### PR TITLE
Port unwind-protect, minor changes

### DIFF
--- a/rust_src/admin/rustize-emacs
+++ b/rust_src/admin/rustize-emacs
@@ -30,6 +30,8 @@ def build_lisp_fn_args(min_args=None, max_args=None, intspec=None,
     pieces = []
     if min_args != max_args and max_args != 'MANY':
         pieces.append(('min', min_args))
+    if max_args == 'UNEVALLED':
+        pieces.append(('unevalled', 'true'))
     if intspec is not None:
         pieces.append(('intspec', intspec))
     if lisp_name != func_name.replace('_', '-'):
@@ -126,7 +128,7 @@ pub extern "C" fn {name}({args}){return}
 
 
 def parse_c_definition(c_code):
-    defun_regex = re.compile(r'''^\s*DEFUN\s+\("(?P<lisp_name>[^"]+)",\s+F(?P<func_name>\w+),\s+S\w+,\s+(?P<min_args>\d),\s+(?P<max_args>\d),\s+(?P<intspec>0|"[^"]*"),
+    defun_regex = re.compile(r'''^\s*DEFUN\s+\("(?P<lisp_name>[^"]+)",\s+F(?P<func_name>\w+),\s+S\w+,\s+(?P<min_args>\d),\s+(?P<max_args>[^,]+),\s+(?P<intspec>0|"[^"]*"),
 \s+doc:\s+/\*\s+(?P<docstring>.+)\*/\s*.*\)
 \s*\((?P<func_args>[^\)]+)\)
 (?P<code>.+)''', re.DOTALL)

--- a/rust_src/src/eval.rs
+++ b/rust_src/src/eval.rs
@@ -140,8 +140,8 @@ pub extern "C" fn prog_ignore(body: LispObject) {
 /// whose values are discarded.
 /// usage: (prog1 FIRST BODY...)
 #[lisp_fn(min = "1", unevalled = "true")]
-pub fn prog1(args: LispObject) -> LispObject {
-    let (first, body) = args.as_cons_or_error().as_tuple();
+pub fn prog1(args: LispCons) -> LispObject {
+    let (first, body) = args.as_tuple();
 
     let val = unsafe { eval_sub(first) };
     progn(body);
@@ -153,11 +153,11 @@ pub fn prog1(args: LispObject) -> LispObject {
 /// remaining args, whose values are discarded.
 /// usage: (prog2 FORM1 FORM2 BODY...)
 #[lisp_fn(min = "2", unevalled = "true")]
-pub fn prog2(args: LispObject) -> LispObject {
-    let (form1, tail) = args.as_cons_or_error().as_tuple();
+pub fn prog2(args: LispCons) -> LispObject {
+    let (form1, tail) = args.as_tuple();
 
     unsafe { eval_sub(form1) };
-    prog1(tail)
+    prog1(tail.as_cons_or_error())
 }
 
 /// Set each SYM to the value of its VAL.
@@ -293,8 +293,8 @@ pub fn special_variable_p(symbol: LispSymbolRef) -> bool {
 /// The optional DOCSTRING specifies the variable's documentation string.
 /// usage: (defconst SYMBOL INITVALUE [DOCSTRING])
 #[lisp_fn(min = "2", unevalled = "true")]
-pub fn defconst(args: LispObject) -> LispSymbolRef {
-    let (sym, tail) = args.as_cons_or_error().as_tuple();
+pub fn defconst(args: LispCons) -> LispSymbolRef {
+    let (sym, tail) = args.as_tuple();
 
     let mut docstring = if cdr(tail).is_not_nil() {
         if cdr(cdr(tail)).is_not_nil() {
@@ -306,7 +306,7 @@ pub fn defconst(args: LispObject) -> LispSymbolRef {
         Qnil
     };
 
-    let mut tem = unsafe { eval_sub(car(cdr(args))) };
+    let mut tem = unsafe { eval_sub(car(tail)) };
     if unsafe { globals.Vpurify_flag } != Qnil {
         tem = unsafe { Fpurecopy(tem) };
     }

--- a/rust_src/src/eval.rs
+++ b/rust_src/src/eval.rs
@@ -1141,4 +1141,19 @@ pub extern "C" fn unbind_to(count: libc::ptrdiff_t, value: LispObject) -> LispOb
     value
 }
 
+/// Do BODYFORM, protecting with UNWINDFORMS.
+/// If BODYFORM completes normally, its value is returned
+/// after executing the UNWINDFORMS.
+/// If BODYFORM exits nonlocally, the UNWINDFORMS are executed anyway.
+/// usage: (unwind-protect BODYFORM UNWINDFORMS...)
+#[lisp_fn(min = "1", unevalled = "true")]
+pub fn unwind_protect(args: LispCons) -> LispObject {
+    let (bodyform, unwindforms) = args.as_tuple();
+    let count = c_specpdl_index();
+
+    unsafe { record_unwind_protect(Some(prog_ignore), unwindforms) };
+
+    unbind_to(count, unsafe { eval_sub(bodyform) })
+}
+
 include!(concat!(env!("OUT_DIR"), "/eval_exports.rs"));

--- a/src/eval.c
+++ b/src/eval.c
@@ -671,23 +671,6 @@ Both TAG and VALUE are evalled.  */
       }
   xsignal2 (Qno_catch, tag, value);
 }
-
-
-DEFUN ("unwind-protect", Funwind_protect, Sunwind_protect, 1, UNEVALLED, 0,
-       doc: /* Do BODYFORM, protecting with UNWINDFORMS.
-If BODYFORM completes normally, its value is returned
-after executing the UNWINDFORMS.
-If BODYFORM exits nonlocally, the UNWINDFORMS are executed anyway.
-usage: (unwind-protect BODYFORM UNWINDFORMS...)  */)
-  (Lisp_Object args)
-{
-  Lisp_Object val;
-  ptrdiff_t count = SPECPDL_INDEX ();
-
-  record_unwind_protect (prog_ignore, XCDR (args));
-  val = eval_sub (XCAR (args));
-  return unbind_to (count, val);
-}
 
 DEFUN ("condition-case", Fcondition_case, Scondition_case, 2, UNEVALLED, 0,
        doc: /* Regain control when an error is signaled.
@@ -3196,7 +3179,6 @@ alist of active lexical bindings.  */);
   DEFSYM (Qdefvaralias, "defvaralias");
   defsubr (&Scatch);
   defsubr (&Sthrow);
-  defsubr (&Sunwind_protect);
   defsubr (&Scondition_case);
   defsubr (&Ssignal);
   defsubr (&Sapply);


### PR DESCRIPTION
This updates `rustize-emacs` to handle `UNEVALLED`, with `unwind-protect` as a test case. While porting, I noticed a few places where `LispObject` could be `LispCons`, so I updated those too.