### PR TITLE
Fix 'usage' in docstrings.

### DIFF
--- a/test/lib-src/make-docfile-tests.el
+++ b/test/lib-src/make-docfile-tests.el
@@ -1,0 +1,24 @@
+(require 'ert)
+
+(defun validate-fundoc (func expected)
+  (should (equal
+    (car (help-split-fundoc (documentation func) func))
+    expected)))
+
+(ert-deftest make-docfile-no-args-defun ()
+  (validate-fundoc 'current-buffer "(current-buffer)"))
+
+(ert-deftest make-docfile-optional-args-defun ()
+  (validate-fundoc 'buffer-list "(buffer-list &optional FRAME)")
+  (validate-fundoc 'set-frame-selected-window
+                   "(set-frame-selected-window FRAME WINDOW &optional NORECORD)"))
+
+(ert-deftest make-docfile-many-defun ()
+  (validate-fundoc 'funcall-interactively "(funcall-interactively FUNCTION &rest ARGUMENTS)")
+  (validate-fundoc 'message "(message FORMAT-STRING &rest ARGS)"))
+
+(ert-deftest make-docfile-simple-defun ()
+  (validate-fundoc 'set-buffer "(set-buffer BUFFER-OR-NAME)")
+  (validate-fundoc 'buffer-local-value "(buffer-local-value VARIABLE BUFFER)"))
+
+(provide 'make-docfile-tests)


### PR DESCRIPTION
Emacs stores the function usage without the function name like this:

    (fn foo &rest args)

When we find a function with an explicit `usage:` section we keep
the part after the function name.

If the function does not have usage we generate it.