### PR TITLE
Fix a broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ This code is so much better that it's hard to believe just how simple the implem
 # Contributing
 
 Pull requests welcome, no copyright assignment required. This project is under the
-[Rust code of conduct](https://www.rust-lang.org/en-US/conduct.html).
+[Rust code of conduct](https://www.rust-lang.org/policies/code-of-conduct).
 
 There's lots to do! We keep a list of [low hanging fruit](https://github.com/Wilfred/remacs/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) here so you can easily choose
 one. You can find information in the [Porting cookbook](https://github.com/Wilfred/remacs/wiki/Porting-cookbook) or ask for help in our gitter channel.


### PR DESCRIPTION
A link to Rust code of conduct in README.md seems to be broken, so fixed it.