### PR TITLE
Add clang-7 to list of dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ more Emacs-y.
 
         apt install texinfo libjpeg-dev libtiff-dev \
           libgif-dev libxpm-dev libgtk-3-dev libgnutls28-dev \
-          libncurses5-dev libxml2-dev libxt-dev
+          libncurses5-dev libxml2-dev libxt-dev clang-7
 
    macOS:
    

--- a/README.md
+++ b/README.md
@@ -138,14 +138,17 @@ more Emacs-y.
    This happens automatically, so don't override the toolchain manually.
 
 2. You will need a C compiler and toolchain. On Linux, you can do
-   something like `apt install build-essential automake clang`. On
-   macOS, you'll need Xcode.
+   something like:
+
+        apt install build-essential automake clang libclang-dev
+
+   On macOS, you'll need Xcode.
 
 3. Linux:
 
         apt install texinfo libjpeg-dev libtiff-dev \
           libgif-dev libxpm-dev libgtk-3-dev libgnutls28-dev \
-          libncurses5-dev libxml2-dev libxt-dev clang-7
+          libncurses5-dev libxml2-dev libxt-dev
 
    macOS:
    


### PR DESCRIPTION
This should prevent encountering any issues with a missing `stdbool.h`, as seen in issue #1140.