### PR TITLE
Port window-parameters

### DIFF
--- a/rust_src/src/windows.rs
+++ b/rust_src/src/windows.rs
@@ -15,6 +15,7 @@ use crate::{
     lists::{assq, setcdr},
     marker::{marker_position_lisp, set_marker_restricted},
     remacs_sys::globals,
+    remacs_sys::Fcopy_alist,
     remacs_sys::{
         estimate_mode_line_height, minibuf_level,
         minibuf_selected_window as current_minibuf_window, scroll_command, select_window,
@@ -1142,6 +1143,15 @@ pub fn select_window_lisp(window: LispObject, norecord: LispObject) -> LispObjec
 pub fn window_top_line(window: LispWindowValidOrSelected) -> EmacsInt {
     let win: LispWindowRef = window.into();
     EmacsInt::from(win.top_line)
+}
+
+/// Return the parameters of WINDOW and their values.
+/// WINDOW must be a valid window and defaults to the selected one.  The
+/// return value is a list of elements of the form (PARAMETER . VALUE).
+#[lisp_fn(min = "0")]
+pub fn window_parameters(window: LispWindowValidOrSelected) -> LispObject {
+    let win: LispWindowRef = window.into();
+    unsafe { Fcopy_alist(win.window_parameters) }
 }
 
 include!(concat!(env!("OUT_DIR"), "/windows_exports.rs"));

--- a/src/window.c
+++ b/src/window.c
@@ -1535,16 +1535,6 @@ though when run from an idle timer with a delay of zero seconds.  */)
   return Fnreverse (rows);
 }
 
-DEFUN ("window-parameters", Fwindow_parameters, Swindow_parameters,
-       0, 1, 0,
-       doc: /* Return the parameters of WINDOW and their values.
-WINDOW must be a valid window and defaults to the selected one.  The
-return value is a list of elements of the form (PARAMETER . VALUE).  */)
-  (Lisp_Object window)
-{
-  return Fcopy_alist (decode_valid_window (window)->window_parameters);
-}
-
 struct Lisp_Char_Table *
 window_display_table (struct window *w)
 {
@@ -6761,7 +6751,6 @@ displayed after a scrolling operation to be somewhat inaccurate.  */);
   defsubr (&Swindow_scroll_bars);
   defsubr (&Swindow_vscroll);
   defsubr (&Sset_window_vscroll);
-  defsubr (&Swindow_parameters);
 }
 
 void

--- a/test/rust_src/src/windows-tests.el
+++ b/test/rust_src/src/windows-tests.el
@@ -80,3 +80,10 @@
     (delete-window w2)
     (select-window w1)
     (should (eq (get-mru-window) w1))))
+
+(ert-deftest window-parameters ()
+  (should (eq nil (window-parameters)))
+  (should (eq nil (window-parameters (selected-window))))
+  (set-window-parameter (selected-window) 'test 'test)
+  (should (consp (window-parameters)))
+  (should (consp (window-parameters (selected-window)))))


### PR DESCRIPTION
Hi! I ported `window-parameters`. This PR will close #1104.

BTW, `rust_src/Cargo.lock` is edited (by `cargo`?) after `make`.
`Cargo.lock` had also changed if I run `make` on `master` branch, so I decided not to add this change to my PR.
Is it OK?