### PR TITLE
Implement From<Vec<T>> for LispObject and convert one use

### DIFF
--- a/rust_src/src/fns.rs
+++ b/rust_src/src/fns.rs
@@ -9,6 +9,7 @@ use crate::{
     lisp::defsubr,
     lisp::LispObject,
     lists::{assq, car, get, member, memq, put, LispCons},
+    numbers::LispNumber,
     obarray::loadhist_attach,
     objects::equal,
     remacs_sys::Vautoload_queue,
@@ -334,7 +335,7 @@ unsafe fn getloadaverage(loadavg: *mut libc::c_double, nelem: libc::c_int) -> li
 /// setgid so that it can read kernel information, and that usually isn't
 /// advisable.
 #[lisp_fn(min = "0")]
-pub fn load_average(use_floats: bool) -> Vec<LispObject> {
+pub fn load_average(use_floats: bool) -> Vec<LispNumber> {
     let mut load_avg: [libc::c_double; 3] = [0.0, 0.0, 0.0];
     let loads = unsafe { getloadaverage(load_avg.as_mut_ptr(), 3) };
 
@@ -345,9 +346,9 @@ pub fn load_average(use_floats: bool) -> Vec<LispObject> {
     (0..loads as usize)
         .map(|i| {
             if use_floats {
-                LispObject::from(load_avg[i])
+                LispNumber::Float(load_avg[i])
             } else {
-                LispObject::from((100.0 * load_avg[i]) as i64)
+                LispNumber::Fixnum((100.0 * load_avg[i]) as i64)
             }
         })
         .collect()

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -18,6 +18,7 @@
 #![feature(const_fn_union)]
 #![feature(ptr_offset_from)]
 #![feature(self_struct_ctor)]
+#![feature(specialization)]
 
 extern crate errno;
 #[macro_use]

--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -258,6 +258,19 @@ impl From<Vec<LispObject>> for LispObject {
     }
 }
 
+impl<T> From<Vec<T>> for LispObject
+where
+    LispObject: From<T>,
+{
+    default fn from(v: Vec<T>) -> LispObject {
+        list(
+            &v.into_iter()
+                .map(LispObject::from)
+                .collect::<Vec<LispObject>>(),
+        )
+    }
+}
+
 impl From<LispObject> for bool {
     fn from(o: LispObject) -> Self {
         o.is_not_nil()

--- a/rust_src/src/numbers.rs
+++ b/rust_src/src/numbers.rs
@@ -187,16 +187,6 @@ impl From<LispNumber> for LispObject {
     }
 }
 
-impl From<Vec<LispNumber>> for LispObject {
-    fn from(v: Vec<LispNumber>) -> LispObject {
-        LispObject::from(
-            v.into_iter()
-                .map(LispObject::from)
-                .collect::<Vec<LispObject>>(),
-        )
-    }
-}
-
 impl LispObject {
     pub fn is_number(self) -> bool {
         self.is_fixnum() || self.is_float()

--- a/rust_src/src/numbers.rs
+++ b/rust_src/src/numbers.rs
@@ -187,6 +187,16 @@ impl From<LispNumber> for LispObject {
     }
 }
 
+impl From<Vec<LispNumber>> for LispObject {
+    fn from(v: Vec<LispNumber>) -> LispObject {
+        LispObject::from(
+            v.into_iter()
+                .map(LispObject::from)
+                .collect::<Vec<LispObject>>(),
+        )
+    }
+}
+
 impl LispObject {
     pub fn is_number(self) -> bool {
         self.is_fixnum() || self.is_float()


### PR DESCRIPTION
This came out of the discussion in #1148 where the return value for `load-average`/`load_average` ended up being too generic.

This lets us return `Vec<LispNumber>` from a function we want to expose to lisp.