### PR TITLE
Fix base64-encode-string NO-LINE-BREAK behaviour

### DIFF
--- a/rust_src/src/base64.rs
+++ b/rust_src/src/base64.rs
@@ -359,7 +359,7 @@ pub fn base64_encode_string(mut string: LispStringRef, no_line_break: bool) -> L
         length,
         encoded,
         allength,
-        no_line_break,
+        !no_line_break,
         string.is_multibyte(),
     );
     if encoded_length < 0 {

--- a/test/rust_src/src/base64-tests.el
+++ b/test/rust_src/src/base64-tests.el
@@ -11,3 +11,10 @@
         (encoded "RG9icv0gZGVu"))
     (should (string= raw (base64-decode-string encoded)))
     (should (string= encoded (base64-encode-string clear)))))
+
+(ert-deftest base64-tests-no-linebreak ()
+  (let ((clear (make-string 60 ?x))
+        (encoded-with-break (concat (apply 'concat (make-list 19 "eHh4")) "\n" "eHh4"))
+        (encoded-without-break (apply 'concat (make-list 20 "eHh4"))))
+    (should (string= encoded-with-break (base64-encode-string clear)))
+    (should (string= encoded-without-break (base64-encode-string clear t)))))


### PR DESCRIPTION
The function receives a no-line-break argument but the function which
performs the encoding expects a line-break argument, making us do the
opposite of documented behaviour.

Negate the variable when passing it along and add a test to verify
this behaviour.

We have to use a long string so the inputs are a bit awkward. I tried to make it better with `make-list` but it's still not great.

This fixes #1125 