### PR TITLE
Port time-add, time-subtract and time-less-p

### DIFF
--- a/rust_src/src/editfns.rs
+++ b/rust_src/src/editfns.rs
@@ -1,6 +1,7 @@
 //! Lisp functions pertaining to editing.
 
 use std;
+use std::cmp::max;
 use std::ptr;
 
 use libc;
@@ -28,12 +29,12 @@ use crate::{
     remacs_sys::{
         buffer_overflow, build_string, current_message, del_range, del_range_1, downcase,
         find_before_next_newline, find_newline, get_char_property_and_overlay, globals, insert,
-        insert_and_inherit, insert_from_buffer, make_buffer_string, make_buffer_string_both,
-        make_save_obj_obj_obj_obj, make_string_from_bytes, maybe_quit, message1, message3,
-        record_unwind_current_buffer, record_unwind_protect, save_excursion_restore,
-        save_restriction_restore, save_restriction_save, scan_newline_from_point,
-        set_buffer_internal_1, set_point, set_point_both, styled_format, update_buffer_properties,
-        STRING_BYTES,
+        insert_and_inherit, insert_from_buffer, lisp_time, make_buffer_string,
+        make_buffer_string_both, make_save_obj_obj_obj_obj, make_string_from_bytes, maybe_quit,
+        message1, message3, record_unwind_current_buffer, record_unwind_protect,
+        save_excursion_restore, save_restriction_restore, save_restriction_save,
+        scan_newline_from_point, set_buffer_internal_1, set_point, set_point_both, styled_format,
+        update_buffer_properties, STRING_BYTES,
     },
     remacs_sys::{
         Fadd_text_properties, Fcopy_sequence, Fget_pos_property, Fnext_single_char_property_change,
@@ -42,6 +43,7 @@ use crate::{
     remacs_sys::{Qboundary, Qfield, Qinteger_or_marker_p, Qmark_inactive, Qnil, Qt},
     textprop::get_char_property,
     threads::{c_specpdl_index, ThreadState},
+    time::{lisp_time_struct, time_overflow, LO_TIME_BITS},
     util::clip_to_bounds,
     windows::selected_window,
 };
@@ -1391,6 +1393,96 @@ pub fn delete_and_extract_region(
         }
         .as_string()
     }
+}
+
+fn time_arith<F: FnOnce(lisp_time, lisp_time) -> lisp_time>(
+    a: LispObject,
+    b: LispObject,
+    op: F,
+) -> Vec<LispNumber> {
+    let mut alen: c_int = 0;
+    let mut blen: c_int = 0;
+    let ta = unsafe { lisp_time_struct(a, &mut alen) };
+    let tb = unsafe { lisp_time_struct(b, &mut blen) };
+    let t = op(ta, tb);
+    if LispObject::fixnum_overflow(t.hi) {
+        time_overflow();
+    }
+
+    let maxlen = max(alen, blen) as usize;
+    let mut v = Vec::with_capacity(maxlen);
+
+    if maxlen >= 2 {
+        v.push(LispNumber::Fixnum(t.hi));
+        v.push(LispNumber::Fixnum(t.lo.into()));
+    }
+    if maxlen >= 3 {
+        v.push(LispNumber::Fixnum(t.us.into()));
+    }
+    if maxlen > 3 {
+        v.push(LispNumber::Fixnum(t.ps.into()));
+    }
+
+    v
+}
+
+fn time_add(ta: lisp_time, tb: lisp_time) -> lisp_time {
+    let mut hi = EmacsInt::from(ta.hi + tb.hi);
+    let mut lo = ta.lo + tb.lo;
+    let mut us = ta.us + tb.us;
+    let mut ps = ta.ps + tb.ps;
+
+    if ps > 1_000_000 {
+        ps += 1;
+        us -= 1_000_000;
+    }
+    if us > 1_000_000 {
+        lo += 1;
+        us -= 1_000_000;
+    }
+    if lo > 1 << LO_TIME_BITS {
+        hi += 1;
+        lo -= 1 << LO_TIME_BITS;
+    }
+
+    lisp_time { hi, lo, us, ps }
+}
+
+fn time_subtract(ta: lisp_time, tb: lisp_time) -> lisp_time {
+    let mut hi = EmacsInt::from(ta.hi - tb.hi);
+    let mut lo = ta.lo - tb.lo;
+    let mut us = ta.us - tb.us;
+    let mut ps = ta.ps - tb.ps;
+
+    if ps < 0 {
+        us -= 1;
+        ps += 1_000_000;
+    }
+    if us < 0 {
+        lo -= 1;
+        us += 1_000_000;
+    }
+    if hi < 0 {
+        hi -= 1;
+        lo += 1 << LO_TIME_BITS;
+    }
+
+    lisp_time { hi, lo, us, ps }
+}
+
+/// Return the sum of two time values A and B, as a time value. A nil value for either argument
+/// stands for the current time. See `current-time-string' for the various forms of a time value.
+#[lisp_fn(name = "time-add", c_name = "time_add")]
+pub fn time_add_lisp(a: LispObject, b: LispObject) -> Vec<LispNumber> {
+    time_arith(a, b, time_add)
+}
+
+/// Return the difference between two time values A and B, as a time value. Use `float-time' to
+/// convert the difference into elapsed seconds.  A nil value for either argument stands for the
+/// current time.  See `current-time-string' for the various forms of a time value.
+#[lisp_fn(name = "time-subtract", c_name = "time_subtract")]
+pub fn time_subtract_lisp(a: LispObject, b: LispObject) -> Vec<LispNumber> {
+    time_arith(a, b, time_subtract)
 }
 
 include!(concat!(env!("OUT_DIR"), "/editfns_exports.rs"));

--- a/rust_src/src/editfns.rs
+++ b/rust_src/src/editfns.rs
@@ -1485,4 +1485,30 @@ pub fn time_subtract_lisp(a: LispObject, b: LispObject) -> Vec<LispNumber> {
     time_arith(a, b, time_subtract)
 }
 
+macro_rules! return_if_different {
+    ($a:expr, $b:expr) => {{
+        if $a != $b {
+            return $a < $b;
+        }
+    }};
+}
+
+/// Return non-nil if time value T1 is earlier than time value T2.  A nil value for either
+/// argument stands for the current time.  See `current-time-string' for the various forms of a
+/// time value.
+#[lisp_fn]
+pub fn time_less_p(t1: LispObject, t2: LispObject) -> bool {
+    let mut t1len: c_int = 0;
+    let mut t2len: c_int = 0;
+    let a = unsafe { lisp_time_struct(t1, &mut t1len) };
+    let b = unsafe { lisp_time_struct(t2, &mut t2len) };
+
+    return_if_different!(a.hi, b.hi);
+    return_if_different!(a.lo, b.lo);
+    return_if_different!(a.us, b.us);
+    return_if_different!(a.ps, b.ps);
+
+    false
+}
+
 include!(concat!(env!("OUT_DIR"), "/editfns_exports.rs"));

--- a/rust_src/src/editfns.rs
+++ b/rust_src/src/editfns.rs
@@ -1396,11 +1396,10 @@ pub fn delete_and_extract_region(
     }
 }
 
-fn time_arith<F: FnOnce(LispTime, LispTime) -> LispTime>(
-    a: LispObject,
-    b: LispObject,
-    op: F,
-) -> Vec<EmacsInt> {
+fn time_arith<F>(a: LispObject, b: LispObject, op: F) -> Vec<EmacsInt>
+where
+    F: FnOnce(LispTime, LispTime) -> LispTime,
+{
     let mut alen: c_int = 0;
     let mut blen: c_int = 0;
     let ta = unsafe { lisp_time_struct(a, &mut alen) };

--- a/rust_src/src/editfns.rs
+++ b/rust_src/src/editfns.rs
@@ -1473,14 +1473,6 @@ pub fn time_subtract_lisp(a: LispObject, b: LispObject) -> Vec<EmacsInt> {
     time_arith(a, b, time_subtract)
 }
 
-macro_rules! return_if_different {
-    ($a:expr, $b:expr) => {{
-        if $a != $b {
-            return $a < $b;
-        }
-    }};
-}
-
 /// Return non-nil if time value T1 is earlier than time value T2.  A nil value for either
 /// argument stands for the current time.  See `current-time-string' for the various forms of a
 /// time value.
@@ -1491,12 +1483,7 @@ pub fn time_less_p(t1: LispObject, t2: LispObject) -> bool {
     let a = unsafe { lisp_time_struct(t1, &mut t1len) };
     let b = unsafe { lisp_time_struct(t2, &mut t2len) };
 
-    return_if_different!(a.hi, b.hi);
-    return_if_different!(a.lo, b.lo);
-    return_if_different!(a.us, b.us);
-    return_if_different!(a.ps, b.ps);
-
-    false
+    a < b
 }
 
 include!(concat!(env!("OUT_DIR"), "/editfns_exports.rs"));

--- a/rust_src/src/editfns.rs
+++ b/rust_src/src/editfns.rs
@@ -1399,7 +1399,7 @@ fn time_arith<F: FnOnce(lisp_time, lisp_time) -> lisp_time>(
     a: LispObject,
     b: LispObject,
     op: F,
-) -> Vec<LispNumber> {
+) -> Vec<EmacsInt> {
     let mut alen: c_int = 0;
     let mut blen: c_int = 0;
     let ta = unsafe { lisp_time_struct(a, &mut alen) };
@@ -1413,21 +1413,21 @@ fn time_arith<F: FnOnce(lisp_time, lisp_time) -> lisp_time>(
     let mut v = Vec::with_capacity(maxlen);
 
     if maxlen >= 2 {
-        v.push(LispNumber::Fixnum(t.hi));
-        v.push(LispNumber::Fixnum(t.lo.into()));
+        v.push(t.hi);
+        v.push(t.lo.into());
     }
     if maxlen >= 3 {
-        v.push(LispNumber::Fixnum(t.us.into()));
+        v.push(t.us.into());
     }
     if maxlen > 3 {
-        v.push(LispNumber::Fixnum(t.ps.into()));
+        v.push(t.ps.into());
     }
 
     v
 }
 
 fn time_add(ta: lisp_time, tb: lisp_time) -> lisp_time {
-    let mut hi = EmacsInt::from(ta.hi + tb.hi);
+    let mut hi = ta.hi + tb.hi;
     let mut lo = ta.lo + tb.lo;
     let mut us = ta.us + tb.us;
     let mut ps = ta.ps + tb.ps;
@@ -1449,7 +1449,7 @@ fn time_add(ta: lisp_time, tb: lisp_time) -> lisp_time {
 }
 
 fn time_subtract(ta: lisp_time, tb: lisp_time) -> lisp_time {
-    let mut hi = EmacsInt::from(ta.hi - tb.hi);
+    let mut hi = ta.hi - tb.hi;
     let mut lo = ta.lo - tb.lo;
     let mut us = ta.us - tb.us;
     let mut ps = ta.ps - tb.ps;
@@ -1473,7 +1473,7 @@ fn time_subtract(ta: lisp_time, tb: lisp_time) -> lisp_time {
 /// Return the sum of two time values A and B, as a time value. A nil value for either argument
 /// stands for the current time. See `current-time-string' for the various forms of a time value.
 #[lisp_fn(name = "time-add", c_name = "time_add")]
-pub fn time_add_lisp(a: LispObject, b: LispObject) -> Vec<LispNumber> {
+pub fn time_add_lisp(a: LispObject, b: LispObject) -> Vec<EmacsInt> {
     time_arith(a, b, time_add)
 }
 
@@ -1481,7 +1481,7 @@ pub fn time_add_lisp(a: LispObject, b: LispObject) -> Vec<LispNumber> {
 /// convert the difference into elapsed seconds.  A nil value for either argument stands for the
 /// current time.  See `current-time-string' for the various forms of a time value.
 #[lisp_fn(name = "time-subtract", c_name = "time_subtract")]
-pub fn time_subtract_lisp(a: LispObject, b: LispObject) -> Vec<LispNumber> {
+pub fn time_subtract_lisp(a: LispObject, b: LispObject) -> Vec<EmacsInt> {
     time_arith(a, b, time_subtract)
 }
 

--- a/rust_src/src/time.rs
+++ b/rust_src/src/time.rs
@@ -16,7 +16,7 @@ use crate::{
     remacs_sys::{lisp_time, EmacsDouble, EmacsInt},
 };
 
-const LO_TIME_BITS: i32 = 16;
+pub const LO_TIME_BITS: i32 = 16;
 
 /// Return the upper part of the time T (everything but the bottom 16 bits).
 #[no_mangle]
@@ -320,7 +320,7 @@ fn invalid_time() -> ! {
 }
 
 /// Report that a time value is out of range for Emacs.
-fn time_overflow() -> ! {
+pub fn time_overflow() -> ! {
     error!("Specified time is not representable");
 }
 

--- a/rust_src/src/time.rs
+++ b/rust_src/src/time.rs
@@ -59,9 +59,9 @@ impl Ord for LispTime {
     fn cmp(&self, other: &LispTime) -> Ordering {
         self.hi
             .cmp(&other.hi)
-            .then(self.lo.cmp(&other.lo))
-            .then(self.us.cmp(&other.us))
-            .then(self.ps.cmp(&other.ps))
+            .then_with(|| self.lo.cmp(&other.lo))
+            .then_with(|| self.us.cmp(&other.us))
+            .then_with(|| self.ps.cmp(&other.ps))
     }
 }
 

--- a/rust_src/src/time.rs
+++ b/rust_src/src/time.rs
@@ -41,15 +41,6 @@ impl LispTime {
     }
 }
 
-macro_rules! return_if_different {
-    ($a:expr, $b:expr) => {{
-        let o = $a.cmp(&$b);
-        if o != Ordering::Equal {
-            return o;
-        }
-    }};
-}
-
 impl PartialEq for LispTime {
     fn eq(&self, other: &LispTime) -> bool {
         self.hi == other.hi && self.lo == other.lo && self.us == other.us && self.ps == other.ps
@@ -66,12 +57,11 @@ impl PartialOrd for LispTime {
 
 impl Ord for LispTime {
     fn cmp(&self, other: &LispTime) -> Ordering {
-        return_if_different!(self.hi, other.hi);
-        return_if_different!(self.lo, other.lo);
-        return_if_different!(self.us, other.us);
-        return_if_different!(self.ps, other.ps);
-
-        Ordering::Equal
+        self.hi
+            .cmp(&other.hi)
+            .then(self.lo.cmp(&other.lo))
+            .then(self.us.cmp(&other.us))
+            .then(self.ps.cmp(&other.ps))
     }
 }
 

--- a/rust_src/src/time.rs
+++ b/rust_src/src/time.rs
@@ -75,15 +75,15 @@ impl Add for LispTime {
         let mut us = self.us + other.us;
         let mut ps = self.ps + other.ps;
 
-        if ps > 1_000_000 {
-            ps += 1;
-            us -= 1_000_000;
+        if ps >= 1_000_000 {
+            us += 1;
+            ps -= 1_000_000;
         }
-        if us > 1_000_000 {
+        if us >= 1_000_000 {
             lo += 1;
             us -= 1_000_000;
         }
-        if lo > 1 << LO_TIME_BITS {
+        if lo >= 1 << LO_TIME_BITS {
             hi += 1;
             lo -= 1 << LO_TIME_BITS;
         }

--- a/rust_src/src/time.rs
+++ b/rust_src/src/time.rs
@@ -18,6 +18,27 @@ use crate::{
 
 pub const LO_TIME_BITS: i32 = 16;
 
+pub type LispTime = lisp_time;
+
+impl LispTime {
+    pub fn into_vec(self, nelem: usize) -> Vec<EmacsInt> {
+        let mut v = Vec::with_capacity(nelem);
+
+        if nelem >= 2 {
+            v.push(self.hi);
+            v.push(self.lo.into());
+        }
+        if nelem >= 3 {
+            v.push(self.us.into());
+        }
+        if nelem > 3 {
+            v.push(self.ps.into());
+        }
+
+        v
+    }
+}
+
 /// Return the upper part of the time T (everything but the bottom 16 bits).
 #[no_mangle]
 pub extern "C" fn hi_time(t: time_t) -> EmacsInt {

--- a/rust_src/src/time.rs
+++ b/rust_src/src/time.rs
@@ -1,5 +1,6 @@
 //! Time support
 
+use std::cmp::Ordering;
 use std::ptr;
 
 use libc::timespec as c_timespec;
@@ -36,6 +37,40 @@ impl LispTime {
         }
 
         v
+    }
+}
+
+macro_rules! return_if_different {
+    ($a:expr, $b:expr) => {{
+        let o = $a.cmp(&$b);
+        if o != Ordering::Equal {
+            return o;
+        }
+    }};
+}
+
+impl PartialEq for LispTime {
+    fn eq(&self, other: &LispTime) -> bool {
+        self.hi == other.hi && self.lo == other.lo && self.us == other.us && self.ps == other.ps
+    }
+}
+
+impl Eq for LispTime {}
+
+impl PartialOrd for LispTime {
+    fn partial_cmp(&self, other: &LispTime) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for LispTime {
+    fn cmp(&self, other: &LispTime) -> Ordering {
+        return_if_different!(self.hi, other.hi);
+        return_if_different!(self.lo, other.lo);
+        return_if_different!(self.us, other.us);
+        return_if_different!(self.ps, other.ps);
+
+        Ordering::Equal
     }
 }
 

--- a/src/editfns.c
+++ b/src/editfns.c
@@ -655,23 +655,6 @@ hi_time (time_t t);
 extern EMACS_INT
 lo_time (time_t t);
 
-DEFUN ("time-less-p", Ftime_less_p, Stime_less_p, 2, 2, 0,
-       doc: /* Return non-nil if time value T1 is earlier than time value T2.
-A nil value for either argument stands for the current time.
-See `current-time-string' for the various forms of a time value.  */)
-  (Lisp_Object t1, Lisp_Object t2)
-{
-  int t1len, t2len;
-  struct lisp_time a = lisp_time_struct (t1, &t1len);
-  struct lisp_time b = lisp_time_struct (t2, &t2len);
-  return ((a.hi != b.hi ? a.hi < b.hi
-	   : a.lo != b.lo ? a.lo < b.lo
-	   : a.us != b.us ? a.us < b.us
-	   : a.ps < b.ps)
-	  ? Qt : Qnil);
-}
-
-
 DEFUN ("get-internal-run-time", Fget_internal_run_time, Sget_internal_run_time,
        0, 0, 0,
        doc: /* Return the current run time used by Emacs.
@@ -3781,7 +3764,6 @@ functions if all the text being accessed has this property.  */);
   defsubr (&Suser_login_name);
   defsubr (&Suser_real_login_name);
   defsubr (&Suser_full_name);
-  defsubr (&Stime_less_p);
   defsubr (&Sget_internal_run_time);
   defsubr (&Sformat_time_string);
   defsubr (&Sdecode_time);

--- a/test/rust_src/src/editfns-tests.el
+++ b/test/rust_src/src/editfns-tests.el
@@ -83,3 +83,16 @@
       (insert payload)
       (should (equal (delete-and-extract-region 12 5) " buffer"))
       (should (equal (buffer-string) "test contents")))))
+
+(ert-deftest time-comparison ()
+  (let ((fixed-time '(23580 5248 742594 205000)))
+    (should (time-less-p fixed-time (current-time)))))
+
+(ert-deftest time-arithmetic ()
+  (let ((fixed-time '(23580 5248 742594 205000))
+        (more-time '(23580 5258 742594 205000))
+        (less-time '(23580 5228 742594 205000)))
+    (should (equal fixed-time (time-add fixed-time 0)))
+    (should (equal fixed-time (time-subtract fixed-time 0)))
+    (should (equal more-time (time-add fixed-time '(0 10))))
+    (should (equal less-time (time-subtract fixed-time '(0 20))))))


### PR DESCRIPTION
This doesn't go as far as #965 and leaves the types untouched. It also makes use of the new `From` magic and returns `Vec<LispNumber>` for the time. :man_dancing: 

The carries from one unit to the next in `time_add` and `time_subtract` have been ported to a more explicit and rusty form, but this does mean we've introduced conditionals which are not there in the C version. I don't know how big a deal this actually is, but we could have a version that casts e.g. `(us > 1_000_000 as u32)` so we can add/multiply 0 and 1.