### PR TITLE
Port base64-decode-region and base64-encode-region and rustify support code

### DIFF
--- a/rust_src/src/base64.rs
+++ b/rust_src/src/base64.rs
@@ -16,7 +16,6 @@ use crate::{
         del_range_both, del_range_byte, insert, insert_1_both, make_unibyte_string, move_gap_both,
         set_point, set_point_both, signal_after_change, temp_set_point_both,
     },
-    strings::MIME_LINE_LENGTH,
     threads::ThreadState,
 };
 
@@ -118,58 +117,6 @@ ZmFyLXJlYWNoaW5nIGNoYW5nZXMu"
         .to_string();
     assert_eq!(expected, encoded);
     assert_eq!(expected.len(), encoded.len());
-}
-
-#[no_mangle]
-pub extern "C" fn compute_decode_size(len: usize) -> usize {
-    ((len + 3) / 4) * 3
-}
-
-#[no_mangle]
-pub extern "C" fn compute_encode_size(len: usize) -> usize {
-    ((len * 4) / 3) + 4
-}
-
-#[no_mangle]
-pub extern "C" fn pad_base64_size(len: usize) -> usize {
-    len + (len / (MIME_LINE_LENGTH as usize)) + 1 + 6
-}
-
-#[test]
-fn test_compute_decode_size() {
-    assert_eq!(3, compute_decode_size(1));
-    assert_eq!(3, compute_decode_size(2));
-    assert_eq!(3, compute_decode_size(3));
-    assert_eq!(3, compute_decode_size(4));
-    assert_eq!(6, compute_decode_size(5));
-    assert_eq!(6, compute_decode_size(6));
-    assert_eq!(6, compute_decode_size(7));
-    assert_eq!(6, compute_decode_size(8));
-}
-
-#[test]
-fn test_compute_encode_size() {
-    assert_eq!(5, compute_encode_size(1));
-    assert_eq!(6, compute_encode_size(2));
-    assert_eq!(8, compute_encode_size(3));
-    assert_eq!(9, compute_encode_size(4));
-    assert_eq!(10, compute_encode_size(5));
-    assert_eq!(12, compute_encode_size(6));
-    assert_eq!(13, compute_encode_size(7));
-    assert_eq!(14, compute_encode_size(8));
-}
-
-#[test]
-fn test_pad_base64_size() {
-    assert_eq!(8, pad_base64_size(1));
-    assert_eq!(9, pad_base64_size(2));
-    assert_eq!(10, pad_base64_size(3));
-    assert_eq!(11, pad_base64_size(4));
-    assert_eq!(12, pad_base64_size(5));
-    assert_eq!(13, pad_base64_size(6));
-    assert_eq!(14, pad_base64_size(7));
-    assert_eq!(15, pad_base64_size(8));
-    assert_eq!(84, pad_base64_size(76));
 }
 
 #[test]

--- a/rust_src/src/base64.rs
+++ b/rust_src/src/base64.rs
@@ -19,7 +19,7 @@ use crate::{
     threads::ThreadState,
 };
 
-pub fn base64_encode_1(bytes: &[u8], line_break: bool, multibyte: bool) -> Result<String, ()> {
+fn base64_encode_1(bytes: &[u8], line_break: bool, multibyte: bool) -> Result<String, ()> {
     let config = if line_break {
         // base64_crate::MIME, but with LF instead of CRLF
         base64_crate::Config::new(
@@ -59,7 +59,7 @@ pub fn base64_encode_1(bytes: &[u8], line_break: bool, multibyte: bool) -> Resul
 
 /// Base64-decode the data in ENCODED. If MULTIBYTE, the decoded result should be in multibyte
 /// form. It returns the decoded data and the number of bytes in the original decoded string.
-pub fn base64_decode_1(encoded: &[u8], multibyte: bool) -> Result<(Vec<u8>, usize), ()> {
+fn base64_decode_1(encoded: &[u8], multibyte: bool) -> Result<(Vec<u8>, usize), ()> {
     // Use the MIME config to allow embedded newlines.
     match base64_crate::decode_config(encoded, base64_crate::MIME) {
         Ok(decoded) => {

--- a/rust_src/src/buffers.rs
+++ b/rust_src/src/buffers.rs
@@ -227,7 +227,13 @@ impl LispBufferRef {
 
     /// Return the address of byte position N in current buffer.
     pub fn byte_pos_addr(self, n: ptrdiff_t) -> *mut c_uchar {
-        unsafe { (*self.text).beg.offset(n - BEG_BYTE) }
+        let offset = if n >= self.gpt_byte() {
+            self.gap_size()
+        } else {
+            0
+        };
+
+        unsafe { self.beg_addr().offset(offset + n - self.beg_byte()) }
     }
 
     /// Return the address of character at byte position BYTE_POS.
@@ -238,13 +244,7 @@ impl LispBufferRef {
 
     /// Return the byte at byte position N.
     pub fn fetch_byte(self, n: ptrdiff_t) -> u8 {
-        let offset = if n >= self.gpt_byte() {
-            self.gap_size()
-        } else {
-            0
-        };
-
-        unsafe { *(self.beg_addr().offset(offset + n - self.beg_byte())) as u8 }
+        unsafe { *self.byte_pos_addr(n) }
     }
 
     /// Return character at byte position POS.  See the caveat WARNING for

--- a/rust_src/src/strings.rs
+++ b/rust_src/src/strings.rs
@@ -18,8 +18,6 @@ use crate::{
     },
 };
 
-pub static MIME_LINE_LENGTH: isize = 76;
-
 /// Return t if OBJECT is a string.
 #[lisp_fn]
 pub fn stringp(object: LispObject) -> bool {

--- a/src/fns.c
+++ b/src/fns.c
@@ -1815,136 +1815,6 @@ The data read from the system are decoded using `locale-coding-system'.  */)
 #endif	/* HAVE_LANGINFO_CODESET*/
   return Qnil;
 }
-
-/* base64 encode/decode functions (RFC 2045).
-   Based on code from GNU recode. */
-
-ptrdiff_t base64_encode_1 (const char *, ptrdiff_t, char *, ptrdiff_t, bool, bool);
-ptrdiff_t base64_decode_1 (const char *, ptrdiff_t, char *, ptrdiff_t, bool,
-                           ptrdiff_t *);
-ptrdiff_t pad_base64_size(ptrdiff_t len);
-ptrdiff_t compute_decode_size(ptrdiff_t len);
-ptrdiff_t compute_encode_size(ptrdiff_t len);
-
-DEFUN ("base64-encode-region", Fbase64_encode_region, Sbase64_encode_region,
-       2, 3, "r",
-       doc: /* Base64-encode the region between BEG and END.
-Return the length of the encoded text.
-Optional third argument NO-LINE-BREAK means do not break long lines
-into shorter lines.  */)
-  (Lisp_Object beg, Lisp_Object end, Lisp_Object no_line_break)
-{
-  char *encoded;
-  ptrdiff_t allength, length;
-  ptrdiff_t ibeg, iend, encoded_length;
-  ptrdiff_t old_pos = PT;
-  USE_SAFE_ALLOCA;
-
-  validate_region (&beg, &end);
-
-  ibeg = CHAR_TO_BYTE (XFASTINT (beg));
-  iend = CHAR_TO_BYTE (XFASTINT (end));
-  move_gap_both (XFASTINT (beg), ibeg);
-
-  /* We need to allocate enough room for encoding the text.
-     We need 33 1/3% more space, plus a newline every 76
-     characters, and then we round up. */
-  length = iend - ibeg;
-  allength = pad_base64_size(compute_encode_size(length));
-
-  encoded = SAFE_ALLOCA (allength);
-  encoded_length = base64_encode_1 ((char *) BYTE_POS_ADDR (ibeg), length,
-                                    encoded, allength,
-                                    NILP (no_line_break),
-				    !NILP (BVAR (current_buffer, enable_multibyte_characters)));
-
-  if (encoded_length < 0)
-    {
-      /* The encoding wasn't possible. */
-      SAFE_FREE ();
-      error ("Multibyte character in data for base64 encoding");
-    }
-
-  /* Now we have encoded the region, so we insert the new contents
-     and delete the old.  (Insert first in order to preserve markers.)  */
-  SET_PT_BOTH (XFASTINT (beg), ibeg);
-  insert (encoded, encoded_length);
-  SAFE_FREE ();
-  del_range_byte (ibeg + encoded_length, iend + encoded_length);
-
-  /* If point was outside of the region, restore it exactly; else just
-     move to the beginning of the region.  */
-  if (old_pos >= XFASTINT (end))
-    old_pos += encoded_length - (XFASTINT (end) - XFASTINT (beg));
-  else if (old_pos > XFASTINT (beg))
-    old_pos = XFASTINT (beg);
-  SET_PT (old_pos);
-
-  /* We return the length of the encoded text. */
-  return make_number (encoded_length);
-}
-
-DEFUN ("base64-decode-region", Fbase64_decode_region, Sbase64_decode_region,
-       2, 2, "r",
-       doc: /* Base64-decode the region between BEG and END.
-Return the length of the decoded text.
-If the region can't be decoded, signal an error and don't modify the buffer.  */)
-  (Lisp_Object beg, Lisp_Object end)
-{
-  ptrdiff_t ibeg, iend, length, allength;
-  char *decoded;
-  ptrdiff_t old_pos = PT;
-  ptrdiff_t decoded_length;
-  ptrdiff_t inserted_chars;
-  bool multibyte = !NILP (BVAR (current_buffer, enable_multibyte_characters));
-  USE_SAFE_ALLOCA;
-
-  validate_region (&beg, &end);
-
-  ibeg = CHAR_TO_BYTE (XFASTINT (beg));
-  iend = CHAR_TO_BYTE (XFASTINT (end));
-
-  length = iend - ibeg;
-
-  /* We need to allocate enough room for decoding the text.  If we are
-     working on a multibyte buffer, each decoded code may occupy at
-     most two bytes.  */
-  allength = compute_decode_size(multibyte ? length * 2 : length);
-  decoded = SAFE_ALLOCA (allength);
-
-  move_gap_both (XFASTINT (beg), ibeg);
-  decoded_length = base64_decode_1 ((char *) BYTE_POS_ADDR (ibeg), length,
-				    decoded, allength,
-				    multibyte, &inserted_chars);
-
-  if (decoded_length < 0)
-    {
-      /* The decoding wasn't possible. */
-      error ("Invalid base64 data");
-    }
-
-  /* Now we have decoded the region, so we insert the new contents
-     and delete the old.  (Insert first in order to preserve markers.)  */
-  TEMP_SET_PT_BOTH (XFASTINT (beg), ibeg);
-  insert_1_both (decoded, inserted_chars, decoded_length, 0, 1, 0);
-  signal_after_change (XFASTINT (beg), 0, inserted_chars);
-  SAFE_FREE ();
-
-  /* Delete the original text.  */
-  del_range_both (PT, PT_BYTE, XFASTINT (end) + inserted_chars,
-		  iend + decoded_length, 1);
-
-  /* If point was outside of the region, restore it exactly; else just
-     move to the beginning of the region.  */
-  if (old_pos >= XFASTINT (end))
-    old_pos += inserted_chars - (XFASTINT (end) - XFASTINT (beg));
-  else if (old_pos > XFASTINT (beg))
-    old_pos = XFASTINT (beg);
-  SET_PT (old_pos > ZV ? ZV : old_pos);
-
-  return make_number (inserted_chars);
-}
-
 
 
 /***********************************************************************
@@ -3356,8 +3226,6 @@ this variable.  */);
   defsubr (&Swidget_put);
   defsubr (&Swidget_get);
   defsubr (&Swidget_apply);
-  defsubr (&Sbase64_encode_region);
-  defsubr (&Sbase64_decode_region);
   defsubr (&Ssecure_hash_algorithms);
   defsubr (&Slocale_info);
 }


### PR DESCRIPTION
This build on top of #1168 so the rustification part doesn't conflict. We start by fixing the logic in `byte_pos_addr` which did not take the gap/gpt into account and thus would return wrong values when we tried to use it after `move_gap_both`.

After moving the implementation for `base64-{decode,encode}-region` there were no more base64 functions in C, so we no longer need the `extern "C"` or unsafe buffer operations. We can move those support functions to use Rust types. We can also remove functions meant to figure out how much to preallocate.