### PR TITLE
Skip running bindgen if C source hasn't changed

### DIFF
--- a/rust_src/build.rs
+++ b/rust_src/build.rs
@@ -639,6 +639,13 @@ fn run_bindgen() {
             .expect("Could not create bindings.rs");
         return;
     }
+    // Set by the Makefile to non-empty value if we need to generate the bindings
+    let do_build = std::env::var_os("BUILD_BINDINGS");
+    match do_build.as_ref() {
+        Some(s) if s == "" => return,
+        None => return,
+        _ => {}
+    }
     let cflags = std::env::var_os("EMACS_CFLAGS");
     match cflags {
         None => {

--- a/rust_src/build.rs
+++ b/rust_src/build.rs
@@ -639,11 +639,11 @@ fn run_bindgen() {
             .expect("Could not create bindings.rs");
         return;
     }
-    // Set by the Makefile to non-empty value if we need to generate the bindings
+    // Set by the Makefile to non-empty value if we need to regenerate the bindings
     let do_build = std::env::var_os("BUILD_BINDINGS");
     match do_build.as_ref() {
-        Some(s) if s == "" => return,
-        None => return,
+        Some(s) if s == "" && out_path.exists() => return,
+        None if out_path.exists() => return,
         _ => {}
     }
     let cflags = std::env::var_os("EMACS_CFLAGS");

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -606,14 +606,27 @@ $(RUSTFLAGS_FILE) : FORCE
 	diff -q $@ $@.tmp || cp $@.tmp $@
 	rm -f $@.tmp
 
+# We hash the C code and if it's different from the previous hash, we
+# set BUILD_BINDINGS=true. Otherwise it gets set empty. If
+# BUILD_BINDINGS=true the cargo build script runs bindgen to generate
+# the bindings. Otherwise it skips that step.
+BUILD_BINDINGS=""
+CSRC_HASH_FILE=$(rust_srcdir)/target/.csrchash
+$(CSRC_HASH_FILE) : FORCE $(libsrc)/hashdir/target/$(CARGO_BUILD_DIR)/hashdir$(EXEEXT)
+	mkdir -p $(dir $@)
+	$(shell EMACS_CFLAGS="$(EMACS_CFLAGS)" ../lib-src/hashdir/target/$(CARGO_BUILD_DIR)/hashdir > $@.tmp)
+	$(eval BUILD_BINDINGS=$(shell diff -q $@ $@.tmp >/dev/null || (cp $@.tmp $@ && echo true)))
+	rm -f $@.tmp
+
 macosx_alloc_dir=$(rust_srcdir)/alloc_unexecmacosx
 MACOSX_ALLOC_INPUTS=$(macosx_alloc_dir)/src/** $(macosx_alloc_dir)/Cargo.*
 cargo_manifest=$(rust_srcdir)/Cargo.toml
 LIBREMACS_ARCHIVE=$(rust_srcdir)/target/$(CARGO_BUILD_DIR)/$(REMACSLIB_NAME)
-$(LIBREMACS_ARCHIVE): globals.h $(rust_srcdir)/src/** $(rust_srcdir)/Cargo.* $(MACOSX_ALLOC_INPUTS) $(libsrc)/hashdir/target/$(CARGO_BUILD_DIR)/hashdir$(EXEEXT)
+$(LIBREMACS_ARCHIVE): $(CSRC_HASH_FILE) globals.h $(rust_srcdir)/src/** $(rust_srcdir)/Cargo.* $(MACOSX_ALLOC_INPUTS) $(libsrc)/hashdir/target/$(CARGO_BUILD_DIR)/hashdir$(EXEEXT)
 	RUSTFLAGS="$(RUSTFLAGS)" \
 	EMACS_CFLAGS="$(EMACS_CFLAGS)" \
 	SRC_HASH="$(shell EMACS_CFLAGS="-I../rust_src $(EMACS_CFLAGS)" ../lib-src/hashdir/target/$(CARGO_BUILD_DIR)/hashdir)" \
+	BUILD_BINDINGS="$(BUILD_BINDINGS)" \
 	$(CARGO_BUILD) $(CARGO_FLAGS) --manifest-path $(cargo_manifest)
 
 clippy:

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -629,17 +629,19 @@ $(LIBREMACS_ARCHIVE): $(CSRC_HASH_FILE) globals.h $(rust_srcdir)/src/** $(rust_s
 	BUILD_BINDINGS="$(BUILD_BINDINGS)" \
 	$(CARGO_BUILD) $(CARGO_FLAGS) --manifest-path $(cargo_manifest)
 
-clippy:
+clippy: $(CSRC_HASH_FILE)
 	RUSTFLAGS="$(RUSTFLAGS)" \
 	EMACS_CFLAGS="$(EMACS_CFLAGS)" \
+	BUILD_BINDINGS="$(BUILD_BINDINGS)" \
 	$(CARGO_CLIPPY) $(CARGO_FLAGS) --manifest-path $(cargo_manifest)
 
 .PHONY: clippy
 
-check check-maybe check-expensive: $(libsrc)/hashdir/target/$(CARGO_BUILD_DIR)/hashdir$(EXEEXT)
+check check-maybe check-expensive: $(CSRC_HASH_FILE) $(libsrc)/hashdir/target/$(CARGO_BUILD_DIR)/hashdir$(EXEEXT)
 	RUSTFLAGS="$(RUSTFLAGS)" \
 	EMACS_CFLAGS="$(EMACS_CFLAGS)" \
 	SRC_HASH="$(shell EMACS_CFLAGS="-I../rust_src $(EMACS_CFLAGS)" ../lib-src/hashdir)" \
+	BUILD_BINDINGS="$(BUILD_BINDINGS)" \
 	$(CARGO_TEST) $(CARGO_FLAGS) --manifest-path $(cargo_manifest)
 
 $(libsrc)/hashdir/target/$(CARGO_BUILD_DIR)/hashdir$(EXEEXT): ${libsrc}/hashdir/Cargo.toml ${libsrc}/hashdir/src/main.rs


### PR DESCRIPTION
The cargo build script performs a few different tasks so we run it
whenever any of the source code has changed.

A particularly expensive task is running bindgen to generate Rust code
from the C code automatically. This can take minutes and we run it
even if only Rust code has changed, which would not produce a change.

Teach the Makefile to keep track of a hash for the C source code and
tell the cargo build script. Teach the build script to skip running
bindgen unless the Makefile has determined that it needs to be run.