### PR TITLE
Port frame-after-make-frame (fix #1106)

### DIFF
--- a/rust_src/src/frames.rs
+++ b/rust_src/src/frames.rs
@@ -508,4 +508,22 @@ pub fn previous_frame(frame: LispFrameOrSelected, miniframe: LispObject) -> Lisp
     }
 }
 
+/// Mark FRAME as made.
+/// FRAME nil means use the selected frame.  Second argument MADE non-nil
+/// means functions on `window-configuration-change-hook' are called
+/// whenever the window configuration of FRAME changes.  MADE nil means
+/// these functions are not called.
+///
+/// This function is currently called by `make-frame' only and should be
+/// otherwise used with utter care to avoid that running functions on
+/// `window-configuration-change-hook' is impeded forever.
+#[lisp_fn]
+pub fn frame_after_make_frame(frame: LispFrameOrSelected, made: LispObject) -> LispObject{
+    let mut frame_ref = frame.live_or_error();
+    frame_ref.set_after_make_frame(made.is_not_nil());
+    frame_ref.set_inhibit_horizontal_resize(false);
+    frame_ref.set_inhibit_vertical_resize(false);
+    made
+}
+
 include!(concat!(env!("OUT_DIR"), "/frames_exports.rs"));

--- a/rust_src/src/frames.rs
+++ b/rust_src/src/frames.rs
@@ -518,7 +518,7 @@ pub fn previous_frame(frame: LispFrameOrSelected, miniframe: LispObject) -> Lisp
 /// otherwise used with utter care to avoid that running functions on
 /// `window-configuration-change-hook' is impeded forever.
 #[lisp_fn]
-pub fn frame_after_make_frame(frame: LispFrameOrSelected, made: LispObject) -> LispObject{
+pub fn frame_after_make_frame(frame: LispFrameOrSelected, made: LispObject) -> LispObject {
     let mut frame_ref = frame.live_or_error();
     frame_ref.set_after_make_frame(made.is_not_nil());
     frame_ref.set_inhibit_horizontal_resize(false);

--- a/src/frame.c
+++ b/src/frame.c
@@ -2502,27 +2502,6 @@ If there is no window system support, this function does nothing.  */)
   return Qnil;
 }
 
-DEFUN ("frame-after-make-frame",
-       Fframe_after_make_frame,
-       Sframe_after_make_frame, 2, 2, 0,
-       doc: /* Mark FRAME as made.
-FRAME nil means use the selected frame.  Second argument MADE non-nil
-means functions on `window-configuration-change-hook' are called
-whenever the window configuration of FRAME changes.  MADE nil means
-these functions are not called.
-
-This function is currently called by `make-frame' only and should be
-otherwise used with utter care to avoid that running functions on
-`window-configuration-change-hook' is impeded forever.  */)
-  (Lisp_Object frame, Lisp_Object made)
-{
-  struct frame *f = decode_live_frame (frame);
-  f->after_make_frame = !NILP (made);
-  f->inhibit_horizontal_resize = false;
-  f->inhibit_vertical_resize = false;
-  return made;
-}
-
 
 /* Discard BUFFER from the buffer-list and buried-buffer-list of each frame.  */
 
@@ -5718,7 +5697,6 @@ iconify the top level frame instead.  */);
   defsubr (&Sraise_frame);
   defsubr (&Slower_frame);
   defsubr (&Sx_focus_frame);
-  defsubr (&Sframe_after_make_frame);
   defsubr (&Sredirect_frame_focus);
   defsubr (&Sframe_focus);
   defsubr (&Sframe_parameters);


### PR DESCRIPTION
This is my first attempt with the remacs project.

I think I got the implementation straight but when I launch remacs it says `Symbol’s function definition is void: frame-after-make-frame`.