### PR TITLE
Make cons and equality functions generic

### DIFF
--- a/rust_src/src/buffers.rs
+++ b/rust_src/src/buffers.rs
@@ -828,9 +828,7 @@ pub extern "C" fn nsberror(spec: LispObject) -> ! {
 #[lisp_fn]
 pub fn overlay_lists() -> LispObject {
     let list_overlays = |ol: LispOverlayRef| -> LispObject {
-        ol.iter().fold(Qnil, |accum, n| {
-            LispObject::cons(LispObject::from(n), accum)
-        })
+        ol.iter().fold(Qnil, |accum, n| LispObject::cons(n, accum))
     };
 
     let cur_buf = ThreadState::current_buffer();

--- a/rust_src/src/data.rs
+++ b/rust_src/src/data.rs
@@ -703,7 +703,7 @@ pub fn set_default(symbol: LispSymbolRef, value: LispObject) -> LispObject {
 
 extern "C" fn harmonize_variable_watchers(alias: LispObject, base_variable: LispObject) {
     if !base_variable.eq(alias)
-        && base_variable.eq(alias.as_symbol_or_error().get_indirect_variable().into())
+        && base_variable.eq(alias.as_symbol_or_error().get_indirect_variable())
     {
         alias
             .as_symbol_or_error()

--- a/rust_src/src/data.rs
+++ b/rust_src/src/data.rs
@@ -32,7 +32,7 @@ use crate::{
         Qdefalias_fset_function, Qdefun, Qfinalizer, Qfloat, Qfont, Qfont_entity, Qfont_object,
         Qfont_spec, Qframe, Qfunction_documentation, Qhash_table, Qinteger, Qmany, Qmarker,
         Qmodule_function, Qmutex, Qnil, Qnone, Qoverlay, Qprocess, Qrange, Qsetting_constant,
-        Qstring, Qsubr, Qsymbol, Qt, Qterminal, Qthread, Qunbound, Qunevalled, Quser_ptr, Qvector,
+        Qstring, Qsubr, Qsymbol, Qterminal, Qthread, Qunbound, Qunevalled, Quser_ptr, Qvector,
         Qvoid_variable, Qwatchers, Qwindow, Qwindow_configuration,
     },
     symbols::LispSymbolRef,
@@ -176,7 +176,7 @@ pub fn subr_lang(subr: LispSubrRef) -> LispObject {
 #[lisp_fn]
 pub fn aref(array: LispObject, idx: EmacsInt) -> LispObject {
     if idx < 0 {
-        xsignal!(Qargs_out_of_range, array, idx.into());
+        xsignal!(Qargs_out_of_range, array, idx);
     }
 
     let idx_u = idx as usize;
@@ -184,13 +184,13 @@ pub fn aref(array: LispObject, idx: EmacsInt) -> LispObject {
     if let Some(s) = array.as_string() {
         match s.char_indices().nth(idx_u) {
             None => {
-                xsignal!(Qargs_out_of_range, array, idx.into());
+                xsignal!(Qargs_out_of_range, array, idx);
             }
             Some((_, cp)) => EmacsInt::from(cp).into(),
         }
     } else if let Some(bv) = array.as_bool_vector() {
         if idx_u >= bv.len() {
-            xsignal!(Qargs_out_of_range, array, idx.into());
+            xsignal!(Qargs_out_of_range, array, idx);
         }
 
         unsafe { bv.get_unchecked(idx_u) }
@@ -198,13 +198,13 @@ pub fn aref(array: LispObject, idx: EmacsInt) -> LispObject {
         ct.get(idx as isize)
     } else if let Some(v) = array.as_vector() {
         if idx_u >= v.len() {
-            xsignal!(Qargs_out_of_range, array, idx.into());
+            xsignal!(Qargs_out_of_range, array, idx);
         }
         unsafe { v.get_unchecked(idx_u) }
     } else if array.is_byte_code_function() || array.is_record() {
         let vl = array.as_vectorlike().unwrap();
         if idx >= vl.pseudovector_size() {
-            xsignal!(Qargs_out_of_range, array, idx.into());
+            xsignal!(Qargs_out_of_range, array, idx);
         }
         let v = unsafe { vl.as_vector_unchecked() };
         unsafe { v.get_unchecked(idx_u) }
@@ -235,7 +235,7 @@ pub fn aset(array: LispObject, idx: EmacsInt, newelt: LispObject) -> LispObject 
     } else if let Some(mut s) = array.as_string() {
         unsafe { CHECK_IMPURE(array, array.get_untaggedptr()) };
         if idx < 0 || idx >= s.len_chars() as EmacsInt {
-            args_out_of_range!(array, LispObject::from(idx));
+            args_out_of_range!(array, idx);
         }
 
         let c = newelt.as_character_or_error();
@@ -292,7 +292,7 @@ pub fn defalias(
 
         if is_autoload(symbol.get_function()) {
             // Remember that the function was already an autoload.
-            loadhist_attach(LispObject::cons(Qt, sym));
+            loadhist_attach(LispObject::cons(true, sym));
         }
         loadhist_attach(LispObject::cons(
             if autoload { Qautoload } else { Qdefun },
@@ -334,7 +334,7 @@ pub fn subr_arity(subr: LispSubrRef) -> LispObject {
         LispObject::from(EmacsInt::from(subr.max_args()))
     };
 
-    LispObject::cons(LispObject::from(EmacsInt::from(minargs)), maxargs)
+    LispObject::cons(EmacsInt::from(minargs), maxargs)
 }
 
 /// Return name of subroutine SUBR.
@@ -421,7 +421,7 @@ pub fn default_value_lisp(symbol: LispSymbolRef) -> LispObject {
     let value = default_value(symbol);
 
     if value.eq(Qunbound) {
-        xsignal!(Qvoid_variable, symbol.into());
+        xsignal!(Qvoid_variable, symbol);
     }
 
     value

--- a/rust_src/src/dired_unix.rs
+++ b/rust_src/src/dired_unix.rs
@@ -222,7 +222,7 @@ fn fnames_from_os(fnames: &mut Vec<String>, dname: &str, match_re: Option<LispOb
         xsignal!(
             Qfile_missing,
             format!("Opening directory: {}", res.unwrap_err()).to_bstring(),
-            LispObject::from(dname)
+            dname
         );
     }
 }

--- a/rust_src/src/dispnew.rs
+++ b/rust_src/src/dispnew.rs
@@ -159,7 +159,7 @@ pub extern "C" fn ding_internal(terminate_macro: bool) {
         } else if terminate_macro && !is_interactive() {
             // Stop executing a keyboard macro.
             let msg = "Keyboard macro terminated by a command ringing the bell";
-            xsignal!(Quser_error, msg.into());
+            xsignal!(Quser_error, msg);
         } else {
             ring_bell(selected_frame().as_mut())
         }

--- a/rust_src/src/editfns.rs
+++ b/rust_src/src/editfns.rs
@@ -226,11 +226,7 @@ pub fn position_bytes(position: LispNumber) -> Option<EmacsInt> {
 #[lisp_fn(min = "2")]
 pub fn insert_byte(byte: EmacsInt, count: Option<EmacsInt>, inherit: bool) {
     if byte < 0 || byte > 255 {
-        args_out_of_range!(
-            LispObject::from(byte),
-            LispObject::from(0),
-            LispObject::from(255)
-        )
+        args_out_of_range!(byte, 0, 255)
     }
     let buf = ThreadState::current_buffer();
     let toinsert = if byte >= 128 && buf.multibyte_characters_enabled() {
@@ -871,7 +867,7 @@ pub fn insert_buffer_substring(
     }
 
     if !(buf_ref.begv <= b && e <= buf_ref.zv) {
-        args_out_of_range!(beg.into(), end.into());
+        args_out_of_range!(beg, end);
     }
 
     let mut cur_buf = ThreadState::current_buffer();
@@ -938,7 +934,7 @@ pub fn message_box(args: &mut [LispObject]) -> LispObject {
             let val = format_message(args);
             let pane = list!(LispObject::cons(
                 build_string("OK".as_ptr() as *const ::libc::c_char),
-                Qt
+                true
             ));
             let menu = LispObject::cons(val, pane);
             Fx_popup_dialog(Qt, menu, Qt);

--- a/rust_src/src/eval.rs
+++ b/rust_src/src/eval.rs
@@ -177,11 +177,7 @@ pub fn setq(args: LispObject) -> LispObject {
         .enumerate();
     while let Some((nargs, sym)) = it.next() {
         let (_, arg) = it.next().unwrap_or_else(|| {
-            xsignal!(
-                Qwrong_number_of_arguments,
-                Qsetq,
-                LispObject::from(nargs + 1)
-            );
+            xsignal!(Qwrong_number_of_arguments, Qsetq, nargs + 1);
         });
 
         val = unsafe { eval_sub(arg) };
@@ -218,7 +214,7 @@ pub fn function(args: LispObject) -> LispObject {
     let (quoted, tail) = cell.as_tuple();
 
     if tail.is_not_nil() {
-        xsignal!(Qwrong_number_of_arguments, Qfunction, length(args).into());
+        xsignal!(Qwrong_number_of_arguments, Qfunction, length(args));
     }
 
     if unsafe { globals.Vinternal_interpreter_environment != Qnil } {
@@ -707,7 +703,7 @@ pub fn autoload(
 
     defalias(
         function,
-        list!(Qautoload, file.into(), docstring, interactive, ty),
+        list!(Qautoload, file, docstring, interactive, ty),
         Qnil,
     )
 }

--- a/rust_src/src/eval.rs
+++ b/rust_src/src/eval.rs
@@ -693,7 +693,7 @@ pub fn autoload(
         return Qnil;
     }
 
-    if unsafe { globals.Vpurify_flag != Qnil } && docstring.eq(LispObject::from(0)) {
+    if unsafe { globals.Vpurify_flag != Qnil } && docstring.eq(0) {
         // `read1' in lread.c has found the docstring starting with "\
         // and assumed the docstring will be provided by Snarf-documentation, so it
         // passed us 0 instead.  But that leads to accidental sharing in purecopy's
@@ -766,7 +766,7 @@ pub unsafe extern "C" fn un_autoload(oldqueue: LispObject) {
     for first in queue.iter_cars(LispConsEndChecks::off, LispConsCircularChecks::off) {
         let (first, second) = first.as_cons_or_error().as_tuple();
 
-        if first.eq(LispObject::from(0)) {
+        if first.eq(0) {
             globals.Vfeatures = second;
         } else {
             fset(first.as_symbol_or_error(), second);

--- a/rust_src/src/floatfns.rs
+++ b/rust_src/src/floatfns.rs
@@ -272,10 +272,7 @@ pub fn copysign(x1: EmacsDouble, x2: EmacsDouble) -> EmacsDouble {
 #[lisp_fn]
 pub fn frexp(x: EmacsDouble) -> LispObject {
     let (significand, exponent) = libm::frexp(x);
-    LispObject::cons(
-        LispObject::from_float(significand),
-        LispObject::from(exponent),
-    )
+    LispObject::cons(LispObject::from_float(significand), exponent)
 }
 
 /// Return SGNFCAND * 2**EXPONENT, as a floating point number.
@@ -409,7 +406,7 @@ where
         }
     }
 
-    xsignal!(Qrange_error, LispObject::from(name), arg)
+    xsignal!(Qrange_error, name, arg)
 }
 
 fn ceiling2(i1: EmacsInt, i2: EmacsInt) -> EmacsInt {

--- a/rust_src/src/fns.rs
+++ b/rust_src/src/fns.rs
@@ -51,15 +51,13 @@ pub fn provide(feature: LispSymbolRef, subfeature: LispObject) -> LispObject {
     }
     unsafe {
         if Vautoload_queue.is_not_nil() {
-            Vautoload_queue = LispObject::cons(
-                LispObject::cons(LispObject::from(0), globals.Vfeatures),
-                Vautoload_queue,
-            );
+            Vautoload_queue =
+                LispObject::cons(LispObject::cons(0, globals.Vfeatures), Vautoload_queue);
         }
     }
     if memq(feature.into(), unsafe { globals.Vfeatures }).is_nil() {
         unsafe {
-            globals.Vfeatures = LispObject::cons(feature.into(), globals.Vfeatures);
+            globals.Vfeatures = LispObject::cons(feature, globals.Vfeatures);
         }
     }
     if subfeature.is_not_nil() {
@@ -67,7 +65,7 @@ pub fn provide(feature: LispSymbolRef, subfeature: LispObject) -> LispObject {
     }
     unsafe {
         globals.Vcurrent_load_list = LispObject::cons(
-            LispObject::cons(Qprovide, feature.into()),
+            LispObject::cons(Qprovide, feature),
             globals.Vcurrent_load_list,
         );
     }
@@ -93,7 +91,7 @@ pub fn provide(feature: LispSymbolRef, subfeature: LispObject) -> LispObject {
 #[lisp_fn(unevalled = "true")]
 pub fn quote(args: LispCons) -> LispObject {
     if args.cdr().is_not_nil() {
-        xsignal!(Qwrong_number_of_arguments, Qquote, args.length().into());
+        xsignal!(Qwrong_number_of_arguments, Qquote, args.length());
     }
 
     args.car()

--- a/rust_src/src/fonts.rs
+++ b/rust_src/src/fonts.rs
@@ -92,7 +92,7 @@ impl FontExtraType {
         } else if extra_type.eq(unsafe { Qfont_object }) {
             FontExtraType::Object
         } else {
-            wrong_type!(LispObject::from(intern("font-extra-type")), extra_type);
+            wrong_type!(intern("font-extra-type"), extra_type);
         }
     }
 }

--- a/rust_src/src/frames.rs
+++ b/rust_src/src/frames.rs
@@ -124,7 +124,7 @@ impl LispFrameOrSelected {
         if frame.is_live() {
             frame
         } else {
-            wrong_type!(Qframe_live_p, self.into());
+            wrong_type!(Qframe_live_p, self);
         }
     }
 }
@@ -256,7 +256,7 @@ pub fn window_system(frame: LispFrameOrSelected) -> LispObject {
     let window_system = framep_1(frame);
 
     match window_system {
-        Qnil => wrong_type!(Qframep, frame.into()),
+        Qnil => wrong_type!(Qframep, frame),
         Qt => Qnil,
         _ => window_system,
     }
@@ -290,10 +290,7 @@ pub fn frame_visible_p(frame: LispFrameRef) -> LispObject {
 #[lisp_fn(min = "0")]
 pub fn frame_position(frame: LispFrameOrSelected) -> LispObject {
     let frame_ref = frame.live_or_error();
-    LispObject::cons(
-        LispObject::from(frame_ref.left_pos),
-        LispObject::from(frame_ref.top_pos),
-    )
+    LispObject::cons(frame_ref.left_pos, frame_ref.top_pos)
 }
 
 /// Returns t if the mouse pointer displayed on FRAME is visible.

--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -527,11 +527,17 @@ impl LispObject {
 
     // The three Emacs Lisp comparison functions.
 
-    pub fn eq(self, other: LispObject) -> bool {
-        self == other
+    pub fn eq<T>(self, other: T) -> bool
+    where
+        LispObject: From<T>,
+    {
+        self == LispObject::from(other)
     }
 
-    pub fn eql(self, other: LispObject) -> bool {
+    pub fn eql<T>(self, other: T) -> bool
+    where
+        LispObject: From<T>,
+    {
         if self.is_float() {
             self.equal_no_quit(other)
         } else {
@@ -539,12 +545,18 @@ impl LispObject {
         }
     }
 
-    pub fn equal(self, other: LispObject) -> bool {
-        unsafe { internal_equal(self, other, equal_kind::EQUAL_PLAIN, 0, Qnil) }
+    pub fn equal<T>(self, other: T) -> bool
+    where
+        LispObject: From<T>,
+    {
+        unsafe { internal_equal(self, other.into(), equal_kind::EQUAL_PLAIN, 0, Qnil) }
     }
 
-    pub fn equal_no_quit(self, other: LispObject) -> bool {
-        unsafe { internal_equal(self, other, equal_kind::EQUAL_NO_QUIT, 0, Qnil) }
+    pub fn equal_no_quit<T>(self, other: T) -> bool
+    where
+        LispObject: From<T>,
+    {
+        unsafe { internal_equal(self, other.into(), equal_kind::EQUAL_NO_QUIT, 0, Qnil) }
     }
 
     pub fn is_function(self) -> bool {

--- a/rust_src/src/lists.rs
+++ b/rust_src/src/lists.rs
@@ -46,8 +46,8 @@ impl LispObject {
 }
 
 impl LispObject {
-    pub fn cons(car: LispObject, cdr: LispObject) -> Self {
-        unsafe { Fcons(car, cdr) }
+    pub fn cons<A: Into<LispObject>, D: Into<LispObject>>(car: A, cdr: D) -> Self {
+        unsafe { Fcons(car.into(), cdr.into()) }
     }
 
     pub fn is_list(self) -> bool {

--- a/rust_src/src/numbers.rs
+++ b/rust_src/src/numbers.rs
@@ -148,7 +148,7 @@ pub trait IsLispNatnum {
 impl IsLispNatnum for EmacsInt {
     fn check_natnum(self) {
         if self < 0 {
-            wrong_type!(Qwholenump, LispObject::from(self));
+            wrong_type!(Qwholenump, self);
         }
     }
 }

--- a/rust_src/src/symbols.rs
+++ b/rust_src/src/symbols.rs
@@ -103,7 +103,7 @@ impl LispSymbolRef {
             tortoise = unsafe { tortoise.get_alias() };
 
             if hare == tortoise {
-                xsignal!(Qcyclic_variable_indirection, hare.into())
+                xsignal!(Qcyclic_variable_indirection, hare)
             }
         }
 
@@ -370,7 +370,7 @@ pub fn indirect_variable_lisp(object: LispObject) -> LispObject {
 #[lisp_fn]
 pub fn makunbound(symbol: LispSymbolRef) -> LispSymbolRef {
     if symbol.is_constant() {
-        xsignal!(Qsetting_constant, symbol.into());
+        xsignal!(Qsetting_constant, symbol);
     }
     set(symbol, Qunbound);
     symbol
@@ -383,7 +383,7 @@ pub fn makunbound(symbol: LispSymbolRef) -> LispSymbolRef {
 pub fn symbol_value(symbol: LispSymbolRef) -> LispObject {
     let val = unsafe { find_symbol_value(symbol.into()) };
     if val == Qunbound {
-        xsignal!(Qvoid_variable, symbol.into());
+        xsignal!(Qvoid_variable, symbol);
     }
     val
 }

--- a/rust_src/src/syntax.rs
+++ b/rust_src/src/syntax.rs
@@ -75,7 +75,7 @@ pub fn set_syntax_table(table: LispCharTableRef) -> LispCharTableRef {
 
 fn check_syntax_table_p(table: LispCharTableRef) {
     if table.purpose != Qsyntax_table {
-        wrong_type!(Qsyntax_table_p, LispObject::from(table))
+        wrong_type!(Qsyntax_table_p, table)
     }
 }
 

--- a/rust_src/src/vectors.rs
+++ b/rust_src/src/vectors.rs
@@ -278,7 +278,7 @@ macro_rules! impl_vectorlike_ref {
 
             pub fn set_checked(&mut self, idx: usize, item: LispObject) {
                 if idx >= self.len() {
-                    args_out_of_range!(LispObject::from(*self), LispObject::from(idx));
+                    args_out_of_range!(*self, idx);
                 }
 
                 unsafe { self.set_unchecked(idx, item) };
@@ -380,7 +380,7 @@ impl LispBoolVecRef {
 
     pub fn set_checked(&mut self, idx: usize, b: bool) {
         if idx >= self.len() {
-            args_out_of_range!(LispObject::from(*self), LispObject::from(idx));
+            args_out_of_range!(*self, idx);
         }
 
         unsafe { self.set_unchecked(idx, b) }


### PR DESCRIPTION
This allows for getting rid of a lot of manual casts, giving a Lispier feel while providing the same compiler guarantees. I don't think there are any runtime penalties for doing it this way.

Ideally everything would be generic, and we wouldn't need manual casts at all except maybe for weird cases (eg `LispObject::from_float`). In particular, it would be nice if there was a way to make all the `Fc_functions` generic.