### PR TITLE
Use specific error macros instead of xsignal

### DIFF
--- a/rust_src/src/buffers.rs
+++ b/rust_src/src/buffers.rs
@@ -40,7 +40,7 @@ use crate::{
     },
     remacs_sys::{
         Qafter_string, Qbefore_string, Qbuffer_read_only, Qbufferp, Qget_file_buffer,
-        Qinhibit_quit, Qinhibit_read_only, Qnil, Qoverlayp, Qt, Qunbound, Qvoid_variable,
+        Qinhibit_quit, Qinhibit_read_only, Qnil, Qoverlayp, Qt, Qunbound,
     },
     strings::string_equal,
     threads::{c_specpdl_index, ThreadState},
@@ -929,7 +929,7 @@ pub fn buffer_local_value_lisp(variable: LispObject, buffer: LispObject) -> Lisp
     let result = unsafe { buffer_local_value(variable, buffer) };
 
     if result.eq(Qunbound) {
-        xsignal!(Qvoid_variable, variable);
+        void_variable!(variable);
     }
 
     result

--- a/rust_src/src/data.rs
+++ b/rust_src/src/data.rs
@@ -27,13 +27,12 @@ use crate::{
     remacs_sys::{Fdelete, Fget, Fpurecopy},
     remacs_sys::{Lisp_Buffer, Lisp_Subr_Lang},
     remacs_sys::{
-        Qargs_out_of_range, Qarrayp, Qautoload, Qbool_vector, Qbuffer, Qchar_table, Qchoice,
-        Qcompiled_function, Qcondition_variable, Qcons, Qcyclic_function_indirection,
-        Qdefalias_fset_function, Qdefun, Qfinalizer, Qfloat, Qfont, Qfont_entity, Qfont_object,
-        Qfont_spec, Qframe, Qfunction_documentation, Qhash_table, Qinteger, Qmany, Qmarker,
-        Qmodule_function, Qmutex, Qnil, Qnone, Qoverlay, Qprocess, Qrange, Qsetting_constant,
-        Qstring, Qsubr, Qsymbol, Qterminal, Qthread, Qunbound, Qunevalled, Quser_ptr, Qvector,
-        Qvoid_variable, Qwatchers, Qwindow, Qwindow_configuration,
+        Qarrayp, Qautoload, Qbool_vector, Qbuffer, Qchar_table, Qchoice, Qcompiled_function,
+        Qcondition_variable, Qcons, Qcyclic_function_indirection, Qdefalias_fset_function, Qdefun,
+        Qfinalizer, Qfloat, Qfont, Qfont_entity, Qfont_object, Qfont_spec, Qframe,
+        Qfunction_documentation, Qhash_table, Qinteger, Qmany, Qmarker, Qmodule_function, Qmutex,
+        Qnil, Qnone, Qoverlay, Qprocess, Qrange, Qstring, Qsubr, Qsymbol, Qterminal, Qthread,
+        Qunbound, Qunevalled, Quser_ptr, Qvector, Qwatchers, Qwindow, Qwindow_configuration,
     },
     symbols::LispSymbolRef,
     threads::ThreadState,
@@ -176,7 +175,7 @@ pub fn subr_lang(subr: LispSubrRef) -> LispObject {
 #[lisp_fn]
 pub fn aref(array: LispObject, idx: EmacsInt) -> LispObject {
     if idx < 0 {
-        xsignal!(Qargs_out_of_range, array, idx);
+        args_out_of_range!(array, idx);
     }
 
     let idx_u = idx as usize;
@@ -184,13 +183,13 @@ pub fn aref(array: LispObject, idx: EmacsInt) -> LispObject {
     if let Some(s) = array.as_string() {
         match s.char_indices().nth(idx_u) {
             None => {
-                xsignal!(Qargs_out_of_range, array, idx);
+                args_out_of_range!(array, idx);
             }
             Some((_, cp)) => EmacsInt::from(cp).into(),
         }
     } else if let Some(bv) = array.as_bool_vector() {
         if idx_u >= bv.len() {
-            xsignal!(Qargs_out_of_range, array, idx);
+            args_out_of_range!(array, idx);
         }
 
         unsafe { bv.get_unchecked(idx_u) }
@@ -198,13 +197,13 @@ pub fn aref(array: LispObject, idx: EmacsInt) -> LispObject {
         ct.get(idx as isize)
     } else if let Some(v) = array.as_vector() {
         if idx_u >= v.len() {
-            xsignal!(Qargs_out_of_range, array, idx);
+            args_out_of_range!(array, idx);
         }
         unsafe { v.get_unchecked(idx_u) }
     } else if array.is_byte_code_function() || array.is_record() {
         let vl = array.as_vectorlike().unwrap();
         if idx >= vl.pseudovector_size() {
-            xsignal!(Qargs_out_of_range, array, idx);
+            args_out_of_range!(array, idx);
         }
         let v = unsafe { vl.as_vector_unchecked() };
         unsafe { v.get_unchecked(idx_u) }
@@ -421,7 +420,7 @@ pub fn default_value_lisp(symbol: LispSymbolRef) -> LispObject {
     let value = default_value(symbol);
 
     if value.eq(Qunbound) {
-        xsignal!(Qvoid_variable, symbol);
+        void_variable!(symbol);
     }
 
     value
@@ -796,7 +795,7 @@ pub fn fset(mut symbol: LispSymbolRef, definition: LispObject) -> LispObject {
     let sym_obj = LispObject::from(symbol);
     if sym_obj.is_nil() {
         // Perhaps not quite the right error signal, but seems good enough.
-        xsignal!(Qsetting_constant, sym_obj);
+        setting_constant!(sym_obj);
     }
 
     let function = symbol.get_function();

--- a/rust_src/src/dispnew.rs
+++ b/rust_src/src/dispnew.rs
@@ -18,8 +18,8 @@ use crate::{
         specbind, swallow_events, timespec_add, timespec_sub, wait_reading_process_output,
     },
     remacs_sys::{
-        globals, noninteractive, redisplaying_p, Qnil, Qredisplay_dont_pause, Qt, Quser_error,
-        Vframe_list, WAIT_READING_MAX,
+        globals, noninteractive, redisplaying_p, Qnil, Qredisplay_dont_pause, Qt, Vframe_list,
+        WAIT_READING_MAX,
     },
     remacs_sys::{EmacsDouble, EmacsInt, Lisp_Glyph},
     terminal::{clear_frame, update_begin, update_end},
@@ -158,8 +158,7 @@ pub extern "C" fn ding_internal(terminate_macro: bool) {
             putchar_unlocked(0o7);
         } else if terminate_macro && !is_interactive() {
             // Stop executing a keyboard macro.
-            let msg = "Keyboard macro terminated by a command ringing the bell";
-            xsignal!(Quser_error, msg);
+            user_error!("Keyboard macro terminated by a command ringing the bell");
         } else {
             ring_bell(selected_frame().as_mut())
         }

--- a/rust_src/src/eval.rs
+++ b/rust_src/src/eval.rs
@@ -25,7 +25,6 @@ use crate::{
         QCdocumentation, Qautoload, Qclosure, Qerror, Qexit, Qfunction, Qinteractive,
         Qinteractive_form, Qinternal_interpreter_environment, Qinvalid_function, Qlambda, Qmacro,
         Qnil, Qrisky_local_variable, Qsetq, Qt, Qunbound, Qvariable_documentation, Qvoid_function,
-        Qwrong_number_of_arguments,
     },
     remacs_sys::{Vautoload_queue, Vrun_hooks},
     symbols::{fboundp, symbol_function, LispSymbolRef},
@@ -177,7 +176,7 @@ pub fn setq(args: LispObject) -> LispObject {
         .enumerate();
     while let Some((nargs, sym)) = it.next() {
         let (_, arg) = it.next().unwrap_or_else(|| {
-            xsignal!(Qwrong_number_of_arguments, Qsetq, nargs + 1);
+            wrong_number_of_arguments!(Qsetq, nargs + 1);
         });
 
         val = unsafe { eval_sub(arg) };
@@ -214,7 +213,7 @@ pub fn function(args: LispObject) -> LispObject {
     let (quoted, tail) = cell.as_tuple();
 
     if tail.is_not_nil() {
-        xsignal!(Qwrong_number_of_arguments, Qfunction, length(args));
+        wrong_number_of_arguments!(Qfunction, length(args));
     }
 
     if unsafe { globals.Vinternal_interpreter_environment != Qnil } {

--- a/rust_src/src/eval_macros.rs
+++ b/rust_src/src/eval_macros.rs
@@ -95,6 +95,36 @@ macro_rules! args_out_of_range {
     ($($tt:tt)+) => { xsignal!(crate::remacs_sys::Qargs_out_of_range, $($tt)+); };
 }
 
+macro_rules! arith_error {
+    () => {
+        xsignal!(crate::remacs_sys::Qarith_error);
+    };
+}
+
+macro_rules! void_variable {
+    ($var:expr) => {
+        xsignal!(crate::remacs_sys::Qvoid_variable, $var);
+    };
+}
+
+macro_rules! wrong_number_of_arguments {
+    ($sym:expr, $num:expr) => {
+        xsignal!(crate::remacs_sys::Qwrong_number_of_arguments, $sym, $num);
+    };
+}
+
+macro_rules! setting_constant {
+    ($sym:expr) => {
+        xsignal!(crate::remacs_sys::Qsetting_constant, $sym);
+    };
+}
+
+macro_rules! user_error {
+    ($msg:expr) => {
+        xsignal!(crate::remacs_sys::Quser_error, $msg);
+    };
+}
+
 macro_rules! list {
     ($arg:expr, $($tt:tt)+) => { $crate::lisp::LispObject::cons($arg, list!($($tt)+)) };
     ($arg:expr) => { $crate::lisp::LispObject::cons($arg, list!()) };

--- a/rust_src/src/floatfns.rs
+++ b/rust_src/src/floatfns.rs
@@ -14,7 +14,7 @@ use crate::{
     math::ArithOp,
     numbers::{LispNumber, MOST_NEGATIVE_FIXNUM, MOST_POSITIVE_FIXNUM},
     remacs_sys::{EmacsDouble, EmacsInt, EmacsUint, Lisp_Float, Lisp_Type},
-    remacs_sys::{Qarith_error, Qfloatp, Qinteger_or_marker_p, Qnumberp, Qrange_error},
+    remacs_sys::{Qfloatp, Qinteger_or_marker_p, Qnumberp, Qrange_error},
 };
 
 // Float support (LispType == Lisp_Float == 7 )
@@ -385,7 +385,7 @@ where
     } else {
         if let (Some(arg), Some(div)) = (arg.as_fixnum(), divisor.as_fixnum()) {
             if div == 0 {
-                xsignal!(Qarith_error);
+                arith_error!();
             }
             return int_round2(arg, div);
         }

--- a/rust_src/src/fns.rs
+++ b/rust_src/src/fns.rs
@@ -17,10 +17,7 @@ use crate::{
     remacs_sys::{concat as lisp_concat, globals, record_unwind_protect},
     remacs_sys::{equal_kind, Lisp_Type},
     remacs_sys::{Fload, Fmapc},
-    remacs_sys::{
-        Qfuncall, Qlistp, Qnil, Qprovide, Qquote, Qrequire, Qsubfeatures, Qt,
-        Qwrong_number_of_arguments,
-    },
+    remacs_sys::{Qfuncall, Qlistp, Qnil, Qprovide, Qquote, Qrequire, Qsubfeatures, Qt},
     symbols::LispSymbolRef,
     threads::c_specpdl_index,
 };
@@ -91,7 +88,7 @@ pub fn provide(feature: LispSymbolRef, subfeature: LispObject) -> LispObject {
 #[lisp_fn(unevalled = "true")]
 pub fn quote(args: LispCons) -> LispObject {
     if args.cdr().is_not_nil() {
-        xsignal!(Qwrong_number_of_arguments, Qquote, args.length());
+        wrong_number_of_arguments!(Qquote, args.length());
     }
 
     args.car()

--- a/rust_src/src/keyboard.rs
+++ b/rust_src/src/keyboard.rs
@@ -19,9 +19,7 @@ use crate::{
         window_box_left_offset,
     },
     remacs_sys::{Fpos_visible_in_window_p, Fthrow},
-    remacs_sys::{
-        Qexit, Qheader_line, Qhelp_echo, Qmode_line, Qnil, Qt, Quser_error, Qvertical_line,
-    },
+    remacs_sys::{Qexit, Qheader_line, Qhelp_echo, Qmode_line, Qnil, Qt, Qvertical_line},
     threads::c_specpdl_index,
     windows::{selected_window, LispWindowOrSelected},
 };
@@ -131,14 +129,7 @@ pub fn quit_recursive_edit(val: bool) -> ! {
             Fthrow(Qexit, LispObject::from_bool(val));
         }
 
-        let msg = "No recursive edit is in progress";
-        xsignal!(
-            Quser_error,
-            crate::remacs_sys::make_string(
-                msg.as_ptr() as *const ::libc::c_char,
-                msg.len() as ::libc::ptrdiff_t,
-            )
-        );
+        user_error!("No recursive edit is in progress");
     }
 }
 

--- a/rust_src/src/math.rs
+++ b/rust_src/src/math.rs
@@ -1,7 +1,7 @@
 //! Functions doing math on numbers.
 #![allow(clippy::float_cmp)]
 
-use crate::remacs_sys::{EmacsInt, Qarith_error, Qnumberp};
+use crate::remacs_sys::{EmacsInt, Qnumberp};
 use remacs_macros::lisp_fn;
 
 use crate::{
@@ -19,7 +19,7 @@ pub fn lisp_mod(x: LispNumber, y: LispNumber) -> LispObject {
     match (x, y) {
         (LispNumber::Fixnum(mut i1), LispNumber::Fixnum(i2)) => {
             if i2 == 0 {
-                xsignal!(Qarith_error);
+                arith_error!();
             }
 
             i1 %= i2;
@@ -125,7 +125,7 @@ fn arith_driver(code: ArithOp, args: &[LispObject]) -> LispObject {
                             accum = next;
                         } else {
                             if next == 0 {
-                                xsignal!(Qarith_error);
+                                arith_error!();
                             }
                             if accum.checked_div(next).is_none() {
                                 overflow = true;
@@ -392,7 +392,7 @@ pub fn rem(x: LispNumber, y: LispNumber) -> EmacsInt {
     let y = y.to_fixnum();
 
     if y == 0 {
-        xsignal!(Qarith_error);
+        arith_error!();
     }
 
     x % y

--- a/rust_src/src/symbols.rs
+++ b/rust_src/src/symbols.rs
@@ -15,9 +15,7 @@ use crate::{
         symbol_interned, symbol_redirect, symbol_trapped_write,
     },
     remacs_sys::{lispsym, EmacsInt, Lisp_Symbol, Lisp_Type, USE_LSB_TAG},
-    remacs_sys::{
-        Qcyclic_variable_indirection, Qnil, Qsetting_constant, Qsymbolp, Qunbound, Qvoid_variable,
-    },
+    remacs_sys::{Qcyclic_variable_indirection, Qnil, Qsymbolp, Qunbound},
 };
 
 pub type LispSymbolRef = ExternalPtr<Lisp_Symbol>;
@@ -326,7 +324,7 @@ pub fn setplist(mut symbol: LispSymbolRef, newplist: LispObject) -> LispObject {
 pub fn fmakunbound(symbol: LispObject) -> LispSymbolRef {
     let mut sym = symbol.as_symbol_or_error();
     if symbol.is_nil() || symbol.is_t() {
-        xsignal!(Qsetting_constant, symbol);
+        setting_constant!(symbol);
     }
     sym.set_function(Qnil);
     sym
@@ -370,7 +368,7 @@ pub fn indirect_variable_lisp(object: LispObject) -> LispObject {
 #[lisp_fn]
 pub fn makunbound(symbol: LispSymbolRef) -> LispSymbolRef {
     if symbol.is_constant() {
-        xsignal!(Qsetting_constant, symbol);
+        setting_constant!(symbol);
     }
     set(symbol, Qunbound);
     symbol
@@ -383,7 +381,7 @@ pub fn makunbound(symbol: LispSymbolRef) -> LispSymbolRef {
 pub fn symbol_value(symbol: LispSymbolRef) -> LispObject {
     let val = unsafe { find_symbol_value(symbol.into()) };
     if val == Qunbound {
-        xsignal!(Qvoid_variable, symbol);
+        void_variable!(symbol);
     }
     val
 }

--- a/rust_src/src/syntax.rs
+++ b/rust_src/src/syntax.rs
@@ -91,7 +91,7 @@ pub extern "C" fn check_syntax_table(obj: LispObject) {
         .as_char_table()
         .map_or(true, |c| !c.purpose.eq(Qsyntax_table))
     {
-        xsignal!(Qsyntax_table_p, obj);
+        wrong_type!(Qsyntax_table_p, obj);
     }
 }
 


### PR DESCRIPTION
This reduces the number of symbols that need to be passed around.