### PR TITLE
Make 'unexec' support optional for Mac.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5435,6 +5435,14 @@ CARGO_DEFAULT_FEATURES=""
 if test "$HAVE_LIBXML2" = "yes"; then
     CARGO_DEFAULT_FEATURES="${CARGO_DEFAULT_FEATURES}\"use-xml2\", "
 fi
+if test "$CANNOT_DUMP" != "yes"; then
+    if test "$opsys" = "darwin"; then
+        CARGO_DEFAULT_FEATURES="${CARGO_DEFAULT_FEATURES}\"unexecmacosx\", "
+    else
+        CARGO_DEFAULT_FEATURES="${CARGO_DEFAULT_FEATURES}\"unexec\", "
+    fi
+fi
+
 AC_SUBST(CARGO_DEFAULT_FEATURES)
 AC_CONFIG_FILES([rust_src/Cargo.toml])
 

--- a/rust_src/Cargo.toml.in
+++ b/rust_src/Cargo.toml.in
@@ -27,7 +27,7 @@ if_chain = "0.1.3"
 
 # Only want this local crate as dependency on Mac OS X
 [target.'cfg(target_os = "macos")'.dependencies]
-alloc_unexecmacosx = { version = "0.1.0", path = "alloc_unexecmacosx" }
+alloc_unexecmacosx = { version = "0.1.0", path = "alloc_unexecmacosx", optional = true }
 
 [build-dependencies]
 clippy = { version = "*", optional = true }
@@ -48,6 +48,10 @@ panic = "abort"
 
 [features]
 default = [@CARGO_DEFAULT_FEATURES@]
+# Use unexec crate on Mac
+unexecmacosx = ["alloc_unexecmacosx"]
+# unexec everywhere else
+unexec = []
 # Compile with C xml2 library support.
 use-xml2 = []
 compile-errors = []

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -39,7 +39,7 @@ extern crate flate2;
 extern crate core;
 
 // Wilfred/remacs#38 : Need to override the allocator for legacy unexec support on Mac.
-#[cfg(all(not(test), target_os = "macos"))]
+#[cfg(all(not(test), target_os = "macos", feature = "unexecmacosx"))]
 extern crate alloc_unexecmacosx;
 
 // Needed for linking.
@@ -124,10 +124,10 @@ mod window_configuration;
 mod windows;
 mod xml;
 
-#[cfg(all(not(test), target_os = "macos"))]
+#[cfg(all(not(test), target_os = "macos", feature = "unexecmacosx"))]
 use alloc_unexecmacosx::OsxUnexecAlloc;
 
-#[cfg(all(not(test), target_os = "macos"))]
+#[cfg(all(not(test), target_os = "macos", feature = "unexecmacosx"))]
 #[global_allocator]
 static ALLOCATOR: OsxUnexecAlloc = OsxUnexecAlloc;
 


### PR DESCRIPTION
This allows a build with the variable `CANNOT_DUMP=yes`.