### PR TITLE
Port clear-face-cache (fix #1164)

### DIFF
--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -122,6 +122,7 @@ mod util;
 mod vectors;
 mod window_configuration;
 mod windows;
+mod xfaces;
 mod xml;
 
 #[cfg(all(not(test), target_os = "macos", feature = "unexecmacosx"))]

--- a/rust_src/src/xfaces.rs
+++ b/rust_src/src/xfaces.rs
@@ -1,0 +1,21 @@
+//! "Face" primitives.
+
+use remacs_macros::lisp_fn;
+
+use crate::{
+    lisp::defsubr,
+    remacs_sys::{clear_face_cache, set_face_change, windows_or_buffers_changed},
+};
+
+/// Clear face caches on all frames.
+/// Optional THOROUGHLY non-nil means try to free unused fonts, too.
+#[lisp_fn(min = "0", name = "clear-face-cache", c_name = "clear_face_cache")]
+pub fn clear_face_cache_lisp(thoroughly: bool) {
+    unsafe {
+        clear_face_cache(thoroughly);
+        set_face_change(true);
+        windows_or_buffers_changed = 53;
+    }
+}
+
+include!(concat!(env!("OUT_DIR"), "/xfaces_exports.rs"));

--- a/src/dispextern.h
+++ b/src/dispextern.h
@@ -1812,6 +1812,8 @@ GLYPH_CODE_P (Lisp_Object gc)
 
 extern bool face_change;
 
+void set_face_change(bool value);
+
 /* For reordering of bidirectional text.  */
 
 /* UAX#9's max_depth value.  */

--- a/src/xfaces.c
+++ b/src/xfaces.c
@@ -356,6 +356,11 @@ static struct face *realize_non_ascii_face (struct frame *, Lisp_Object,
 			      Utilities
  ***********************************************************************/
 
+void set_face_change(bool value)
+{
+    face_change = value;
+}
+
 #ifdef HAVE_X_WINDOWS
 
 #ifdef DEBUG_X_COLORS
@@ -644,17 +649,6 @@ clear_face_cache (bool clear_fonts_p)
       clear_image_caches (Qnil);
     }
 #endif /* HAVE_WINDOW_SYSTEM */
-}
-
-DEFUN ("clear-face-cache", Fclear_face_cache, Sclear_face_cache, 0, 1, 0,
-       doc: /* Clear face caches on all frames.
-Optional THOROUGHLY non-nil means try to free unused fonts, too.  */)
-  (Lisp_Object thoroughly)
-{
-  clear_face_cache (!NILP (thoroughly));
-  face_change = true;
-  windows_or_buffers_changed = 53;
-  return Qnil;
 }
 
 
@@ -6303,7 +6297,6 @@ syms_of_xfaces (void)
   defsubr (&Sdump_face);
   defsubr (&Sshow_face_resources);
 #endif /* GLYPH_DEBUG */
-  defsubr (&Sclear_face_cache);
   defsubr (&Stty_suppress_bold_inverse_default_colors);
 
 #if defined DEBUG_X_COLORS && defined HAVE_X_WINDOWS


### PR DESCRIPTION
1. I'd like to give that `53` a meaningful constant name, but I don't know what this value means
2. I can't get this to compile, even when cleaning the build. This is the first time I'm making a new Rust module in Remacs so I probably missed something:

```
/usr/bin/ld: composite.o: in function `Fclear_composition_cache':
/home/roeyd/src/remacs/src/composite.c:700: undefined reference to `Fclear_face_cache'
/usr/bin/ld: fontset.o: in function `free_realized_fontsets':
/home/roeyd/src/remacs/src/fontset.c:1327: undefined reference to `Fclear_face_cache'
collect2: error: ld returned 1 exit status
```