### PR TITLE
If the Rust name is not the expected C name we have to set it.

### DIFF
--- a/rust_src/src/buffers.rs
+++ b/rust_src/src/buffers.rs
@@ -1038,7 +1038,11 @@ pub fn delete_overlay(overlay: LispOverlayRef) {
 
 /// Delete all overlays of BUFFER.
 /// BUFFER omitted or nil means delete all overlays of the current buffer.
-#[lisp_fn(min = "0", name = "delete-all-overlays")]
+#[lisp_fn(
+    min = "0",
+    name = "delete-all-overlays",
+    c_name = "delete_all_overlays"
+)]
 pub fn delete_all_overlays_lisp(buffer: LispBufferOrCurrent) {
     let mut buf: LispBufferRef = buffer.into();
     unsafe { delete_all_overlays(buf.as_mut()) };

--- a/rust_src/src/keymap.rs
+++ b/rust_src/src/keymap.rs
@@ -313,7 +313,7 @@ pub unsafe extern "C" fn map_keymap(
 /// This works recursively: if the parent has itself a parent, then the
 /// grandparent's bindings are also included and so on.
 /// usage: (map-keymap FUNCTION KEYMAP)
-#[lisp_fn(name = "map-keymap", min = "2")]
+#[lisp_fn(name = "map-keymap", c_name = "map_keymap", min = "2")]
 pub fn map_keymap_lisp(function: LispObject, keymap: LispObject, sort_first: bool) -> LispObject {
     if sort_first {
         return call!(
@@ -396,7 +396,7 @@ pub unsafe extern "C" fn map_keymap_internal(
 /// FUNCTION is called with two arguments: the event that is bound, and
 /// the definition it is bound to.  The event may be a character range.
 /// If KEYMAP has a parent, this function returns it without processing it.
-#[lisp_fn(name = "map-keymap-internal")]
+#[lisp_fn(name = "map-keymap-internal", c_name = "map_keymap_internal")]
 pub fn map_keymap_internal_lisp(function: LispObject, mut keymap: LispObject) -> LispObject {
     keymap = get_keymap(keymap, true, true);
     unsafe { map_keymap_internal(keymap, Some(map_keymap_call), function, ptr::null_mut()) }
@@ -592,7 +592,7 @@ pub extern "C" fn describe_vector_princ(elt: LispObject, fun: LispObject) {
 /// Insert a description of contents of VECTOR.
 /// This is text showing the elements of vector matched against indices.
 /// DESCRIBER is the output function used; nil means use `princ'.
-#[lisp_fn(min = "1", name = "describe-vector")]
+#[lisp_fn(min = "1", name = "describe-vector", c_name = "describe_vector")]
 pub fn describe_vector_lisp(vector: LispObject, mut describer: LispObject) {
     if describer.is_nil() {
         describer = LispObject::from(intern("princ"));

--- a/rust_src/src/process.rs
+++ b/rust_src/src/process.rs
@@ -532,8 +532,8 @@ pub fn process_running_child_p(mut process: LispObject) -> LispObject {
 /// If this functionality is unsupported, return nil.
 ///
 /// See `process-attributes' for getting attributes of a process given its ID.
-#[lisp_fn(name = "list-system-processes")]
-pub fn list_system_processes_rust() -> LispObject {
+#[lisp_fn(name = "list-system-processes", c_name = "list_system_processes")]
+pub fn list_system_processes_lisp() -> LispObject {
     unsafe { list_system_processes() }
 }
 

--- a/rust_src/src/syntax.rs
+++ b/rust_src/src/syntax.rs
@@ -56,8 +56,8 @@ def_lisp_sym!(Qsyntax_table_p, "syntax-table-p");
 
 // We don't name it scan_lists because there is an internal function
 // with the same name
-#[lisp_fn(name = "scan-lists")]
-pub fn scan_lists_defun(from: EmacsInt, count: EmacsInt, depth: EmacsInt) -> LispObject {
+#[lisp_fn(name = "scan-lists", c_name = "scan_lists")]
+pub fn scan_lists_lisp(from: EmacsInt, count: EmacsInt, depth: EmacsInt) -> LispObject {
     unsafe { scan_lists(from, count, depth, false) }
 }
 

--- a/rust_src/src/window_configuration.rs
+++ b/rust_src/src/window_configuration.rs
@@ -195,7 +195,10 @@ pub fn compare_window_configurations_rust(
 /// Compare two window configurations as regards the structure of windows.
 /// This function ignores details such as the values of point
 /// and scrolling positions.
-#[lisp_fn(name = "compare-window-configurations")]
+#[lisp_fn(
+    name = "compare-window-configurations",
+    c_name = "compare_window_configurations"
+)]
 pub fn compare_window_configurations_lisp(x: SaveWindowDataRef, y: SaveWindowDataRef) -> bool {
     compare_window_configurations_rust(x, y, true)
 }

--- a/rust_src/src/windows.rs
+++ b/rust_src/src/windows.rs
@@ -617,7 +617,7 @@ pub fn minibuffer_window(frame: LispFrameOrSelected) -> LispObject {
 
 /// Return WINDOW's value for PARAMETER.
 /// WINDOW can be any window and defaults to the selected one.
-#[lisp_fn(name = "window-parameter")]
+#[lisp_fn(name = "window-parameter", c_name = "window_parameter")]
 pub fn window_parameter_lisp(window: LispWindowOrSelected, parameter: LispObject) -> LispObject {
     let win: LispWindowRef = window.into();
     win.get_parameter(parameter)
@@ -782,8 +782,8 @@ pub fn window_list(
 ///
 /// If WINDOW is not on the list of windows returned, some other window will
 /// be listed first but no error is signaled.
-#[lisp_fn(min = "0", name = "window-list-1")]
-pub fn window_list_one(
+#[lisp_fn(min = "0", name = "window-list-1", c_name = "window_list_1")]
+pub fn window_list_1_lisp(
     window: LispObject,
     minibuf: LispObject,
     all_frames: LispObject,


### PR DESCRIPTION
The function name exported to C is the Rust name with a capital F
prepended. If this is not the intended name then we have to set the
correct name with `c_name`. The value of `name` is _NOT_ used because
it could be an invalid C (and Rust) name like for instance `+`.

Also, this PR begins standardizing our naming. Rust versions of a DEFUN
which cannot use the orignal name are named `foo_lisp`.