### PR TITLE
Intern should only accept strings

### DIFF
--- a/rust_src/src/minibuf.rs
+++ b/rust_src/src/minibuf.rs
@@ -367,7 +367,7 @@ pub fn read_command_or_variable(
     if name.is_nil() {
         name
     } else {
-        lisp_intern(name, Qnil)
+        lisp_intern(name.into(), None)
     }
 }
 

--- a/test/rust_src/src/obarray-tests.el
+++ b/test/rust_src/src/obarray-tests.el
@@ -9,6 +9,10 @@
   ;; If the second argument is not an obarray, we should error.
   (should-error
    (intern "foo" 123)
+   :type 'wrong-type-argument)
+  ;; `intern' should only accept strings.
+  (should-error
+   (intern 'symbol)
    :type 'wrong-type-argument))
 
 (ert-deftest obarray-tests-mapatoms ()


### PR DESCRIPTION
This is the GNU Emacs behavior.