### PR TITLE
Add from_lispobject_for_option macro

### DIFF
--- a/rust_src/src/buffers.rs
+++ b/rust_src/src/buffers.rs
@@ -417,11 +417,7 @@ impl From<LispBufferRef> for LispObject {
     }
 }
 
-impl From<LispObject> for Option<LispBufferRef> {
-    fn from(o: LispObject) -> Self {
-        o.as_buffer()
-    }
-}
+from_lispobject_for_option!(LispBufferRef);
 
 impl LispObject {
     pub fn is_overlay(self) -> bool {
@@ -451,11 +447,7 @@ impl From<LispOverlayRef> for LispObject {
     }
 }
 
-impl From<LispObject> for Option<LispOverlayRef> {
-    fn from(o: LispObject) -> Self {
-        o.as_overlay()
-    }
-}
+from_lispobject_for_option!(LispOverlayRef);
 
 impl LispMiscRef {
     pub fn as_overlay(self) -> Option<LispOverlayRef> {
@@ -553,19 +545,7 @@ impl From<LispObject> for LispBufferOrName {
     }
 }
 
-impl From<LispObject> for Option<LispBufferOrName> {
-    fn from(v: LispObject) -> Option<LispBufferOrName> {
-        if v.is_nil() {
-            None
-        } else if v.is_string() {
-            Some(LispBufferOrName::Name(v))
-        } else if v.is_buffer() {
-            Some(LispBufferOrName::Buffer(v))
-        } else {
-            None
-        }
-    }
-}
+from_lispobject_for_option!(LispBufferOrName);
 
 impl From<LispBufferOrName> for Option<LispBufferRef> {
     fn from(v: LispBufferOrName) -> Option<LispBufferRef> {

--- a/rust_src/src/chartable.rs
+++ b/rust_src/src/chartable.rs
@@ -45,11 +45,7 @@ impl From<LispObject> for LispCharTableRef {
     }
 }
 
-impl From<LispObject> for Option<LispCharTableRef> {
-    fn from(o: LispObject) -> Self {
-        o.as_char_table()
-    }
-}
+from_lispobject_for_option!(LispCharTableRef);
 
 impl From<LispCharTableRef> for LispObject {
     fn from(ct: LispCharTableRef) -> Self {

--- a/rust_src/src/eval_macros.rs
+++ b/rust_src/src/eval_macros.rs
@@ -7,6 +7,36 @@
  * the unsafe is not used.
  */
 
+/// Ideally, we would be able to write this:
+///
+///   impl<T: From<LispObject>> From<LispObject> for Option<T> {
+///       fn from(o: LispObject) -> Option<T> {
+///           if o.is_nil() {
+///               None
+///           } else {
+///               Some(T::from(o))
+///           }
+///       }
+///   }
+///
+/// Due to the so-called "orphan rule", this is not possible; external
+/// traits (like `From`) can't be implemented for external types (like
+/// `Option`). This may change in the future, but for now a bunch of
+/// boilerplate is required. To get around this, we can use a macro.
+macro_rules! from_lispobject_for_option {
+    ($type:ident) => {
+        impl From<LispObject> for Option<$type> {
+            fn from(o: LispObject) -> Option<$type> {
+                if o.is_nil() {
+                    None
+                } else {
+                    Some($type::from(o))
+                }
+            }
+        }
+    };
+}
+
 /// Macro to generate an error with a list from any number of arguments.
 /// Replaces xsignal0, etc. in the C layer.
 ///

--- a/rust_src/src/floatfns.rs
+++ b/rust_src/src/floatfns.rs
@@ -79,15 +79,7 @@ impl From<LispObject> for EmacsDouble {
     }
 }
 
-impl From<LispObject> for Option<EmacsDouble> {
-    fn from(o: LispObject) -> Self {
-        if o.is_nil() {
-            None
-        } else {
-            Some(o.any_to_float_or_error())
-        }
-    }
-}
+from_lispobject_for_option!(EmacsDouble);
 
 /// Either extracts a floating point number from a lisp number (of any kind) or throws an error
 /// TODO this is used from C in a few places; remove afterwards.

--- a/rust_src/src/frames.rs
+++ b/rust_src/src/frames.rs
@@ -46,11 +46,7 @@ impl From<LispFrameRef> for LispObject {
     }
 }
 
-impl From<LispObject> for Option<LispFrameRef> {
-    fn from(o: LispObject) -> Self {
-        o.as_frame()
-    }
-}
+from_lispobject_for_option!(LispFrameRef);
 
 impl LispObject {
     pub fn is_frame(self) -> bool {

--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -293,14 +293,7 @@ impl From<LispObject> for u32 {
     }
 }
 
-impl From<LispObject> for Option<u32> {
-    fn from(o: LispObject) -> Self {
-        match o.as_fixnum() {
-            None => None,
-            Some(n) => Some(n as u32),
-        }
-    }
-}
+from_lispobject_for_option!(u32);
 
 impl From<!> for LispObject {
     fn from(_v: !) -> Self {
@@ -354,15 +347,7 @@ impl From<LispObject> for EmacsInt {
     }
 }
 
-impl From<LispObject> for Option<EmacsInt> {
-    fn from(o: LispObject) -> Self {
-        if o.is_nil() {
-            None
-        } else {
-            Some(o.as_fixnum_or_error())
-        }
-    }
-}
+from_lispobject_for_option!(EmacsInt);
 
 impl From<LispObject> for EmacsUint {
     fn from(o: LispObject) -> Self {
@@ -370,15 +355,7 @@ impl From<LispObject> for EmacsUint {
     }
 }
 
-impl From<LispObject> for Option<EmacsUint> {
-    fn from(o: LispObject) -> Self {
-        if o.is_nil() {
-            None
-        } else {
-            Some(o.as_natnum_or_error())
-        }
-    }
-}
+from_lispobject_for_option!(EmacsUint);
 
 impl From<EmacsInt> for LispObject {
     fn from(v: EmacsInt) -> Self {

--- a/rust_src/src/lists.rs
+++ b/rust_src/src/lists.rs
@@ -240,15 +240,7 @@ impl From<LispObject> for LispCons {
     }
 }
 
-impl From<LispObject> for Option<LispCons> {
-    fn from(o: LispObject) -> Self {
-        if o.is_list() {
-            Some(o.as_cons_or_error())
-        } else {
-            None
-        }
-    }
-}
+from_lispobject_for_option!(LispCons);
 
 impl From<LispCons> for LispObject {
     fn from(c: LispCons) -> Self {

--- a/rust_src/src/marker.rs
+++ b/rust_src/src/marker.rs
@@ -113,11 +113,7 @@ impl From<LispMarkerRef> for LispObject {
     }
 }
 
-impl From<LispObject> for Option<LispMarkerRef> {
-    fn from(o: LispObject) -> Self {
-        o.as_marker()
-    }
-}
+from_lispobject_for_option!(LispMarkerRef);
 
 impl LispObject {
     pub fn is_marker(self) -> bool {

--- a/rust_src/src/numbers.rs
+++ b/rust_src/src/numbers.rs
@@ -174,11 +174,7 @@ impl From<LispObject> for LispNumber {
     }
 }
 
-impl From<LispObject> for Option<LispNumber> {
-    fn from(o: LispObject) -> Self {
-        o.as_number_coerce_marker()
-    }
-}
+from_lispobject_for_option!(LispNumber);
 
 impl From<LispNumber> for LispObject {
     fn from(n: LispNumber) -> LispObject {

--- a/rust_src/src/obarray.rs
+++ b/rust_src/src/obarray.rs
@@ -90,15 +90,7 @@ impl From<LispObject> for LispObarrayRef {
     }
 }
 
-impl From<LispObject> for Option<LispObarrayRef> {
-    fn from(o: LispObject) -> Self {
-        if o.is_nil() {
-            None
-        } else {
-            Some(o.as_obarray_or_error())
-        }
-    }
-}
+from_lispobject_for_option!(LispObarrayRef);
 
 /// Intern (e.g. create a symbol from) a string.
 pub fn intern<T: AsRef<str>>(string: T) -> LispSymbolRef {

--- a/rust_src/src/process.rs
+++ b/rust_src/src/process.rs
@@ -70,11 +70,7 @@ impl From<LispProcessRef> for LispObject {
     }
 }
 
-impl From<LispObject> for Option<LispProcessRef> {
-    fn from(o: LispObject) -> Self {
-        o.as_process()
-    }
-}
+from_lispobject_for_option!(LispProcessRef);
 
 macro_rules! for_each_process {
     ($name:ident => $action:block) => {

--- a/rust_src/src/symbols.rs
+++ b/rust_src/src/symbols.rs
@@ -163,11 +163,7 @@ impl From<LispSymbolRef> for LispObject {
     }
 }
 
-impl From<LispObject> for Option<LispSymbolRef> {
-    fn from(o: LispObject) -> Self {
-        o.as_symbol()
-    }
-}
+from_lispobject_for_option!(LispSymbolRef);
 
 // Symbol support (LispType == Lisp_Symbol == 0)
 impl LispObject {

--- a/rust_src/src/windows.rs
+++ b/rust_src/src/windows.rs
@@ -235,11 +235,7 @@ impl From<LispWindowRef> for LispObject {
     }
 }
 
-impl From<LispObject> for Option<LispWindowRef> {
-    fn from(o: LispObject) -> Self {
-        o.as_window()
-    }
-}
+from_lispobject_for_option!(LispWindowRef);
 
 impl LispObject {
     pub fn is_window(self) -> bool {


### PR DESCRIPTION
Ideally, we would be able to write this:

```rust
  impl<T: From<LispObject>> From<LispObject> for Option<T> {
      fn from(o: LispObject) -> Option<T> {
          if o.is_nil() {
              None
          } else {
              Some(T::from(o))
          }
      }
  }
```

Due to the so-called "orphan rule", this is not possible; external
traits (like `From`) can't be implemented for external types (like
`Option`). This may change in the future, but for now a bunch of
boilerplate is required. To get around this, we can use a macro.