### PR TITLE
impl From<(S, T)> for LispObject

### DIFF
--- a/rust_src/src/buffers.rs
+++ b/rust_src/src/buffers.rs
@@ -827,14 +827,13 @@ pub extern "C" fn nsberror(spec: LispObject) -> ! {
 /// However, the overlays you get are the real objects that the buffer uses.
 #[lisp_fn]
 pub fn overlay_lists() -> LispObject {
-    let list_overlays = |ol: LispOverlayRef| -> LispObject {
-        ol.iter().fold(Qnil, |accum, n| LispObject::cons(n, accum))
-    };
+    let list_overlays =
+        |ol: LispOverlayRef| -> LispObject { ol.iter().fold(Qnil, |accum, n| (n, accum).into()) };
 
     let cur_buf = ThreadState::current_buffer();
     let before = cur_buf.overlays_before().map_or(Qnil, &list_overlays);
     let after = cur_buf.overlays_after().map_or(Qnil, &list_overlays);
-    unsafe { LispObject::cons(Fnreverse(before), Fnreverse(after)) }
+    unsafe { (Fnreverse(before), Fnreverse(after)).into() }
 }
 
 fn get_truename_buffer_1(filename: LispObject) -> LispObject {

--- a/rust_src/src/data.rs
+++ b/rust_src/src/data.rs
@@ -291,12 +291,9 @@ pub fn defalias(
 
         if is_autoload(symbol.get_function()) {
             // Remember that the function was already an autoload.
-            loadhist_attach(LispObject::cons(true, sym));
+            loadhist_attach((true, sym).into());
         }
-        loadhist_attach(LispObject::cons(
-            if autoload { Qautoload } else { Qdefun },
-            sym,
-        ));
+        loadhist_attach((if autoload { Qautoload } else { Qdefun }, sym).into());
     }
 
     // Handle automatic advice activation.
@@ -323,7 +320,7 @@ pub fn defalias(
 /// of args.  MAX is the maximum number or the symbol `many', for a
 /// function with `&rest' args, or `unevalled' for a special form.
 #[lisp_fn]
-pub fn subr_arity(subr: LispSubrRef) -> LispObject {
+pub fn subr_arity(subr: LispSubrRef) -> (EmacsInt, LispObject) {
     let minargs = subr.min_args();
     let maxargs = if subr.is_many() {
         Qmany
@@ -333,7 +330,7 @@ pub fn subr_arity(subr: LispSubrRef) -> LispObject {
         LispObject::from(EmacsInt::from(subr.max_args()))
     };
 
-    LispObject::cons(EmacsInt::from(minargs), maxargs)
+    (EmacsInt::from(minargs), maxargs)
 }
 
 /// Return name of subroutine SUBR.
@@ -737,11 +734,7 @@ pub fn add_variable_watcher(symbol: LispSymbolRef, watch_function: LispObject) {
     let mem = member(watch_function, watchers);
 
     if mem.is_nil() {
-        put(
-            symbol,
-            Qwatchers,
-            LispObject::cons(watch_function, watchers),
-        );
+        put(symbol, Qwatchers, (watch_function, watchers).into());
     }
 }
 
@@ -802,8 +795,7 @@ pub fn fset(mut symbol: LispSymbolRef, definition: LispObject) -> LispObject {
 
     unsafe {
         if Vautoload_queue.is_not_nil() && function.is_not_nil() {
-            Vautoload_queue =
-                LispObject::cons(LispObject::cons(sym_obj, function), Vautoload_queue);
+            Vautoload_queue = ((sym_obj, function), Vautoload_queue).into();
         }
     }
 

--- a/rust_src/src/editfns.rs
+++ b/rust_src/src/editfns.rs
@@ -428,7 +428,7 @@ pub fn propertize(args: &[LispObject]) -> LispObject {
 
     while let Some(a) = it.next() {
         let b = it.next().unwrap(); // safe due to the odd check at the beginning
-        properties = LispObject::cons(*a, LispObject::cons(*b, properties));
+        properties = (*a, (*b, properties)).into();
     }
 
     unsafe {
@@ -933,12 +933,8 @@ pub fn message_box(args: &mut [LispObject]) -> LispObject {
             Qnil
         } else {
             let val = format_message(args);
-            let pane = list!(LispObject::cons(
-                build_string("OK".as_ptr() as *const ::libc::c_char),
-                true
-            ));
-            let menu = LispObject::cons(val, pane);
-            Fx_popup_dialog(Qt, menu, Qt);
+            let pane = list!((build_string("OK".as_ptr() as *const ::libc::c_char), true));
+            Fx_popup_dialog(Qt, (val, pane).into(), Qt);
             val
         }
     }

--- a/rust_src/src/floatfns.rs
+++ b/rust_src/src/floatfns.rs
@@ -270,9 +270,9 @@ pub fn copysign(x1: EmacsDouble, x2: EmacsDouble) -> EmacsDouble {
 /// The function returns the cons cell (SGNFCAND . EXP).
 /// If X is zero, both parts (SGNFCAND and EXP) are zero.
 #[lisp_fn]
-pub fn frexp(x: EmacsDouble) -> LispObject {
+pub fn frexp(x: EmacsDouble) -> (LispObject, libc::c_int) {
     let (significand, exponent) = libm::frexp(x);
-    LispObject::cons(LispObject::from_float(significand), exponent)
+    (LispObject::from_float(significand), exponent)
 }
 
 /// Return SGNFCAND * 2**EXPONENT, as a floating point number.

--- a/rust_src/src/fns.rs
+++ b/rust_src/src/fns.rs
@@ -48,23 +48,19 @@ pub fn provide(feature: LispSymbolRef, subfeature: LispObject) -> LispObject {
     }
     unsafe {
         if Vautoload_queue.is_not_nil() {
-            Vautoload_queue =
-                LispObject::cons(LispObject::cons(0, globals.Vfeatures), Vautoload_queue);
+            Vautoload_queue = ((0, globals.Vfeatures), Vautoload_queue).into();
         }
     }
     if memq(feature.into(), unsafe { globals.Vfeatures }).is_nil() {
         unsafe {
-            globals.Vfeatures = LispObject::cons(feature, globals.Vfeatures);
+            globals.Vfeatures = (feature, globals.Vfeatures).into();
         }
     }
     if subfeature.is_not_nil() {
         put(feature, Qsubfeatures, subfeature);
     }
     unsafe {
-        globals.Vcurrent_load_list = LispObject::cons(
-            LispObject::cons(Qprovide, feature),
-            globals.Vcurrent_load_list,
-        );
+        globals.Vcurrent_load_list = ((Qprovide, feature), globals.Vcurrent_load_list).into();
     }
     // Run any load-hooks for this file.
     unsafe {
@@ -136,7 +132,7 @@ pub fn require(feature: LispObject, filename: LispObject, noerror: LispObject) -
             .any(|elt| elt.cdr().is_nil() && elt.car().is_string());
 
     if from_file {
-        let tem = LispObject::cons(Qrequire, feature);
+        let tem = (Qrequire, feature).into();
         if member(tem, current_load_list).is_nil() {
             loadhist_attach(tem);
         }
@@ -175,7 +171,7 @@ pub fn require(feature: LispObject, filename: LispObject, noerror: LispObject) -
     unsafe {
         // Update the list for any nested `require's that occur.
         record_unwind_protect(Some(require_unwind), require_nesting_list);
-        require_nesting_list = LispObject::cons(feature, require_nesting_list);
+        require_nesting_list = (feature, require_nesting_list).into();
 
         // Value saved here is to be restored into Vautoload_queue
         record_unwind_protect(Some(un_autoload), Vautoload_queue);

--- a/rust_src/src/frames.rs
+++ b/rust_src/src/frames.rs
@@ -1,5 +1,7 @@
 //! Generic frame functions.
 
+use libc::c_int;
+
 use remacs_macros::lisp_fn;
 
 use crate::{
@@ -288,9 +290,9 @@ pub fn frame_visible_p(frame: LispFrameRef) -> LispObject {
 /// FRAME's outer frame, in pixels relative to an origin (0, 0) of FRAME's
 /// display.
 #[lisp_fn(min = "0")]
-pub fn frame_position(frame: LispFrameOrSelected) -> LispObject {
+pub fn frame_position(frame: LispFrameOrSelected) -> (c_int, c_int) {
     let frame_ref = frame.live_or_error();
-    LispObject::cons(frame_ref.left_pos, frame_ref.top_pos)
+    (frame_ref.left_pos, frame_ref.top_pos)
 }
 
 /// Returns t if the mouse pointer displayed on FRAME is visible.

--- a/rust_src/src/keymap.rs
+++ b/rust_src/src/keymap.rs
@@ -151,7 +151,7 @@ pub extern "C" fn get_keymap(
 /// The optional arg STRING supplies a menu name for the keymap
 /// in case you use it as a menu with `x-popup-menu'.
 #[lisp_fn(min = "0")]
-pub fn make_keymap(string: LispObject) -> LispObject {
+pub fn make_keymap(string: LispObject) -> (LispObject, (LispObject, LispObject)) {
     let tail: LispObject = if string.is_not_nil() {
         list!(string)
     } else {
@@ -159,7 +159,7 @@ pub fn make_keymap(string: LispObject) -> LispObject {
     };
 
     let char_table = unsafe { Fmake_char_table(Qkeymap, Qnil) };
-    LispObject::cons(Qkeymap, LispObject::cons(char_table, tail))
+    (Qkeymap, (char_table, tail))
 }
 
 /// Return t if OBJECT is a keymap.
@@ -670,7 +670,7 @@ pub fn copy_keymap(keymap: LispObject) -> LispObject {
                 // This is a sub keymap
                 elt = copy_keymap(elt);
             } else {
-                elt = LispObject::cons(front, unsafe { copy_keymap_item(cons_1.cdr()) });
+                elt = (front, unsafe { copy_keymap_item(cons_1.cdr()) }).into();
             }
         }
 

--- a/rust_src/src/lread.rs
+++ b/rust_src/src/lread.rs
@@ -224,7 +224,7 @@ pub fn eval_region(
         specbind(Qstandard_output, tem);
         specbind(
             Qeval_buffer_list,
-            LispObject::cons(cur_buf_obj, globals.Veval_buffer_list),
+            (cur_buf_obj, globals.Veval_buffer_list).into(),
         );
 
         // `readevalloop' calls functions which check the type of start and end.

--- a/rust_src/src/obarray.rs
+++ b/rust_src/src/obarray.rs
@@ -115,7 +115,7 @@ pub fn intern<T: AsRef<str>>(string: T) -> LispSymbolRef {
 pub extern "C" fn loadhist_attach(x: LispObject) {
     unsafe {
         if initialized {
-            globals.Vcurrent_load_list = LispObject::cons(x, globals.Vcurrent_load_list);
+            globals.Vcurrent_load_list = (x, globals.Vcurrent_load_list).into();
         }
     }
 }

--- a/rust_src/src/process.rs
+++ b/rust_src/src/process.rs
@@ -298,8 +298,8 @@ pub fn process_status(process: LispObject) -> LispObject {
 
 /// Return a cons of coding systems for decoding and encoding of PROCESS.
 #[lisp_fn]
-pub fn process_coding_system(process: LispProcessRef) -> LispObject {
-    LispObject::cons(process.decode_coding_system, process.encode_coding_system)
+pub fn process_coding_system(process: LispProcessRef) -> (LispObject, LispObject) {
+    (process.decode_coding_system, process.encode_coding_system)
 }
 
 /// Return the locking thread of PROCESS.

--- a/rust_src/src/windows.rs
+++ b/rust_src/src/windows.rs
@@ -473,7 +473,7 @@ pub fn window_pixel_height(window: LispWindowValidOrSelected) -> i32 {
 /// If a marginal area does not exist, its width will be returned
 /// as nil.
 #[lisp_fn(min = "0")]
-pub fn window_margins(window: LispWindowLiveOrSelected) -> LispObject {
+pub fn window_margins(window: LispWindowLiveOrSelected) -> (LispObject, LispObject) {
     fn margin_as_object(margin: c_int) -> LispObject {
         if margin == 0 {
             Qnil
@@ -483,7 +483,7 @@ pub fn window_margins(window: LispWindowLiveOrSelected) -> LispObject {
     }
     let win: LispWindowRef = window.into();
 
-    LispObject::cons(
+    (
         margin_as_object(win.left_margin_cols),
         margin_as_object(win.right_margin_cols),
     )
@@ -660,8 +660,7 @@ pub fn set_window_parameter(
     let mut win: LispWindowRef = window.into();
     let old_alist_elt = assq(parameter, win.window_parameters);
     if old_alist_elt.is_nil() {
-        win.window_parameters =
-            LispObject::cons(LispObject::cons(parameter, value), win.window_parameters);
+        win.window_parameters = ((parameter, value), win.window_parameters).into();
     } else {
         setcdr(old_alist_elt.as_cons_or_error(), value);
     }


### PR DESCRIPTION
Calls to LispObject::cons would look cleaner if they were just
tuples. We can have the compiler do the conversions for us. This makes
the code a little Lispier.

Note that the conversion works recursively, so nested pairs don't need
to be handled as a special case.