### PR TITLE
Add tuple conversions, cut as_tuple and as_cons_or_error

### DIFF
--- a/rust_src/src/buffers.rs
+++ b/rust_src/src/buffers.rs
@@ -516,7 +516,8 @@ impl LispBufferLocalValueRef {
     }
 
     pub fn get_value(self) -> LispObject {
-        self.valcell.as_cons_or_error().cdr()
+        let (_, d) = self.valcell.into();
+        d
     }
 }
 

--- a/rust_src/src/casefiddle.rs
+++ b/rust_src/src/casefiddle.rs
@@ -189,7 +189,7 @@ fn casefiddle_region(
         );
 
         for elt in bounds.iter_cars(LispConsEndChecks::off, LispConsCircularChecks::off) {
-            let (car, cdr) = elt.as_cons_or_error().as_tuple();
+            let (car, cdr) = elt.into();
             unsafe { casify_region(action, car, cdr) };
         }
     }

--- a/rust_src/src/crypto/mod.rs
+++ b/rust_src/src/crypto/mod.rs
@@ -123,8 +123,10 @@ fn get_coding_system_for_buffer(
         // Check file-coding-system-alist.
         let mut args = [Qwrite_region, start, end, file_name];
         let val = unsafe { Ffind_operation_coding_system(4, args.as_mut_ptr()) };
-        if val.is_cons() && val.as_cons_or_error().cdr().is_not_nil() {
-            return val.as_cons_or_error().cdr();
+        if let Some((_, d)) = val.into() {
+            if d.is_not_nil() {
+                return d;
+            }
         }
     }
     if buffer.buffer_file_coding_system_.is_not_nil() {

--- a/rust_src/src/data.rs
+++ b/rust_src/src/data.rs
@@ -371,7 +371,8 @@ fn default_value(mut symbol: LispSymbolRef) -> LispObject {
             if !fwd.is_null() && blv.valcell.eq(blv.defcell) {
                 unsafe { do_symval_forwarding(fwd) }
             } else {
-                blv.defcell.as_cons_or_error().cdr()
+                let (_, d) = blv.defcell.into();
+                d
             }
         }
         symbol_redirect::SYMBOL_FORWARDED => {
@@ -573,8 +574,7 @@ pub unsafe extern "C" fn store_symval_forwarding(
                     }
                 } else {
                     prop = Fget(predicate, Qrange);
-                    if prop.is_cons() {
-                        let (min, max) = prop.as_cons_or_error().as_tuple();
+                    if let Some((min, max)) = prop.into() {
                         let args = [min, newval, max];
                         if !newval.is_number() || leq(&args) {
                             wrong_range(min, max, newval);
@@ -800,7 +800,8 @@ pub fn fset(mut symbol: LispSymbolRef, definition: LispObject) -> LispObject {
     }
 
     if is_autoload(function) {
-        put(symbol, Qautoload, function.as_cons_or_error().cdr());
+        let (_, d) = function.into();
+        put(symbol, Qautoload, d);
     }
 
     // Convert to eassert or remove after GC bug is found.  In the

--- a/rust_src/src/eval.rs
+++ b/rust_src/src/eval.rs
@@ -79,15 +79,15 @@ where
 /// If COND yields nil, and there are no ELSE's, the value is nil.
 /// usage: (if COND THEN ELSE...)
 #[lisp_fn(name = "if", c_name = "if", min = "2", unevalled = "true")]
-pub fn lisp_if(args: LispObject) -> LispObject {
-    let cell = args.as_cons_or_error();
-    let cond = unsafe { eval_sub(cell.car()) };
-    let cnsq = cell.cdr().as_cons_or_error();
+pub fn lisp_if(args: LispCons) -> LispObject {
+    let (cond, consq) = args.into();
+    let (then, else_) = consq.into();
+    let result = unsafe { eval_sub(cond) };
 
-    if cond.is_not_nil() {
-        unsafe { eval_sub(cnsq.car()) }
+    if result.is_not_nil() {
+        unsafe { eval_sub(then) }
     } else {
-        progn(cnsq.cdr())
+        progn(else_)
     }
 }
 
@@ -105,7 +105,7 @@ pub fn cond(args: LispObject) -> LispObject {
     let mut val = Qnil;
 
     for clause in args.iter_cars(LispConsEndChecks::off, LispConsCircularChecks::off) {
-        let (head, tail) = clause.as_cons_or_error().as_tuple();
+        let (head, tail) = clause.into();
         val = unsafe { eval_sub(head) };
         if val != Qnil {
             if tail.is_not_nil() {
@@ -140,7 +140,7 @@ pub extern "C" fn prog_ignore(body: LispObject) {
 /// usage: (prog1 FIRST BODY...)
 #[lisp_fn(min = "1", unevalled = "true")]
 pub fn prog1(args: LispCons) -> LispObject {
-    let (first, body) = args.as_tuple();
+    let (first, body) = args.into();
 
     let val = unsafe { eval_sub(first) };
     progn(body);
@@ -153,10 +153,10 @@ pub fn prog1(args: LispCons) -> LispObject {
 /// usage: (prog2 FORM1 FORM2 BODY...)
 #[lisp_fn(min = "2", unevalled = "true")]
 pub fn prog2(args: LispCons) -> LispObject {
-    let (form1, tail) = args.as_tuple();
+    let (form1, tail) = args.into();
 
     unsafe { eval_sub(form1) };
-    prog1(tail.as_cons_or_error())
+    prog1(tail.into())
 }
 
 /// Set each SYM to the value of its VAL.
@@ -208,17 +208,15 @@ def_lisp_sym!(Qsetq, "setq");
 /// `quote' cannot do that.
 /// usage: (function ARG)
 #[lisp_fn(min = "1", unevalled = "true")]
-pub fn function(args: LispObject) -> LispObject {
-    let cell = args.as_cons_or_error();
-    let (quoted, tail) = cell.as_tuple();
+pub fn function(args: LispCons) -> LispObject {
+    let (quoted, tail) = args.into();
 
     if tail.is_not_nil() {
-        wrong_number_of_arguments!(Qfunction, length(args));
+        wrong_number_of_arguments!(Qfunction, length(args.into()));
     }
 
     if unsafe { globals.Vinternal_interpreter_environment != Qnil } {
-        if let Some(cell) = quoted.as_cons() {
-            let (first, mut cdr) = cell.as_tuple();
+        if let Some((first, mut cdr)) = quoted.into() {
             if first.eq(Qlambda) {
                 // This is a lambda expression within a lexical environment;
                 // return an interpreted closure instead of a simple lambda.
@@ -228,15 +226,16 @@ pub fn function(args: LispObject) -> LispObject {
                     .and_then(|c| c.cdr().as_cons())
                     .and_then(|c| c.car().as_cons());
                 if let Some(cell) = tmp {
-                    let (typ, tail) = cell.as_tuple();
+                    let (typ, tail) = cell.into();
                     if typ.eq(QCdocumentation) {
                         // Handle the special (:documentation <form>) to build the docstring
                         // dynamically.
 
                         let docstring = unsafe { eval_sub(car(tail)) };
                         docstring.as_string_or_error();
-                        let (a, b) = cdr.as_cons().unwrap().as_tuple();
-                        cdr = (a, (docstring, b.as_cons().unwrap().cdr())).into();
+                        let (a, b) = cdr.into();
+                        let (_, bd) = b.into();
+                        cdr = (a, (docstring, bd)).into();
                     }
                 }
 
@@ -285,7 +284,7 @@ pub fn special_variable_p(symbol: LispSymbolRef) -> bool {
 /// usage: (defconst SYMBOL INITVALUE [DOCSTRING])
 #[lisp_fn(min = "2", unevalled = "true")]
 pub fn defconst(args: LispCons) -> LispSymbolRef {
-    let (sym, tail) = args.as_tuple();
+    let (sym, tail) = args.into();
 
     let mut docstring = if cdr(tail).is_not_nil() {
         if cdr(cdr(tail)).is_not_nil() {
@@ -328,11 +327,11 @@ fn let_binding_value(obj: LispObject) -> (LispObject, LispObject) {
     if obj.is_symbol() {
         (obj, Qnil)
     } else {
-        let (front, tail) = obj.as_cons_or_error().as_tuple();
+        let (front, tail) = obj.into();
         let (to_eval, tail) = if tail.is_nil() {
             (Qnil, tail)
         } else {
-            tail.as_cons_or_error().as_tuple()
+            tail.into()
         };
 
         if tail.is_nil() {
@@ -352,7 +351,7 @@ fn let_binding_value(obj: LispObject) -> (LispObject, LispObject) {
 #[lisp_fn(name = "let*", min = "1", unevalled = "true")]
 pub fn letX(args: LispCons) -> LispObject {
     let count = c_specpdl_index();
-    let (varlist, body) = args.as_tuple();
+    let (varlist, body) = args.into();
 
     let lexenv = unsafe { globals.Vinternal_interpreter_environment };
 
@@ -413,7 +412,7 @@ pub fn letX(args: LispCons) -> LispObject {
 #[lisp_fn(name = "let", c_name = "let", min = "1", unevalled = "true")]
 pub fn lisp_let(args: LispCons) -> LispObject {
     let count = c_specpdl_index();
-    let (varlist, body) = args.as_tuple();
+    let (varlist, body) = args.into();
 
     varlist.check_list();
 
@@ -465,7 +464,7 @@ pub fn lisp_let(args: LispCons) -> LispObject {
 /// usage: (while TEST BODY...)
 #[lisp_fn(name = "while", c_name = "while", min = "1", unevalled = "true")]
 pub fn lisp_while(args: LispCons) {
-    let (test, body) = args.as_tuple();
+    let (test, body) = args.into();
 
     while unsafe { eval_sub(test) } != Qnil {
         unsafe { maybe_quit() };
@@ -483,12 +482,11 @@ pub fn lisp_while(args: LispCons) {
 /// definitions to shadow the loaded ones for use in file byte-compilation.
 #[lisp_fn(min = "1")]
 pub fn macroexpand(mut form: LispObject, environment: LispObject) -> LispObject {
-    while let Some(form_cell) = form.as_cons() {
+    while let Some((mut sym, body)) = form.into() {
         // Come back here each time we expand a macro call,
         // in case it expands into another macro call.
 
         // Set SYM, give DEF and TEM right values in case SYM is not a symbol.
-        let (mut sym, body) = form_cell.as_tuple();
         let mut def = sym;
         let mut tem = Qnil;
 
@@ -513,13 +511,12 @@ pub fn macroexpand(mut form: LispObject, environment: LispObject) -> LispObject 
             // SYM is not mentioned in ENVIRONMENT.
             // Look at its function definition.
             def = autoload_do_load(def, sym, Qmacro);
-            match def.as_cons() {
-                Some(cell) => {
-                    let func = cell.car();
+            match def.into() {
+                Some((func, cdr)) => {
                     if !func.eq(Qmacro) {
                         break;
                     }
-                    cell.cdr()
+                    cdr
                 }
                 None => {
                     // Not defined or definition not suitable.
@@ -527,7 +524,7 @@ pub fn macroexpand(mut form: LispObject, environment: LispObject) -> LispObject 
                 }
             }
         } else {
-            let next = tem.as_cons_or_error().cdr();
+            let (_, next) = tem.into();
             if next.is_nil() {
                 break;
             }
@@ -636,17 +633,16 @@ pub fn commandp(function: LispObject, for_call_interactively: bool) -> bool {
         return (vl.is_pseudovector(pvec_type::PVEC_COMPILED)
             && vl.pseudovector_size() > EmacsInt::from(Lisp_Compiled::COMPILED_INTERACTIVE))
             || has_interactive_prop;
-    } else if let Some(cell) = fun.as_cons() {
+    } else if let Some((funcar, d)) = fun.into() {
         // Lists may represent commands.
-        let funcar = cell.car();
         if funcar.eq(Qclosure) {
-            let bound = assq(Qinteractive, cdr(cdr(cell.cdr())));
+            let bound = assq(Qinteractive, cdr(cdr(d)));
             return bound.is_not_nil() || has_interactive_prop;
         } else if funcar.eq(Qlambda) {
-            let bound = assq(Qinteractive, cdr(cell.cdr()));
+            let bound = assq(Qinteractive, cdr(d));
             return bound.is_not_nil() || has_interactive_prop;
         } else if funcar.eq(Qautoload) {
-            let value = car(cdr(cdr(cell.cdr())));
+            let value = car(cdr(cdr(d)));
             return value.is_not_nil() || has_interactive_prop;
         }
     }
@@ -724,9 +720,9 @@ pub extern "C" fn FUNCTIONP(object: LispObject) -> bool {
                         }
                     }
 
-                    return match it.rest().as_cons() {
+                    return match it.rest().into() {
                         None => true,
-                        Some(c) => c.car().is_nil(),
+                        Some((a, _)) => a.is_nil(),
                     };
                 }
             }
@@ -737,8 +733,7 @@ pub extern "C" fn FUNCTIONP(object: LispObject) -> bool {
         !subr.is_unevalled()
     } else if obj.is_byte_code_function() || obj.is_module_function() {
         true
-    } else if let Some(cons) = obj.as_cons() {
-        let car = cons.car();
+    } else if let Some((car, _)) = obj.into() {
         car.eq(Qlambda) || car.eq(Qclosure)
     } else {
         false
@@ -752,7 +747,7 @@ pub unsafe extern "C" fn un_autoload(oldqueue: LispObject) {
     Vautoload_queue = oldqueue;
 
     for first in queue.iter_cars(LispConsEndChecks::off, LispConsCircularChecks::off) {
-        let (first, second) = first.as_cons_or_error().as_tuple();
+        let (first, second) = first.into();
 
         if first.eq(0) {
             globals.Vfeatures = second;
@@ -1057,9 +1052,7 @@ fn resolve_fun(fun: LispObject) -> Result<LispFun, LispFunError> {
             return Ok(LispFun::LambdaFun(fun));
         }
 
-        if let Some(cons) = fun.as_cons() {
-            let funcar = cons.car();
-
+        if let Some((funcar, _)) = fun.into() {
             if !funcar.is_symbol() {
                 return Err(LispFunError::InvalidFun);
             }
@@ -1201,7 +1194,7 @@ pub extern "C" fn unbind_to(count: libc::ptrdiff_t, value: LispObject) -> LispOb
 /// usage: (unwind-protect BODYFORM UNWINDFORMS...)
 #[lisp_fn(min = "1", unevalled = "true")]
 pub fn unwind_protect(args: LispCons) -> LispObject {
-    let (bodyform, unwindforms) = args.as_tuple();
+    let (bodyform, unwindforms) = args.into();
     let count = c_specpdl_index();
 
     unsafe { record_unwind_protect(Some(prog_ignore), unwindforms) };
@@ -1218,7 +1211,7 @@ pub fn unwind_protect(args: LispCons) -> LispObject {
 /// usage: (catch TAG BODY...)
 #[lisp_fn(min = "1", unevalled = "true")]
 pub fn catch(args: LispCons) -> LispObject {
-    let (tag, body) = args.as_tuple();
+    let (tag, body) = args.into();
 
     let val = unsafe { eval_sub(tag) };
 

--- a/rust_src/src/ffi.rs
+++ b/rust_src/src/ffi.rs
@@ -28,7 +28,7 @@ pub extern "C" fn arithcompare(
 
 #[no_mangle]
 pub extern "C" fn lucid_event_type_list_p(event: LispObject) -> bool {
-    keyboard::lucid_event_type_list_p(event.as_cons())
+    keyboard::lucid_event_type_list_p(event.into())
 }
 
 #[no_mangle]

--- a/rust_src/src/fns.rs
+++ b/rust_src/src/fns.rs
@@ -67,8 +67,8 @@ pub fn provide(feature: LispSymbolRef, subfeature: LispObject) -> LispObject {
     }
     // Run any load-hooks for this file.
     unsafe {
-        if let Some(c) = assq(feature.into(), globals.Vafter_load_alist).as_cons() {
-            Fmapc(Qfuncall, c.cdr());
+        if let Some((_, d)) = assq(feature.into(), globals.Vafter_load_alist).into() {
+            Fmapc(Qfuncall, d);
         }
     }
     feature.into()

--- a/rust_src/src/fonts.rs
+++ b/rust_src/src/fonts.rs
@@ -137,8 +137,8 @@ pub fn font_match_p(spec: LispObject, font: LispObject) -> bool {
 #[lisp_fn(min = "1")]
 pub fn find_font(spec: LispObject, frame: LispObject) -> LispObject {
     let val = unsafe { Flist_fonts(spec, frame, LispObject::from(1), Qnil) };
-    match val.as_cons() {
-        Some(cons) => cons.car(),
+    match val.into() {
+        Some((a, _)) => a,
         None => val,
     }
 }

--- a/rust_src/src/keymap.rs
+++ b/rust_src/src/keymap.rs
@@ -14,7 +14,7 @@ use crate::{
     keyboard::lucid_event_type_list_p,
     lisp::{defsubr, LispObject},
     lists::{nth, setcdr},
-    lists::{LispConsCircularChecks, LispConsEndChecks},
+    lists::{LispCons, LispConsCircularChecks, LispConsEndChecks},
     obarray::intern,
     remacs_sys::{
         access_keymap, copy_keymap_item, describe_vector, make_save_funcptr_ptr_obj,
@@ -106,22 +106,21 @@ pub extern "C" fn get_keymap(
             break;
         }
 
-        if let Some(cons) = object.as_cons() {
-            if cons.car().eq(Qkeymap) {
+        if let Some((car, _)) = object.into() {
+            if car.eq(Qkeymap) {
                 return object;
             }
         }
 
         let tem = indirect_function(object);
-        if let Some(cons) = tem.as_cons() {
-            if cons.car().eq(Qkeymap) {
+        if let Some((car, _)) = tem.into() {
+            if car.eq(Qkeymap) {
                 return tem;
             }
 
             // Should we do an autoload?  Autoload forms for keymaps have
             // Qkeymap as their fifth element.
-            if (autoload || !error_if_not_keymap) && cons.car().eq(Qautoload) && object.is_symbol()
-            {
+            if (autoload || !error_if_not_keymap) && car.eq(Qautoload) && object.is_symbol() {
                 let tail = nth(4, tem);
                 if tail.eq(Qkeymap) {
                     if autoload {
@@ -233,7 +232,7 @@ pub fn set_keymap_parent(keymap: LispObject, parent: LispObject) -> LispObject {
     }
 
     // Skip past the initial element 'keymap'.
-    let mut prev = keymap.as_cons_or_error();
+    let mut prev = LispCons::from(keymap);
     let mut list;
 
     loop {
@@ -289,8 +288,7 @@ pub unsafe extern "C" fn map_keymap(
 ) {
     let mut map = get_keymap(map, true, autoload);
     while map.is_cons() {
-        if let Some(cons) = map.as_cons() {
-            let (car, cdr) = cons.as_tuple();
+        if let Some((car, cdr)) = map.into() {
             if keymapp(car) {
                 map_keymap(car, fun, args, data, autoload);
                 map = cdr;
@@ -344,10 +342,9 @@ pub unsafe extern "C" fn map_keymap_internal(
     data: *mut c_void,
 ) -> LispObject {
     let map = map;
-    let tail = match map.as_cons() {
+    let tail = match map.into() {
         None => Qnil,
-        Some(cons) => {
-            let (car, cdr) = cons.as_tuple();
+        Some((car, cdr)) => {
             if car.eq(Qkeymap) {
                 cdr
             } else {
@@ -367,8 +364,7 @@ pub unsafe extern "C" fn map_keymap_internal(
                 break;
             }
 
-            if let Some(binding_cons) = binding.as_cons() {
-                let (car, cdr) = binding_cons.as_tuple();
+            if let Some((car, cdr)) = binding.into() {
                 map_keymap_item(fun, args, car, cdr, data);
             } else if binding.is_vector() {
                 if let Some(binding_vec) = binding.as_vectorlike() {
@@ -498,7 +494,7 @@ pub fn lookup_key(keymap: LispObject, key: LispObject, accept_default: LispObjec
         let mut c = aref(key, idx);
         idx += 1;
 
-        if c.is_cons() && lucid_event_type_list_p(c.as_cons()) {
+        if c.is_cons() && lucid_event_type_list_p(c.into()) {
             c = unsafe { Fevent_convert_list(c) };
         }
 
@@ -643,14 +639,13 @@ pub extern "C" fn copy_keymap_1(chartable: LispObject, idx: LispObject, elt: Lis
 /// is not copied.
 #[lisp_fn]
 pub fn copy_keymap(keymap: LispObject) -> LispObject {
-    let mut keymap = get_keymap(keymap, true, false);
+    let keymap = get_keymap(keymap, true, false);
     let mut tail = list!(Qkeymap);
     let copy = tail;
 
-    keymap = keymap.as_cons_or_error().cdr(); // Skip the `keymap' symbol.
+    let (_, mut keymap) = keymap.into(); // Skip the `keymap' symbol.
 
-    while let Some(cons) = keymap.as_cons() {
-        let mut elt = cons.car();
+    while let Some((mut elt, kmd)) = keymap.into() {
         if elt.eq(Qkeymap) {
             break;
         }
@@ -664,22 +659,21 @@ pub fn copy_keymap(keymap: LispObject) -> LispObject {
             for (i, obj) in v.iter().enumerate() {
                 v2.set(i, unsafe { copy_keymap_item(obj) });
             }
-        } else if let Some(cons_1) = elt.as_cons() {
-            let front = cons_1.car();
+        } else if let Some((front, back)) = elt.into() {
             if front.eq(Qkeymap) {
                 // This is a sub keymap
                 elt = copy_keymap(elt);
             } else {
-                elt = (front, unsafe { copy_keymap_item(cons_1.cdr()) }).into();
+                elt = (front, unsafe { copy_keymap_item(back) }).into();
             }
         }
 
-        setcdr(tail.as_cons().unwrap(), list!(elt));
-        tail = tail.as_cons().unwrap().cdr();
-        keymap = cons.cdr();
+        setcdr(tail.into(), list!(elt));
+        tail = LispCons::from(tail).cdr();
+        keymap = kmd;
     }
 
-    setcdr(tail.as_cons().unwrap(), keymap);
+    setcdr(tail.into(), keymap);
     copy
 }
 

--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -507,9 +507,10 @@ impl_alistval_iter! {LiveBufferIter, LispBufferRef, unsafe { Vbuffer_alist }}
 impl_alistval_iter! {ProcessIter, LispProcessRef, unsafe { Vprocess_alist }}
 
 pub fn is_autoload(function: LispObject) -> bool {
-    function
-        .as_cons()
-        .map_or(false, |cell| cell.car().eq(Qautoload))
+    match function.into() {
+        None => false,
+        Some((car, _)) => car.eq(Qautoload),
+    }
 }
 
 impl LispObject {
@@ -619,9 +620,9 @@ impl Debug for LispObject {
             Lisp_Type::Lisp_Cons => {
                 let mut cdr = *self;
                 write!(f, "'(")?;
-                while let Some(cons) = cdr.as_cons() {
-                    write!(f, "{:?} ", cons.car())?;
-                    cdr = cons.cdr();
+                while let Some((a, d)) = cdr.into() {
+                    write!(f, "{:?} ", a)?;
+                    cdr = d;
                 }
                 if cdr.is_nil() {
                     write!(f, ")")?;

--- a/rust_src/src/lists.rs
+++ b/rust_src/src/lists.rs
@@ -39,10 +39,6 @@ impl LispObject {
             None
         }
     }
-
-    pub fn as_cons_or_error(self) -> LispCons {
-        self.as_cons().unwrap_or_else(|| wrong_type!(Qconsp, self))
-    }
 }
 
 impl LispObject {
@@ -236,14 +232,14 @@ impl Iterator for CarIter {
 
 impl From<LispObject> for LispCons {
     fn from(o: LispObject) -> Self {
-        o.as_cons_or_error()
+        o.as_cons().unwrap_or_else(|| wrong_type!(Qconsp, o))
     }
 }
 
 impl From<LispObject> for Option<LispCons> {
     fn from(o: LispObject) -> Self {
         if o.is_list() {
-            Some(o.as_cons_or_error())
+            Some(LispCons::from(o))
         } else {
             None
         }
@@ -262,6 +258,28 @@ impl<S: Into<LispObject>, T: Into<LispObject>> From<(S, T)> for LispObject {
     }
 }
 
+impl From<LispCons> for (LispObject, LispObject) {
+    fn from(c: LispCons) -> Self {
+        (c.car(), c.cdr())
+    }
+}
+
+impl From<LispObject> for (LispObject, LispObject) {
+    fn from(o: LispObject) -> Self {
+        LispCons::from(o).into()
+    }
+}
+
+impl From<LispObject> for Option<(LispObject, LispObject)> {
+    fn from(o: LispObject) -> Self {
+        if o.is_cons() {
+            Some(o.into())
+        } else {
+            None
+        }
+    }
+}
+
 impl LispCons {
     fn _extract(self) -> *mut Lisp_Cons {
         self.0.get_untaggedptr() as *mut Lisp_Cons
@@ -275,10 +293,6 @@ impl LispCons {
     /// Return the cdr (second cell).
     pub fn cdr(self) -> LispObject {
         unsafe { (*self._extract()).u.s.as_ref().u.cdr }
-    }
-
-    pub fn as_tuple(self) -> (LispObject, LispObject) {
-        (self.car(), self.cdr())
     }
 
     /// Set the car of the cons cell.
@@ -320,8 +334,8 @@ impl LispCons {
         loop {
             match (it1.next(), it2.next()) {
                 (Some(cons1), Some(cons2)) => {
-                    let (item1, tail1) = cons1.as_tuple();
-                    let (item2, tail2) = cons2.as_tuple();
+                    let (item1, tail1) = cons1.into();
+                    let (item2, tail2) = cons2.into();
                     if !unsafe { internal_equal(item1, item2, kind, item_depth, item_ht) } {
                         return false;
                     } else if tail1.eq(tail2) {
@@ -415,7 +429,8 @@ pub fn car(list: LispObject) -> LispObject {
     if list.is_nil() {
         list
     } else {
-        list.as_cons_or_error().car()
+        let (a, _) = list.into();
+        a
     }
 }
 
@@ -429,20 +444,27 @@ pub fn cdr(list: LispObject) -> LispObject {
     if list.is_nil() {
         list
     } else {
-        list.as_cons_or_error().cdr()
+        let (_, d) = list.into();
+        d
     }
 }
 
 /// Return the car of OBJECT if it is a cons cell, or else nil.
 #[lisp_fn]
 pub fn car_safe(object: LispObject) -> LispObject {
-    object.as_cons().map_or(Qnil, |cons| cons.car())
+    match object.into() {
+        Some((car, _)) => car,
+        None => Qnil,
+    }
 }
 
 /// Return the cdr of OBJECT if it is a cons cell, or else nil.
 #[lisp_fn]
 pub fn cdr_safe(object: LispObject) -> LispObject {
-    object.as_cons().map_or(Qnil, |cons| cons.cdr())
+    match object.into() {
+        Some((_, cdr)) => cdr,
+        None => Qnil,
+    }
 }
 
 /// Take cdr N times on LIST, return the result.
@@ -572,7 +594,7 @@ pub fn delq(elt: LispObject, list: LispObject) -> LispObject {
     let mut prev = None;
     list.iter_tails(LispConsEndChecks::on, LispConsCircularChecks::on)
         .fold(list, |remaining, tail| {
-            let (item, rest) = tail.as_tuple();
+            let (item, rest) = tail.into();
             if elt.eq(item) {
                 match prev {
                     Some(cons) => setcdr(cons, rest),
@@ -632,7 +654,7 @@ where
         .iter_tails_plist(end_checks, circular_checks)
         .step_by(2)
     {
-        match tail.cdr().as_cons() {
+        match tail.cdr().into() {
             None => {
                 // need an extra check here to catch odd-length lists
                 if end_checks == LispConsEndChecks::on && LispObject::from(tail).is_not_nil() {
@@ -641,9 +663,9 @@ where
 
                 break;
             }
-            Some(tail_cdr_cons) => {
+            Some((tail_cdr_cons_car, _)) => {
                 if cmp(tail.car(), prop) {
-                    return tail_cdr_cons.car();
+                    return tail_cdr_cons_car;
                 }
             }
         }
@@ -700,8 +722,10 @@ where
     match last_cons {
         None => (prop, (val, Qnil)).into(),
         Some(last_cons) => {
-            let last_cons_cdr = last_cons.cdr().as_cons_or_error();
-            last_cons_cdr.set_cdr((prop, (val, last_cons_cdr.cdr())).into());
+            let (_, last_cons_cdr) = last_cons.into();
+            let last_cons_cdr = LispCons::from(last_cons_cdr);
+            let (_, lcc_cdr) = last_cons_cdr.into();
+            last_cons_cdr.set_cdr((prop, (val, lcc_cdr)).into());
             plist
         }
     }
@@ -789,7 +813,7 @@ pub fn sort_list(list: LispObject, pred: LispObject) -> LispObject {
 
     let item = nthcdr(length / 2 - 1, list);
     let back = cdr(item);
-    setcdr(item.as_cons_or_error(), Qnil);
+    setcdr(item.into(), Qnil);
 
     let front = sort_list(list, pred);
     let back = sort_list(back, pred);
@@ -842,7 +866,7 @@ pub fn merge(mut l1: LispObject, mut l2: LispObject, pred: LispObject) -> LispOb
                 value = item;
             }
         };
-        tail = item.as_cons();
+        tail = item.into();
     }
 }
 

--- a/rust_src/src/minibuf.rs
+++ b/rust_src/src/minibuf.rs
@@ -336,9 +336,9 @@ pub fn read_string(
 
     if let Some(s) = val.as_string() {
         if s.len_chars() == 0 && default_value.is_not_nil() {
-            val = match default_value.as_cons() {
+            val = match default_value.into() {
                 None => default_value,
-                Some(c) => c.car(),
+                Some((a, _)) => a,
             }
         }
     }

--- a/rust_src/src/process.rs
+++ b/rust_src/src/process.rs
@@ -279,8 +279,8 @@ pub fn process_status(process: LispObject) -> LispObject {
         unsafe { update_status(process.as_mut()) };
     }
     let mut status = process.status;
-    if let Some(c) = status.as_cons() {
-        status = c.car();
+    if let Some((a, _)) = status.into() {
+        status = a;
     };
     let process_type = process.ptype();
     if process_type.eq(Qnetwork) || process_type.eq(Qserial) || process_type.eq(Qpipe) {
@@ -488,9 +488,10 @@ pub fn process_exit_status(mut process: LispProcessRef) -> LispObject {
         unsafe { update_status(process.as_mut()) };
     }
     let status = process.status;
-    status
-        .as_cons()
-        .map_or_else(|| LispObject::from(0), |cons| car(cons.cdr()))
+    match status.into() {
+        None => 0.into(),
+        Some((_, d)) => car(d),
+    }
 }
 
 /// Return non-nil if PROCESS has given the terminal to a

--- a/rust_src/src/time.rs
+++ b/rust_src/src/time.rs
@@ -176,18 +176,16 @@ pub unsafe extern "C" fn disassemble_lisp_time(
     let mut psec = LispObject::from(0);
     let mut len = 4;
 
-    if let Some(cons) = specified_time.as_cons() {
-        high = cons.car();
-        low = cons.cdr();
+    if let Some((car, cdr)) = specified_time.into() {
+        high = car;
+        low = cdr;
 
-        if let Some(cons) = cons.cdr().as_cons() {
-            let low_tail = cons.cdr();
-            low = cons.car();
-            if let Some(cons) = low_tail.as_cons() {
-                usec = cons.car();
-                let low_tail = cons.cdr();
-                if let Some(cons) = low_tail.as_cons() {
-                    psec = cons.car();
+        if let Some((a, low_tail)) = cdr.into() {
+            low = a;
+            if let Some((a, low_tail)) = low_tail.into() {
+                usec = a;
+                if let Some((a, _)) = low_tail.into() {
+                    psec = a;
                 } else {
                     len = 3;
                 }

--- a/rust_src/src/windows.rs
+++ b/rust_src/src/windows.rs
@@ -218,8 +218,10 @@ impl LispWindowRef {
     }
 
     pub fn get_parameter(self, parameter: LispObject) -> LispObject {
-        let result = assq(parameter, self.window_parameters);
-        result.as_cons().map_or(Qnil, |c| c.cdr())
+        match assq(parameter, self.window_parameters).into() {
+            Some((_, cdr)) => cdr,
+            None => Qnil,
+        }
     }
 }
 
@@ -662,7 +664,7 @@ pub fn set_window_parameter(
     if old_alist_elt.is_nil() {
         win.window_parameters = ((parameter, value), win.window_parameters).into();
     } else {
-        setcdr(old_alist_elt.as_cons_or_error(), value);
+        setcdr(old_alist_elt.into(), value);
     }
     value
 }


### PR DESCRIPTION
This change complements 6f4ac71065. I wanted to make it possible to
destructure arbitrary conses, as in

```rust
  let (a, (b, c)) = obj.into();
```

but I don't think that's possible. A little destructuring is possible
though, and this replaces `as_tuple` with it. `as_cons_or_error` is
also cut along the way, in favor of `From`/`into`.

A few style changes have also been made wrt destructuring, like

```
  -        self.valcell.as_cons_or_error().cdr()
  +        let (_, d) = self.valcell.into();
  +        d
```

I think this is a little more in keeping with the Rust mindset of
exhaustive matching -- the caller explicitly acknowledges that there
is another value in the cons cell, and that that value is being thrown
away.