### PR TITLE
Rewrite as_type methods in terms of From

### DIFF
--- a/rust_src/src/buffers.rs
+++ b/rust_src/src/buffers.rs
@@ -433,7 +433,7 @@ impl LispObject {
     }
 
     pub fn as_buffer(self) -> Option<LispBufferRef> {
-        self.as_vectorlike().and_then(|v| v.as_buffer())
+        self.into()
     }
 
     pub fn as_live_buffer(self) -> Option<LispBufferRef> {
@@ -441,14 +441,13 @@ impl LispObject {
     }
 
     pub fn as_buffer_or_error(self) -> LispBufferRef {
-        self.as_buffer()
-            .unwrap_or_else(|| wrong_type!(Qbufferp, self))
+        self.into()
     }
 }
 
 impl From<LispObject> for LispBufferRef {
     fn from(o: LispObject) -> Self {
-        o.as_buffer_or_error()
+        o.as_buffer().unwrap_or_else(|| wrong_type!(Qbufferp, o))
     }
 }
 
@@ -460,7 +459,7 @@ impl From<LispBufferRef> for LispObject {
 
 impl From<LispObject> for Option<LispBufferRef> {
     fn from(o: LispObject) -> Self {
-        o.as_buffer()
+        o.as_vectorlike().and_then(|v| v.as_buffer())
     }
 }
 
@@ -471,18 +470,17 @@ impl LispObject {
     }
 
     pub fn as_overlay(self) -> Option<LispOverlayRef> {
-        self.as_misc().and_then(|m| m.as_overlay())
+        self.into()
     }
 
     pub fn as_overlay_or_error(self) -> LispOverlayRef {
-        self.as_overlay()
-            .unwrap_or_else(|| wrong_type!(Qoverlayp, self))
+        self.into()
     }
 }
 
 impl From<LispObject> for LispOverlayRef {
     fn from(o: LispObject) -> Self {
-        o.as_overlay_or_error()
+        o.as_overlay().unwrap_or_else(|| wrong_type!(Qoverlayp, o))
     }
 }
 
@@ -494,7 +492,7 @@ impl From<LispOverlayRef> for LispObject {
 
 impl From<LispObject> for Option<LispOverlayRef> {
     fn from(o: LispObject) -> Self {
-        o.as_overlay()
+        o.as_misc().and_then(|m| m.as_overlay())
     }
 }
 

--- a/rust_src/src/charset.rs
+++ b/rust_src/src/charset.rs
@@ -3,19 +3,17 @@
 use remacs_macros::lisp_fn;
 
 use crate::{
-    hashtable::HashLookupResult,
+    hashtable::{HashLookupResult, LispHashTableRef},
     lisp::{defsubr, LispObject},
     remacs_sys::Vcharset_hash_table,
 };
 
 impl LispObject {
     pub fn is_charset(self) -> bool {
-        unsafe {
-            let h_ref = Vcharset_hash_table.as_hash_table_or_error();
-            match h_ref.lookup(self) {
-                HashLookupResult::Found(_) => true,
-                HashLookupResult::Missing(_) => false,
-            }
+        let h_ref: LispHashTableRef = unsafe { Vcharset_hash_table }.into();
+        match h_ref.lookup(self) {
+            HashLookupResult::Found(_) => true,
+            HashLookupResult::Missing(_) => false,
         }
     }
 }

--- a/rust_src/src/chartable.rs
+++ b/rust_src/src/chartable.rs
@@ -27,27 +27,23 @@ impl LispObject {
     }
 
     pub fn as_char_table(self) -> Option<LispCharTableRef> {
-        self.as_vectorlike().and_then(|v| v.as_char_table())
-    }
-
-    pub fn as_char_table_or_error(self) -> LispCharTableRef {
-        if let Some(chartable) = self.as_char_table() {
-            chartable
-        } else {
-            wrong_type!(Qchar_table_p, self)
-        }
+        self.into()
     }
 }
 
 impl From<LispObject> for LispCharTableRef {
     fn from(o: LispObject) -> Self {
-        o.as_char_table_or_error()
+        if let Some(chartable) = o.as_char_table() {
+            chartable
+        } else {
+            wrong_type!(Qchar_table_p, o)
+        }
     }
 }
 
 impl From<LispObject> for Option<LispCharTableRef> {
     fn from(o: LispObject) -> Self {
-        o.as_char_table()
+        o.as_vectorlike().and_then(|v| v.as_char_table())
     }
 }
 

--- a/rust_src/src/coding.rs
+++ b/rust_src/src/coding.rs
@@ -7,6 +7,7 @@ use crate::{
     hashtable::{
         gethash,
         HashLookupResult::{Found, Missing},
+        LispHashTableRef,
     },
     lisp::defsubr,
     lisp::LispObject,
@@ -30,7 +31,7 @@ fn coding_system_spec(coding_system: LispObject) -> LispObject {
 /// Return the ID of OBJECT.
 /// Same as the CODING_SYSTEM_ID C macro.
 pub fn coding_system_id(object: LispObject) -> isize {
-    let h_ref = unsafe { Vcoding_system_hash_table }.as_hash_table_or_error();
+    let h_ref: LispHashTableRef = unsafe { Vcoding_system_hash_table }.into();
     match h_ref.lookup(object) {
         Found(idx) => idx as isize,
         Missing(_) => -1,

--- a/rust_src/src/frames.rs
+++ b/rust_src/src/frames.rs
@@ -38,7 +38,7 @@ impl LispFrameRef {
 
 impl From<LispObject> for LispFrameRef {
     fn from(o: LispObject) -> Self {
-        o.as_frame_or_error()
+        o.as_frame().unwrap_or_else(|| wrong_type!(Qframep, o))
     }
 }
 
@@ -50,7 +50,7 @@ impl From<LispFrameRef> for LispObject {
 
 impl From<LispObject> for Option<LispFrameRef> {
     fn from(o: LispObject) -> Self {
-        o.as_frame()
+        o.as_vectorlike().and_then(|v| v.as_frame())
     }
 }
 
@@ -61,13 +61,12 @@ impl LispObject {
     }
 
     pub fn as_frame(self) -> Option<LispFrameRef> {
-        self.as_vectorlike().and_then(|v| v.as_frame())
+        self.into()
     }
 
     // Same as CHECK_FRAME
     pub fn as_frame_or_error(self) -> LispFrameRef {
-        self.as_frame()
-            .unwrap_or_else(|| wrong_type!(Qframep, self))
+        self.into()
     }
 
     pub fn as_live_frame(self) -> Option<LispFrameRef> {

--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -230,17 +230,23 @@ impl LispObject {
     }
 
     pub fn as_subr(self) -> Option<LispSubrRef> {
-        self.as_vectorlike().and_then(|v| v.as_subr())
+        self.into()
     }
 
     pub fn as_subr_or_error(self) -> LispSubrRef {
-        self.as_subr().unwrap_or_else(|| wrong_type!(Qsubrp, self))
+        self.into()
     }
 }
 
 impl From<LispObject> for LispSubrRef {
     fn from(o: LispObject) -> Self {
-        o.as_subr_or_error()
+        o.as_subr().unwrap_or_else(|| wrong_type!(Qsubrp, o))
+    }
+}
+
+impl From<LispObject> for Option<LispSubrRef> {
+    fn from(o: LispObject) -> Self {
+        o.as_vectorlike().and_then(|v| v.as_subr())
     }
 }
 

--- a/rust_src/src/marker.rs
+++ b/rust_src/src/marker.rs
@@ -103,7 +103,7 @@ impl LispMarkerRef {
 
 impl From<LispObject> for LispMarkerRef {
     fn from(o: LispObject) -> Self {
-        o.as_marker_or_error()
+        o.as_marker().unwrap_or_else(|| wrong_type!(Qmarkerp, o))
     }
 }
 
@@ -115,7 +115,7 @@ impl From<LispMarkerRef> for LispObject {
 
 impl From<LispObject> for Option<LispMarkerRef> {
     fn from(o: LispObject) -> Self {
-        o.as_marker()
+        o.as_misc().and_then(|m| m.as_marker())
     }
 }
 
@@ -126,12 +126,11 @@ impl LispObject {
     }
 
     pub fn as_marker(self) -> Option<LispMarkerRef> {
-        self.as_misc().and_then(|m| m.as_marker())
+        self.into()
     }
 
     pub fn as_marker_or_error(self) -> LispMarkerRef {
-        self.as_marker()
-            .unwrap_or_else(|| wrong_type!(Qmarkerp, self))
+        self.into()
     }
 }
 

--- a/rust_src/src/multibyte.rs
+++ b/rust_src/src/multibyte.rs
@@ -259,7 +259,17 @@ impl From<EmacsDouble> for LispObject {
 
 impl From<LispObject> for LispStringRef {
     fn from(o: LispObject) -> Self {
-        o.as_string_or_error()
+        o.as_string().unwrap_or_else(|| wrong_type!(Qstringp, o))
+    }
+}
+
+impl From<LispObject> for Option<LispStringRef> {
+    fn from(o: LispObject) -> Self {
+        if o.is_string() {
+            Some(unsafe { o.as_string_unchecked() })
+        } else {
+            None
+        }
     }
 }
 
@@ -275,16 +285,11 @@ impl LispObject {
     }
 
     pub fn as_string(self) -> Option<LispStringRef> {
-        if self.is_string() {
-            Some(unsafe { self.as_string_unchecked() })
-        } else {
-            None
-        }
+        self.into()
     }
 
     pub fn as_string_or_error(self) -> LispStringRef {
-        self.as_string()
-            .unwrap_or_else(|| wrong_type!(Qstringp, self))
+        self.into()
     }
 
     pub unsafe fn as_string_unchecked(self) -> LispStringRef {

--- a/rust_src/src/obarray.rs
+++ b/rust_src/src/obarray.rs
@@ -78,15 +78,9 @@ impl LispObarrayRef {
     }
 }
 
-impl LispObject {
-    pub fn as_obarray_or_error(self) -> LispObarrayRef {
-        LispObarrayRef::new(check_obarray(self))
-    }
-}
-
 impl From<LispObject> for LispObarrayRef {
     fn from(o: LispObject) -> LispObarrayRef {
-        o.as_obarray_or_error()
+        LispObarrayRef::new(check_obarray(o))
     }
 }
 
@@ -95,7 +89,7 @@ impl From<LispObject> for Option<LispObarrayRef> {
         if o.is_nil() {
             None
         } else {
-            Some(o.as_obarray_or_error())
+            Some(o.into())
         }
     }
 }

--- a/rust_src/src/process.rs
+++ b/rust_src/src/process.rs
@@ -49,18 +49,17 @@ impl LispObject {
     }
 
     pub fn as_process(self) -> Option<LispProcessRef> {
-        self.as_vectorlike().and_then(|v| v.as_process())
+        self.into()
     }
 
     pub fn as_process_or_error(self) -> LispProcessRef {
-        self.as_process()
-            .unwrap_or_else(|| wrong_type!(Qprocessp, self))
+        self.into()
     }
 }
 
 impl From<LispObject> for LispProcessRef {
     fn from(o: LispObject) -> Self {
-        o.as_process_or_error()
+        o.as_process().unwrap_or_else(|| wrong_type!(Qprocessp, o))
     }
 }
 
@@ -72,7 +71,7 @@ impl From<LispProcessRef> for LispObject {
 
 impl From<LispObject> for Option<LispProcessRef> {
     fn from(o: LispObject) -> Self {
-        o.as_process()
+        o.as_vectorlike().and_then(|v| v.as_process())
     }
 }
 

--- a/rust_src/src/symbols.rs
+++ b/rust_src/src/symbols.rs
@@ -153,7 +153,11 @@ impl LispSymbolRef {
 
 impl From<LispObject> for LispSymbolRef {
     fn from(o: LispObject) -> Self {
-        o.as_symbol_or_error()
+        if let Some(sym) = o.as_symbol() {
+            sym
+        } else {
+            wrong_type!(Qsymbolp, o)
+        }
     }
 }
 
@@ -165,7 +169,11 @@ impl From<LispSymbolRef> for LispObject {
 
 impl From<LispObject> for Option<LispSymbolRef> {
     fn from(o: LispObject) -> Self {
-        o.as_symbol()
+        if o.is_symbol() {
+            Some(LispSymbolRef::new(o.symbol_ptr_value() as *mut Lisp_Symbol))
+        } else {
+            None
+        }
     }
 }
 
@@ -176,21 +184,11 @@ impl LispObject {
     }
 
     pub fn as_symbol(self) -> Option<LispSymbolRef> {
-        if self.is_symbol() {
-            Some(LispSymbolRef::new(
-                self.symbol_ptr_value() as *mut Lisp_Symbol
-            ))
-        } else {
-            None
-        }
+        self.into()
     }
 
     pub fn as_symbol_or_error(self) -> LispSymbolRef {
-        if let Some(sym) = self.as_symbol() {
-            sym
-        } else {
-            wrong_type!(Qsymbolp, self)
-        }
+        self.into()
     }
 
     pub fn symbol_or_string_as_string(self) -> LispStringRef {

--- a/rust_src/src/syntax.rs
+++ b/rust_src/src/syntax.rs
@@ -98,24 +98,24 @@ pub extern "C" fn check_syntax_table(obj: LispObject) {
 /// Construct a new syntax table and return it.
 /// It is a copy of the TABLE, which defaults to the standard syntax table.
 #[lisp_fn(min = "0")]
-pub fn copy_syntax_table(mut table: LispObject) -> LispObject {
+pub fn copy_syntax_table(mut table: LispObject) -> LispCharTableRef {
     let buffer_table = unsafe { buffer_defaults.syntax_table_ };
     if table.is_not_nil() {
         check_syntax_table(table);
     } else {
         table = buffer_table;
     }
-    let copy = unsafe { Fcopy_sequence(table) };
+    let copy: LispCharTableRef = unsafe { Fcopy_sequence(table) }.into();
 
     // Only the standard syntax table should have a default element.
     // Other syntax tables should inherit from parents instead.
-    unsafe { set_char_table_defalt(copy, Qnil) };
+    unsafe { set_char_table_defalt(copy.into(), Qnil) };
 
     // Copied syntax tables should all have parents.
     // If we copied one with no parent, such as the standard syntax table,
     // use the standard syntax table as the copy's parent.
-    if copy.as_char_table_or_error().parent.is_nil() {
-        unsafe { Fset_char_table_parent(copy, buffer_table) };
+    if copy.parent.is_nil() {
+        unsafe { Fset_char_table_parent(copy.into(), buffer_table) };
     }
     copy
 }

--- a/rust_src/src/threads.rs
+++ b/rust_src/src/threads.rs
@@ -48,7 +48,7 @@ impl ThreadStateRef {
 
 impl From<LispObject> for ThreadStateRef {
     fn from(o: LispObject) -> Self {
-        o.as_thread_or_error()
+        o.as_thread().unwrap_or_else(|| wrong_type!(Qthreadp, o))
     }
 }
 
@@ -69,8 +69,7 @@ impl LispObject {
     }
 
     pub fn as_thread_or_error(self) -> ThreadStateRef {
-        self.as_thread()
-            .unwrap_or_else(|| wrong_type!(Qthreadp, self))
+        self.into()
     }
 }
 

--- a/rust_src/src/window_configuration.rs
+++ b/rust_src/src/window_configuration.rs
@@ -103,7 +103,8 @@ impl SavedWindowRef {
 
 impl From<LispObject> for SaveWindowDataRef {
     fn from(o: LispObject) -> Self {
-        o.as_window_configuration_or_error()
+        o.as_window_configuration()
+            .unwrap_or_else(|| wrong_type!(Qwindow_configuration_p, o))
     }
 }
 
@@ -111,11 +112,6 @@ impl LispObject {
     pub fn as_window_configuration(self) -> Option<SaveWindowDataRef> {
         self.as_vectorlike()
             .and_then(|v| v.as_window_configuration())
-    }
-
-    pub fn as_window_configuration_or_error(self) -> SaveWindowDataRef {
-        self.as_window_configuration()
-            .unwrap_or_else(|| wrong_type!(Qwindow_configuration_p, self))
     }
 }
 
@@ -150,8 +146,8 @@ pub extern "C" fn compare_window_configurations(
     ignore_positions: bool,
 ) -> bool {
     compare_window_configurations_rust(
-        configuration1.as_window_configuration_or_error(),
-        configuration2.as_window_configuration_or_error(),
+        configuration1.into(),
+        configuration2.into(),
         ignore_positions,
     )
 }

--- a/rust_src/src/windows.rs
+++ b/rust_src/src/windows.rs
@@ -227,7 +227,7 @@ impl LispWindowRef {
 
 impl From<LispObject> for LispWindowRef {
     fn from(o: LispObject) -> Self {
-        o.as_window_or_error()
+        o.as_window().unwrap_or_else(|| wrong_type!(Qwindowp, o))
     }
 }
 
@@ -239,7 +239,7 @@ impl From<LispWindowRef> for LispObject {
 
 impl From<LispObject> for Option<LispWindowRef> {
     fn from(o: LispObject) -> Self {
-        o.as_window()
+        o.as_vectorlike().and_then(|v| v.as_window())
     }
 }
 
@@ -250,12 +250,11 @@ impl LispObject {
     }
 
     pub fn as_window(self) -> Option<LispWindowRef> {
-        self.as_vectorlike().and_then(|v| v.as_window())
+        self.into()
     }
 
     pub fn as_window_or_error(self) -> LispWindowRef {
-        self.as_window()
-            .unwrap_or_else(|| wrong_type!(Qwindowp, self))
+        self.into()
     }
 
     pub fn as_minibuffer_or_error(self) -> LispWindowRef {


### PR DESCRIPTION
Currently a lot of type conversions are written as methods on
LispObject, and the From trait implementations are written in terms of
those. It should be the other way around, so move the as_type logic
into the From implementations and make the as_type functions just do
casts. This will make it easier to remove them entirely in the future,
allowing the type system to do more work.

A few as_type functions, like as_window_configuration_or_error, were
only used in a few places, so those were cut entirely.