### PR TITLE
Quote RUSTFLAGS in lib-src/Makefile.in

### DIFF
--- a/lib-src/Makefile.in
+++ b/lib-src/Makefile.in
@@ -383,7 +383,7 @@ TAGS: etags${EXEEXT} ${tagsfiles}
 
 cargo_manifest=../rust_src/remacs-lib/Cargo.toml
 $(RUST_ARCHIVE): $(rust_srcdir)/remacs-lib/**
-	RUSTFLAGS=$(RUSTFLAGS) \
+	RUSTFLAGS="$(RUSTFLAGS)" \
 	$(CARGO_BUILD) $(CARGO_FLAGS) --manifest-path=$(cargo_manifest)
 
 remacs-libclean:


### PR DESCRIPTION
Fixes #1135.

This prevents occasional build failures when settings custom RUSTFLAGS. The build failure occured when executing below command on a clean checkout.

./autogen.sh && ./configure --enable-rust-debug && \ make -j4 RUSTFLAGS="-C target-cpu=native" all