### PR TITLE
Port record_unwind_protect functions

### DIFF
--- a/rust_src/src/editfns.rs
+++ b/rust_src/src/editfns.rs
@@ -14,7 +14,7 @@ use crate::{
     buffers::{current_buffer, validate_region},
     buffers::{LispBufferOrCurrent, LispBufferOrName, LispBufferRef, BUF_BYTES_MAX},
     character::{char_head_p, dec_pos},
-    eval::{progn, unbind_to},
+    eval::{progn, record_unwind_protect, unbind_to},
     indent::invalidate_current_column,
     lisp::{defsubr, LispObject},
     marker::{
@@ -33,10 +33,9 @@ use crate::{
         find_before_next_newline, find_newline, get_char_property_and_overlay, globals, insert,
         insert_and_inherit, insert_from_buffer, make_buffer_string, make_buffer_string_both,
         make_save_obj_obj_obj_obj, make_string_from_bytes, maybe_quit, message1, message3,
-        record_unwind_current_buffer, record_unwind_protect, save_excursion_restore,
-        save_restriction_restore, save_restriction_save, scan_newline_from_point,
-        set_buffer_internal_1, set_point, set_point_both, styled_format, update_buffer_properties,
-        STRING_BYTES,
+        record_unwind_current_buffer, save_excursion_restore, save_restriction_restore,
+        save_restriction_save, scan_newline_from_point, set_buffer_internal_1, set_point,
+        set_point_both, styled_format, update_buffer_properties, STRING_BYTES,
     },
     remacs_sys::{
         Fadd_text_properties, Fcopy_sequence, Fget_pos_property, Fnext_single_char_property_change,

--- a/rust_src/src/eval.rs
+++ b/rust_src/src/eval.rs
@@ -1,8 +1,8 @@
 //! Generic Lisp eval functions
 
-use libc::c_void;
-
 use std::ptr;
+
+use libc::c_void;
 
 use remacs_macros::lisp_fn;
 

--- a/rust_src/src/eval.rs
+++ b/rust_src/src/eval.rs
@@ -1,5 +1,7 @@
 //! Generic Lisp eval functions
 
+use libc::c_void;
+
 use std::ptr;
 
 use remacs_macros::lisp_fn;
@@ -13,10 +15,13 @@ use crate::{
     multibyte::LispStringRef,
     obarray::loadhist_attach,
     objects::equal,
+    remacs_sys::specbind_tag::{
+        SPECPDL_UNWIND, SPECPDL_UNWIND_INT, SPECPDL_UNWIND_PTR, SPECPDL_UNWIND_VOID,
+    },
     remacs_sys::{
         backtrace_debug_on_exit, build_string, call_debugger, check_cons_list, do_debug_on_call,
         do_one_unbind, eval_sub, find_symbol_value, funcall_lambda, funcall_subr, globals,
-        internal_catch, list2, maybe_gc, maybe_quit, record_in_backtrace, record_unwind_protect,
+        grow_specpdl, internal_catch, list2, maybe_gc, maybe_quit, record_in_backtrace,
         record_unwind_save_match_data, specbind, COMPILEDP, MODULE_FUNCTIONP,
     },
     remacs_sys::{pvec_type, EmacsInt, Lisp_Compiled, Set_Internal_Bind},
@@ -36,6 +41,58 @@ use crate::{
  *   NOTE!!! Every function that can call EVAL must protect its args   *
  *   and temporaries from garbage collection while it needs them.      *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#[no_mangle]
+pub unsafe extern "C" fn record_unwind_protect(
+    function: Option<unsafe extern "C" fn(LispObject)>,
+    arg: LispObject,
+) {
+    let unwind = (*ThreadState::current_thread().m_specpdl_ptr)
+        .unwind
+        .as_mut();
+    unwind.set_kind(SPECPDL_UNWIND);
+    unwind.func = function;
+    unwind.arg = arg;
+    grow_specpdl();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn record_unwind_protect_ptr(
+    function: Option<unsafe extern "C" fn(*mut c_void)>,
+    arg: *mut c_void,
+) {
+    let unwind = (*ThreadState::current_thread().m_specpdl_ptr)
+        .unwind_ptr
+        .as_mut();
+    unwind.set_kind(SPECPDL_UNWIND_PTR);
+    unwind.func = function;
+    unwind.arg = arg;
+    grow_specpdl();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn record_unwind_protect_int(
+    function: Option<unsafe extern "C" fn(i32)>,
+    arg: i32,
+) {
+    let unwind = (*ThreadState::current_thread().m_specpdl_ptr)
+        .unwind_int
+        .as_mut();
+    unwind.set_kind(SPECPDL_UNWIND_INT);
+    unwind.func = function;
+    unwind.arg = arg;
+    grow_specpdl();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn record_unwind_protect_void(function: Option<unsafe extern "C" fn()>) {
+    let unwind = (*ThreadState::current_thread().m_specpdl_ptr)
+        .unwind_void
+        .as_mut();
+    unwind.set_kind(SPECPDL_UNWIND_VOID);
+    unwind.func = function;
+    grow_specpdl();
+}
 
 /// Eval args until one of them yields non-nil, then return that value.
 /// The remaining args are not evalled at all.

--- a/rust_src/src/fns.rs
+++ b/rust_src/src/fns.rs
@@ -7,7 +7,7 @@ use libc;
 use remacs_macros::lisp_fn;
 
 use crate::{
-    eval::{un_autoload, unbind_to},
+    eval::{record_unwind_protect, un_autoload, unbind_to},
     lisp::defsubr,
     lisp::LispObject,
     lists::{assq, car, get, mapcar1, member, memq, put},
@@ -18,7 +18,7 @@ use crate::{
     objects::equal,
     remacs_sys::Fload,
     remacs_sys::Vautoload_queue,
-    remacs_sys::{concat as lisp_concat, globals, record_unwind_protect},
+    remacs_sys::{concat as lisp_concat, globals},
     remacs_sys::{equal_kind, EmacsInt, Lisp_Type},
     remacs_sys::{Qfuncall, Qlistp, Qnil, Qprovide, Qquote, Qrequire, Qsubfeatures, Qt},
     symbols::LispSymbolRef,

--- a/src/eval.c
+++ b/src/eval.c
@@ -267,8 +267,6 @@ restore_stack_limits (Lisp_Object data)
   max_lisp_eval_depth = XINT (XCDR (data));
 }
 
-static void grow_specpdl (void);
-
 /* Call the Lisp debugger, giving it argument ARG.  */
 
 Lisp_Object
@@ -1373,7 +1371,7 @@ error (const char *m, ...)
    never-used entry just before the bottom of the stack; sometimes its
    address is taken.  */
 
-static void
+void
 grow_specpdl (void)
 {
   specpdl_ptr++;
@@ -2397,41 +2395,6 @@ specbind (Lisp_Object symbol, Lisp_Object value)
 }
 
 /* Push unwind-protect entries of various types.  */
-
-void
-record_unwind_protect (void (*function) (Lisp_Object), Lisp_Object arg)
-{
-  specpdl_ptr->unwind.kind = SPECPDL_UNWIND;
-  specpdl_ptr->unwind.func = function;
-  specpdl_ptr->unwind.arg = arg;
-  grow_specpdl ();
-}
-
-void
-record_unwind_protect_ptr (void (*function) (void *), void *arg)
-{
-  specpdl_ptr->unwind_ptr.kind = SPECPDL_UNWIND_PTR;
-  specpdl_ptr->unwind_ptr.func = function;
-  specpdl_ptr->unwind_ptr.arg = arg;
-  grow_specpdl ();
-}
-
-void
-record_unwind_protect_int (void (*function) (int), int arg)
-{
-  specpdl_ptr->unwind_int.kind = SPECPDL_UNWIND_INT;
-  specpdl_ptr->unwind_int.func = function;
-  specpdl_ptr->unwind_int.arg = arg;
-  grow_specpdl ();
-}
-
-void
-record_unwind_protect_void (void (*function) (void))
-{
-  specpdl_ptr->unwind_void.kind = SPECPDL_UNWIND_VOID;
-  specpdl_ptr->unwind_void.func = function;
-  grow_specpdl ();
-}
 
 void
 rebind_for_thread_switch (void)

--- a/src/lisp.h
+++ b/src/lisp.h
@@ -4046,6 +4046,7 @@ extern void syms_of_eval (void);
 extern void prog_ignore (Lisp_Object);
 extern ptrdiff_t record_in_backtrace (Lisp_Object, Lisp_Object *, ptrdiff_t);
 extern void mark_specpdl (union specbinding *first, union specbinding *ptr);
+extern void grow_specpdl (void);
 extern void get_backtrace (Lisp_Object array);
 Lisp_Object backtrace_top_function (void);
 extern bool let_shadows_buffer_binding_p (struct Lisp_Symbol *symbol);


### PR DESCRIPTION
Port the `record_unwind_protect` set of functions.

These changes are split from #1233.