### PR TITLE
Port command-error-or-default-function

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4738,7 +4738,6 @@ AH_TEMPLATE(DOS_NT, [Define if the system is MS DOS or MS Windows.])
 AH_TEMPLATE(USG, [Define if the system is compatible with System III.])
 AH_TEMPLATE(USG5_4, [Define if the system is compatible with System V Release 4.])
 
-CARGO_DEFAULT_FEATURES=""
 case $opsys in
   aix4-2)
     AC_DEFINE(USG, [])
@@ -4774,7 +4773,6 @@ case $opsys in
   mingw32)
     AC_DEFINE(DOS_NT, [])
     AC_DEFINE(WINDOWSNT, 1, [Define if compiling for native MS Windows.])
-    CARGO_DEFAULT_FEATURES="${CARGO_DEFAULT_FEATURES}\"windowsnt\", "
     if test "x$ac_enable_checking" != "x" ; then
       AC_DEFINE(EMACSDEBUG, 1, [Define to 1 to enable w32 debug facilities.])
     fi
@@ -5456,6 +5454,7 @@ fi || AC_MSG_ERROR(['src/epaths.h' could not be made.])
 ], [GCC="$GCC" CPPFLAGS="$CPPFLAGS" opsys="$opsys"])
 
 
+CARGO_DEFAULT_FEATURES=""
 if test "$HAVE_LIBXML2" = "yes"; then
     CARGO_DEFAULT_FEATURES="${CARGO_DEFAULT_FEATURES}\"use-xml2\", "
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -4738,6 +4738,7 @@ AH_TEMPLATE(DOS_NT, [Define if the system is MS DOS or MS Windows.])
 AH_TEMPLATE(USG, [Define if the system is compatible with System III.])
 AH_TEMPLATE(USG5_4, [Define if the system is compatible with System V Release 4.])
 
+CARGO_DEFAULT_FEATURES=""
 case $opsys in
   aix4-2)
     AC_DEFINE(USG, [])
@@ -4773,6 +4774,7 @@ case $opsys in
   mingw32)
     AC_DEFINE(DOS_NT, [])
     AC_DEFINE(WINDOWSNT, 1, [Define if compiling for native MS Windows.])
+    CARGO_DEFAULT_FEATURES="${CARGO_DEFAULT_FEATURES}\"windowsnt\", "
     if test "x$ac_enable_checking" != "x" ; then
       AC_DEFINE(EMACSDEBUG, 1, [Define to 1 to enable w32 debug facilities.])
     fi
@@ -5454,7 +5456,6 @@ fi || AC_MSG_ERROR(['src/epaths.h' could not be made.])
 ], [GCC="$GCC" CPPFLAGS="$CPPFLAGS" opsys="$opsys"])
 
 
-CARGO_DEFAULT_FEATURES=""
 if test "$HAVE_LIBXML2" = "yes"; then
     CARGO_DEFAULT_FEATURES="${CARGO_DEFAULT_FEATURES}\"use-xml2\", "
 fi

--- a/rust_src/Cargo.lock
+++ b/rust_src/Cargo.lock
@@ -32,7 +32,7 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace-sys 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-demangle 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -99,7 +99,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cfg-if"
-version = "0.1.3"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -490,6 +490,7 @@ version = "0.1.0"
 dependencies = [
  "alloc_unexecmacosx 0.1.0",
  "base64 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.206 (registry+https://github.com/rust-lang/crates.io-index)",
  "errno 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "field-offset 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -787,7 +788,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "94f88df23a25417badc922ab0f5716cc1330e87f71ddd9203b3a3ccd9cedf75d"
 "checksum cargo_metadata 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "692a7aaca96b85973d7d92c5f633d75a399760ee61977db480ffdeadd497cbd2"
 "checksum cc 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "49ec142f5768efb5b7622aebc3fdbdbb8950a4b9ba996393cb76ef7466e8747d"
-"checksum cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "405216fd8fe65f718daa7102ea808a946b6ce40c742998fbfd3463645552de18"
+"checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
 "checksum clippy 0.0.206 (registry+https://github.com/rust-lang/crates.io-index)" = "f4ee3a52bb1a86cbd575205449951cb425c14afcebc4f1cb7a423cee1e9f7f1f"
 "checksum clippy_lints 0.0.206 (registry+https://github.com/rust-lang/crates.io-index)" = "9d936ee2f2a30d1421d57d653dba488f806f25e46e24a8fe667bcbfb9fa7cfee"
 "checksum crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"

--- a/rust_src/Cargo.toml.in
+++ b/rust_src/Cargo.toml.in
@@ -25,6 +25,7 @@ sha2 = "0.4.2"
 field-offset = "0.1.1"
 flate2 = { version = "1.0.1", features = ["rust_backend"], default-features = false }
 if_chain = "0.1.3"
+cfg-if = "0.1.6"
 
 # Only want this local crate as dependency on Mac OS X
 [target.'cfg(target_os = "macos")'.dependencies]
@@ -63,8 +64,6 @@ window-system-x11 = []
 window-system-nextstep = []
 # Use the w32 window system
 window-system-w32 = []
-# Compiling for windows
-windowsnt = []
 compile-errors = []
 # Treat warnings as a build error on Travis.
 strict = []

--- a/rust_src/Cargo.toml.in
+++ b/rust_src/Cargo.toml.in
@@ -63,6 +63,8 @@ window-system-x11 = []
 window-system-nextstep = []
 # Use the w32 window system
 window-system-w32 = []
+# Compiling for windows
+windowsnt = []
 compile-errors = []
 # Treat warnings as a build error on Travis.
 strict = []

--- a/rust_src/src/emacs.rs
+++ b/rust_src/src/emacs.rs
@@ -10,6 +10,7 @@ use crate::{
     remacs_sys::Fcopy_sequence,
 };
 
+/// Replaces IS_DAEMON
 cfg_if! {
     if #[cfg(windows)] {
         use crate::remacs_sys::w32_daemon_event;

--- a/rust_src/src/emacs.rs
+++ b/rust_src/src/emacs.rs
@@ -8,6 +8,11 @@ use crate::{
     remacs_sys::Fcopy_sequence,
 };
 
+#[cfg(not(feature = "windowsnt"))]
+use crate::remacs_sys::daemon_type;
+#[cfg(feature = "windowsnt")]
+use crate::remacs_sys::w32_daemon_event;
+
 /// Return the program name that was used to run Emacs.
 /// Any directory names are omitted.
 #[lisp_fn]
@@ -19,6 +24,13 @@ pub fn invocation_name() -> LispObject {
 #[lisp_fn]
 pub fn invocation_directory() -> LispObject {
     unsafe { Fcopy_sequence(globals.Vinvocation_directory) }
+}
+
+pub fn is_daemon() -> bool {
+    #[cfg(feature = "windowsnt")]
+    return unsafe { w32_daemon_event } != std::ptr::null_mut();
+    #[cfg(not(feature = "windowsnt"))]
+    return unsafe { daemon_type } != 0;
 }
 
 include!(concat!(env!("OUT_DIR"), "/emacs_exports.rs"));

--- a/rust_src/src/emacs.rs
+++ b/rust_src/src/emacs.rs
@@ -1,5 +1,7 @@
 //! Emacs!
 
+use cfg_if::cfg_if;
+
 use remacs_macros::lisp_fn;
 
 use crate::{
@@ -8,10 +10,19 @@ use crate::{
     remacs_sys::Fcopy_sequence,
 };
 
-#[cfg(not(feature = "windowsnt"))]
-use crate::remacs_sys::daemon_type;
-#[cfg(feature = "windowsnt")]
-use crate::remacs_sys::w32_daemon_event;
+cfg_if! {
+    if #[cfg(windows)] {
+        use crate::remacs_sys::w32_daemon_event;
+        pub fn is_daemon() -> bool {
+            unsafe { w32_daemon_event != std::ptr::null_mut() }
+        }
+    } else {
+        use crate::remacs_sys::daemon_type;
+        pub fn is_daemon() -> bool {
+            unsafe { daemon_type != 0 }
+        }
+    }
+}
 
 /// Return the program name that was used to run Emacs.
 /// Any directory names are omitted.
@@ -24,13 +35,6 @@ pub fn invocation_name() -> LispObject {
 #[lisp_fn]
 pub fn invocation_directory() -> LispObject {
     unsafe { Fcopy_sequence(globals.Vinvocation_directory) }
-}
-
-pub fn is_daemon() -> bool {
-    #[cfg(feature = "windowsnt")]
-    return unsafe { w32_daemon_event } != std::ptr::null_mut();
-    #[cfg(not(feature = "windowsnt"))]
-    return unsafe { daemon_type } != 0;
 }
 
 include!(concat!(env!("OUT_DIR"), "/emacs_exports.rs"));

--- a/rust_src/src/keyboard.rs
+++ b/rust_src/src/keyboard.rs
@@ -236,7 +236,7 @@ pub fn command_error_default_function(
     data: LispObject,
     context: LispStringRef,
     signal: LispObject,
-) -> LispObject {
+) {
     // If the window system or terminal frame hasn't been initialized
     // yet, or we're not interactive, write the message to stderr and
     // exit.
@@ -272,7 +272,6 @@ pub fn command_error_default_function(
             print_error_message(data, Qt, context.const_sdata_ptr(), signal);
         }
     }
-    Qnil
 }
 
 include!(concat!(env!("OUT_DIR"), "/keyboard_exports.rs"));

--- a/rust_src/src/keyboard.rs
+++ b/rust_src/src/keyboard.rs
@@ -4,21 +4,30 @@ use remacs_macros::lisp_fn;
 
 use crate::{
     buffers::current_buffer,
+    dispnew::ding_internal,
+    emacs::is_daemon,
     eval::{record_unwind_protect, unbind_to},
     frames::{selected_frame, window_frame_live_or_selected_with_action},
     lisp::defsubr,
     lisp::LispObject,
     lists::{LispCons, LispConsCircularChecks, LispConsEndChecks},
+    multibyte::LispStringRef,
     numbers::IsLispNatnum,
+    remacs_sys::globals,
+    remacs_sys::{clear_message, message_log_maybe_newline, print_error_message},
     remacs_sys::{
         command_loop_level, glyph_row_area, interrupt_input_blocked, minibuf_level,
         recursive_edit_1, recursive_edit_unwind, update_mode_lines,
     },
     remacs_sys::{
-        make_lispy_position, temporarily_switch_to_single_kboard, window_box_left_offset,
+        make_lispy_position, output_method, temporarily_switch_to_single_kboard,
+        window_box_left_offset,
     },
-    remacs_sys::{Fpos_visible_in_window_p, Fthrow},
-    remacs_sys::{Qexit, Qheader_line, Qhelp_echo, Qmode_line, Qnil, Qt, Qvertical_line},
+    remacs_sys::{Fdiscard_input, Fkill_emacs, Fpos_visible_in_window_p, Fterpri, Fthrow},
+    remacs_sys::{
+        Qexit, Qexternal_debugging_output, Qheader_line, Qhelp_echo, Qmode_line, Qnil, Qt,
+        Qvertical_line,
+    },
     threads::c_specpdl_index,
     windows::{selected_window, LispWindowOrSelected},
 };
@@ -218,6 +227,54 @@ pub extern "C" fn rust_syms_of_keyboard() {
     /// This is the command `repeat' will try to repeat.
     /// Taken from a previous value of `real-this-command'.  */
     defvar_kboard!(Vlast_repeatable_command_, "last-repeatable-command");
+}
+
+/// Produce default output for unhandled error message.
+/// Default value of `command-error-function'.
+#[lisp_fn]
+pub fn command_error_default_function(
+    data: LispObject,
+    context: LispStringRef,
+    signal: LispObject,
+) -> LispObject {
+    let sf = selected_frame();
+
+    // If the window system or terminal frame hasn't been initialized
+    // yet, or we're not interactive, write the message to stderr and
+    // exit.
+    if sf.glyphs_initialized_p()
+        // The initial frame is a special non-displaying frame. It
+        // will be current in daemon mode when there are no frames to
+        // display, and in non-daemon mode before the real frame has
+        // finished initializing.  If an error is thrown in the latter
+        // case while creating the frame, then the frame will never be
+        // displayed, so the safest thing to do is write to stderr and
+        // quit.  In daemon mode, there are many other potential
+        // errors that do not prevent frames from being created, so
+        // continuing as normal is better in that case.
+        || (!is_daemon() && sf.output_method() == output_method::output_initial)
+        || unsafe {globals.noninteractive1 }
+    {
+        unsafe {
+            print_error_message(
+                data,
+                Qexternal_debugging_output,
+                context.const_sdata_ptr(),
+                signal,
+            );
+            Fterpri(Qexternal_debugging_output, Qnil);
+            Fkill_emacs(LispObject::from(-1));
+        }
+    } else {
+        unsafe {
+            clear_message(true, false);
+            Fdiscard_input();
+            message_log_maybe_newline();
+            ding_internal(true);
+            print_error_message(data, Qt, context.const_sdata_ptr(), signal);
+        }
+    }
+    Qnil
 }
 
 include!(concat!(env!("OUT_DIR"), "/keyboard_exports.rs"));

--- a/rust_src/src/keyboard.rs
+++ b/rust_src/src/keyboard.rs
@@ -234,10 +234,11 @@ pub fn command_error_default_function(
     context: LispStringRef,
     signal: LispObject,
 ) {
+    let selected_frame = selected_frame();
     // If the window system or terminal frame hasn't been initialized
     // yet, or we're not interactive, write the message to stderr and
     // exit.
-    if selected_frame().glyphs_initialized_p()
+    if selected_frame.glyphs_initialized_p()
         // The initial frame is a special non-displaying frame. It
         // will be current in daemon mode when there are no frames to
         // display, and in non-daemon mode before the real frame has
@@ -247,7 +248,7 @@ pub fn command_error_default_function(
         // quit.  In daemon mode, there are many other potential
         // errors that do not prevent frames from being created, so
         // continuing as normal is better in that case.
-        || (!is_daemon() && selected_frame().output_method() == output_method::output_initial)
+        || (!is_daemon() && selected_frame.output_method() == output_method::output_initial)
         || unsafe {globals.noninteractive1 }
     {
         unsafe {

--- a/rust_src/src/keyboard.rs
+++ b/rust_src/src/keyboard.rs
@@ -237,12 +237,10 @@ pub fn command_error_default_function(
     context: LispStringRef,
     signal: LispObject,
 ) -> LispObject {
-    let sf = selected_frame();
-
     // If the window system or terminal frame hasn't been initialized
     // yet, or we're not interactive, write the message to stderr and
     // exit.
-    if sf.glyphs_initialized_p()
+    if selected_frame().glyphs_initialized_p()
         // The initial frame is a special non-displaying frame. It
         // will be current in daemon mode when there are no frames to
         // display, and in non-daemon mode before the real frame has
@@ -252,7 +250,7 @@ pub fn command_error_default_function(
         // quit.  In daemon mode, there are many other potential
         // errors that do not prevent frames from being created, so
         // continuing as normal is better in that case.
-        || (!is_daemon() && sf.output_method() == output_method::output_initial)
+        || (!is_daemon() && selected_frame().output_method() == output_method::output_initial)
         || unsafe {globals.noninteractive1 }
     {
         unsafe {

--- a/rust_src/src/keyboard.rs
+++ b/rust_src/src/keyboard.rs
@@ -14,14 +14,11 @@ use crate::{
     multibyte::LispStringRef,
     numbers::IsLispNatnum,
     remacs_sys::globals,
-    remacs_sys::{clear_message, message_log_maybe_newline, print_error_message},
     remacs_sys::{
-        command_loop_level, glyph_row_area, interrupt_input_blocked, minibuf_level,
-        recursive_edit_1, recursive_edit_unwind, update_mode_lines,
-    },
-    remacs_sys::{
-        make_lispy_position, output_method, temporarily_switch_to_single_kboard,
-        window_box_left_offset,
+        clear_message, command_loop_level, glyph_row_area, interrupt_input_blocked,
+        make_lispy_position, message_log_maybe_newline, minibuf_level, output_method,
+        print_error_message, recursive_edit_1, recursive_edit_unwind,
+        temporarily_switch_to_single_kboard, update_mode_lines, window_box_left_offset,
     },
     remacs_sys::{Fdiscard_input, Fkill_emacs, Fpos_visible_in_window_p, Fterpri, Fthrow},
     remacs_sys::{

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -959,49 +959,6 @@ cmd_error_internal (Lisp_Object data, const char *context)
   Vsignaling_function = Qnil;
 }
 
-DEFUN ("command-error-default-function", Fcommand_error_default_function,
-       Scommand_error_default_function, 3, 3, 0,
-       doc: /* Produce default output for unhandled error message.
-Default value of `command-error-function'.  */)
-  (Lisp_Object data, Lisp_Object context, Lisp_Object signal)
-{
-  struct frame *sf = SELECTED_FRAME ();
-
-  CHECK_STRING (context);
-
-  /* If the window system or terminal frame hasn't been initialized
-     yet, or we're not interactive, write the message to stderr and exit.  */
-  if (!sf->glyphs_initialized_p
-	   /* The initial frame is a special non-displaying frame. It
-	      will be current in daemon mode when there are no frames
-	      to display, and in non-daemon mode before the real frame
-	      has finished initializing.  If an error is thrown in the
-	      latter case while creating the frame, then the frame
-	      will never be displayed, so the safest thing to do is
-	      write to stderr and quit.  In daemon mode, there are
-	      many other potential errors that do not prevent frames
-	      from being created, so continuing as normal is better in
-	      that case.  */
-	   || (!IS_DAEMON && FRAME_INITIAL_P (sf))
-	   || noninteractive)
-    {
-      print_error_message (data, Qexternal_debugging_output,
-			   SSDATA (context), signal);
-      Fterpri (Qexternal_debugging_output, Qnil);
-      Fkill_emacs (make_number (-1));
-    }
-  else
-    {
-      clear_message (1, 0);
-      Fdiscard_input ();
-      message_log_maybe_newline ();
-      ding_internal (true);
-
-      print_error_message (data, Qt, SSDATA (context), signal);
-    }
-  return Qnil;
-}
-
 static Lisp_Object command_loop_2 (Lisp_Object);
 static Lisp_Object top_level_1 (Lisp_Object);
 
@@ -11061,7 +11018,6 @@ syms_of_keyboard (void)
   defsubr (&Sclear_this_command_keys);
   defsubr (&Ssuspend_emacs);
   defsubr (&Srecursion_depth);
-  defsubr (&Scommand_error_default_function);
   defsubr (&Stop_level);
   defsubr (&Sdiscard_input);
   defsubr (&Sopen_dribble_file);


### PR DESCRIPTION
This requires conditional compilation based on whether the platform is windows (for `is_daemon()`).
Not sure what's the best way to do that. I think this works but I didn't test it on windows.