### PR TITLE
Port window-body-height and window-body-width

### DIFF
--- a/rust_src/src/frames.rs
+++ b/rust_src/src/frames.rs
@@ -21,6 +21,9 @@ use crate::remacs_sys::vertical_scroll_bar_type;
 pub type LispFrameRef = ExternalPtr<Lisp_Frame>;
 
 impl LispFrameRef {
+    pub fn root_window(self) -> LispWindowRef {
+        self.root_window.into()
+    }
     pub fn is_live(self) -> bool {
         !self.terminal.is_null()
     }

--- a/rust_src/src/frames.rs
+++ b/rust_src/src/frames.rs
@@ -28,6 +28,11 @@ impl LispFrameRef {
         !self.terminal.is_null()
     }
 
+    // Awaiting Wilfred#1264
+    pub fn is_gui_window(self) -> bool {
+        cfg!(feature = "window_system")
+    }
+
     // Pixel-width of internal border lines.
     pub fn internal_border_width(self) -> i32 {
         unsafe { frame_dimension(self.internal_border_width) }

--- a/rust_src/src/frames.rs
+++ b/rust_src/src/frames.rs
@@ -46,20 +46,29 @@ impl LispFrameRef {
         self.left_fringe_width + self.right_fringe_width
     }
 
+    pub fn vertical_scroll_bar_type(self) -> u32 {
+        #[cfg(feature = "window-system")]
+        {
+            (*self).vertical_scroll_bar_type()
+        }
+        #[cfg(not(feature = "window-system"))]
+        0
+    }
+
     pub fn scroll_bar_area_width(self) -> i32 {
         #[cfg(feature = "window-system")]
         {
             match self.vertical_scroll_bar_type() {
                 vertical_scroll_bar_type::vertical_scroll_bar_left
                 | vertical_scroll_bar_type::vertical_scroll_bar_right => {
-                    return self.config_scroll_bar_width
+                    self.config_scroll_bar_width
                 }
-                _ => return 0,
+                _ => 0,
             }
         }
         #[cfg(not(feature = "window-system"))]
         {
-            return 0;
+            0
         }
     }
 

--- a/rust_src/src/windows.rs
+++ b/rust_src/src/windows.rs
@@ -1520,7 +1520,8 @@ pub fn set_window_redisplay_end_trigger(
 /// means that if a line at the bottom of the text area is only partially
 /// visible, that line is not counted.
 #[lisp_fn]
-pub fn window_body_height(window: LispWindowRef, pixelwise: bool) -> EmacsInt {
+pub fn window_body_height(window: LispWindowLiveOrSelected, pixelwise: bool) -> EmacsInt {
+    let window: LispWindowRef = window.into();
     window.body_height(pixelwise).into()
 }
 
@@ -1538,7 +1539,8 @@ pub fn window_body_height(window: LispWindowRef, pixelwise: bool) -> EmacsInt {
 /// Note that the returned value includes the column reserved for the
 /// continuation glyph.
 #[lisp_fn]
-pub fn window_body_width(window: LispWindowRef, pixelwise: bool) -> EmacsInt {
+pub fn window_body_width(window: LispWindowLiveOrSelected, pixelwise: bool) -> EmacsInt {
+    let window: LispWindowRef = window.into();
     window.body_width(pixelwise).into()
 }
 

--- a/src/window.c
+++ b/src/window.c
@@ -551,27 +551,6 @@ WINDOW must be a valid window and defaults to the selected one.  */)
   return make_number (decode_valid_window (window)->left_col);
 }
 
-/* Return the number of lines/pixels of W's body.  Don't count any mode
-   or header line or horizontal divider of W.  Rounds down to nearest
-   integer when not working pixelwise. */
-static int
-window_body_height (struct window *w, bool pixelwise)
-{
-  int height = (w->pixel_height
-		- WINDOW_HEADER_LINE_HEIGHT (w)
-		- (WINDOW_HAS_HORIZONTAL_SCROLL_BAR (w)
-		   ? WINDOW_SCROLL_BAR_AREA_HEIGHT (w)
-		   : 0)
-		- WINDOW_MODE_LINE_HEIGHT (w)
-		- WINDOW_BOTTOM_DIVIDER_WIDTH (w));
-
-  /* Don't return a negative value.  */
-  return max (pixelwise
-	      ? height
-	      : height / FRAME_LINE_HEIGHT (WINDOW_XFRAME (w)),
-	      0);
-}
-
 /* Return the number of columns/pixels of W's body.  Don't count columns
    occupied by the scroll bar or the divider/vertical bar separating W
    from its right sibling or margins.  On window-systems don't count
@@ -600,23 +579,6 @@ window_body_width (struct window *w, bool pixelwise)
 	      ? width
 	      : width / FRAME_COLUMN_WIDTH (WINDOW_XFRAME (w)),
 	      0);
-}
-
-DEFUN ("window-body-height", Fwindow_body_height, Swindow_body_height, 0, 2, 0,
-       doc: /* Return the height of WINDOW's text area.
-WINDOW must be a live window and defaults to the selected one.  Optional
-argument PIXELWISE non-nil means return the height of WINDOW's text area
-in pixels.  The return value does not include the mode line or header
-line or any horizontal divider.
-
-If PIXELWISE is nil, return the largest integer smaller than WINDOW's
-pixel height divided by the character height of WINDOW's frame.  This
-means that if a line at the bottom of the text area is only partially
-visible, that line is not counted.  */)
-  (Lisp_Object window, Lisp_Object pixelwise)
-{
-  return make_number (window_body_height (decode_live_window (window),
-					  !NILP (pixelwise)));
 }
 
 DEFUN ("window-body-width", Fwindow_body_width, Swindow_body_width, 0, 2, 0,
@@ -6662,7 +6624,6 @@ displayed after a scrolling operation to be somewhat inaccurate.  */);
   defsubr (&Sset_window_new_normal);
   defsubr (&Swindow_resize_apply);
   defsubr (&Swindow_resize_apply_total);
-  defsubr (&Swindow_body_height);
   defsubr (&Swindow_body_width);
   defsubr (&Sset_window_hscroll);
   defsubr (&Swindow_mode_line_height);

--- a/src/window.c
+++ b/src/window.c
@@ -551,56 +551,6 @@ WINDOW must be a valid window and defaults to the selected one.  */)
   return make_number (decode_valid_window (window)->left_col);
 }
 
-/* Return the number of columns/pixels of W's body.  Don't count columns
-   occupied by the scroll bar or the divider/vertical bar separating W
-   from its right sibling or margins.  On window-systems don't count
-   fringes either.  Round down to nearest integer when not working
-   pixelwise.  */
-int
-window_body_width (struct window *w, bool pixelwise)
-{
-  struct frame *f = XFRAME (WINDOW_FRAME (w));
-
-  int width = (w->pixel_width
-	       - WINDOW_RIGHT_DIVIDER_WIDTH (w)
-	       - (WINDOW_HAS_VERTICAL_SCROLL_BAR (w)
-		  ? WINDOW_SCROLL_BAR_AREA_WIDTH (w)
-		  : (/* A vertical bar is either 1 or 0.  */
-		     !FRAME_WINDOW_P (f)
-		     && !WINDOW_RIGHTMOST_P (w)
-		     && !WINDOW_RIGHT_DIVIDER_WIDTH (w)))
-		- WINDOW_MARGINS_WIDTH (w)
-		- (FRAME_WINDOW_P (f)
-		   ? WINDOW_FRINGES_WIDTH (w)
-		   : 0));
-
-  /* Don't return a negative value.  */
-  return max (pixelwise
-	      ? width
-	      : width / FRAME_COLUMN_WIDTH (WINDOW_XFRAME (w)),
-	      0);
-}
-
-DEFUN ("window-body-width", Fwindow_body_width, Swindow_body_width, 0, 2, 0,
-       doc: /* Return the width of WINDOW's text area.
-WINDOW must be a live window and defaults to the selected one.  Optional
-argument PIXELWISE non-nil means return the width in pixels.  The return
-value does not include any vertical dividers, fringes or marginal areas,
-or scroll bars.
-
-If PIXELWISE is nil, return the largest integer smaller than WINDOW's
-pixel width divided by the character width of WINDOW's frame.  This
-means that if a column at the right of the text area is only partially
-visible, that column is not counted.
-
-Note that the returned value includes the column reserved for the
-continuation glyph.  */)
-  (Lisp_Object window, Lisp_Object pixelwise)
-{
-  return make_number (window_body_width (decode_live_window (window),
-					 !NILP (pixelwise)));
-}
-
 DEFUN ("window-mode-line-height", Fwindow_mode_line_height,
        Swindow_mode_line_height, 0, 1, 0,
        doc: /* Return the height in pixels of WINDOW's mode-line.
@@ -6624,7 +6574,6 @@ displayed after a scrolling operation to be somewhat inaccurate.  */);
   defsubr (&Sset_window_new_normal);
   defsubr (&Swindow_resize_apply);
   defsubr (&Swindow_resize_apply_total);
-  defsubr (&Swindow_body_width);
   defsubr (&Sset_window_hscroll);
   defsubr (&Swindow_mode_line_height);
   defsubr (&Swindow_header_line_height);


### PR DESCRIPTION
This closes #1188.

Because the vast majority of functions used in `window_body_{height,width}` are macros, I had to add quite a few functions to `LispWindowRef`.