### PR TITLE
Throw an error if pkg-config is missing

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -197,6 +197,12 @@ archlibdir='${libexecdir}/remacs/${version}/${configuration}'
 etcdocdir='${datadir}/remacs/${version}/etc'
 gamedir='${localstatedir}/games/remacs'
 
+dnl Check for the presence of pkg-config
+AC_CHECK_TOOL([PKG_CONFIG], [pkg-config])
+if test x$PKG_CONFIG = x ; then
+  AC_MSG_ERROR([pkg-config not in path. You may need to install it.])
+fi
+
 dnl Special option to disable the most of other options.
 AC_ARG_WITH(all,
 [AS_HELP_STRING([--without-all],

--- a/configure.ac
+++ b/configure.ac
@@ -197,12 +197,6 @@ archlibdir='${libexecdir}/remacs/${version}/${configuration}'
 etcdocdir='${datadir}/remacs/${version}/etc'
 gamedir='${localstatedir}/games/remacs'
 
-dnl Check for the presence of pkg-config
-AC_CHECK_TOOL([PKG_CONFIG], [pkg-config])
-if test x$PKG_CONFIG = x ; then
-  AC_MSG_ERROR([pkg-config not in path. You may need to install it.])
-fi
-
 dnl Special option to disable the most of other options.
 AC_ARG_WITH(all,
 [AS_HELP_STRING([--without-all],
@@ -1598,6 +1592,9 @@ pre_PKG_CONFIG_CFLAGS=$CFLAGS
 pre_PKG_CONFIG_LIBS=$LIBS
 
 PKG_PROG_PKG_CONFIG(0.9.0)
+if test x$PKG_CONFIG = x ; then
+  AC_MSG_ERROR([pkg-config not found.])
+fi
 
 dnl EMACS_CHECK_MODULES(GSTUFF, gtk+-2.0 >= 1.3 glib = 1.3.4)
 dnl acts like PKG_CHECK_MODULES(GSTUFF, gtk+-2.0 >= 1.3 glib = 1.3.4,


### PR DESCRIPTION
Explicitly check whether `pkg-config` can be found in path. I have a suspicion this check is superfluous, as `PKG_PROG_PKG_CONFIG` may already check for this. I have yet to confirm this, though.
 
This should close #611.