### PR TITLE
Add LispSymbolOrString type

### DIFF
--- a/rust_src/src/buffers.rs
+++ b/rust_src/src/buffers.rs
@@ -635,7 +635,7 @@ impl From<LispBufferOrName> for Option<LispBufferRef> {
             LispBufferOrName::Name(name) => {
                 let tem = unsafe { Vbuffer_alist }
                     .iter_cars(LispConsEndChecks::off, LispConsCircularChecks::off)
-                    .find(|&item| string_equal(car(item), name.into()));
+                    .find(|&item| string_equal(car(item), name));
 
                 cdr(tem.into()).as_buffer()
             }

--- a/rust_src/src/buffers.rs
+++ b/rust_src/src/buffers.rs
@@ -609,7 +609,7 @@ impl From<LispBufferOrName> for Option<LispBufferRef> {
             LispBufferOrName::Name(name) => {
                 let tem = unsafe { Vbuffer_alist }
                     .iter_cars(LispConsEndChecks::off, LispConsCircularChecks::off)
-                    .find(|&item| string_equal(car(item).into(), name.into()));
+                    .find(|&item| string_equal(car(item), name));
 
                 cdr(tem.into())
             }
@@ -876,7 +876,7 @@ fn get_truename_buffer_1(filename: LispSymbolOrString) -> LispObject {
     LiveBufferIter::new()
         .find(|buf| {
             let buf_truename = buf.truename();
-            buf_truename.is_string() && string_equal(buf_truename.into(), filename)
+            buf_truename.is_string() && string_equal(buf_truename, filename)
         })
         .into()
 }
@@ -950,7 +950,7 @@ pub fn get_file_buffer(filename: LispStringRef) -> Option<LispBufferRef> {
     } else {
         LiveBufferIter::new().find(|buf| {
             let buf_filename = buf.filename();
-            buf_filename.is_string() && string_equal(buf_filename.into(), filename.into())
+            buf_filename.is_string() && string_equal(buf_filename, filename)
         })
     }
 }
@@ -1117,7 +1117,7 @@ pub fn erase_buffer() {
 /// is first appended to NAME, to speed up finding a non-existent buffer.
 #[lisp_fn(min = "1")]
 pub fn generate_new_buffer_name(name: LispStringRef, ignore: LispObject) -> LispStringRef {
-    if (ignore.is_not_nil() && string_equal(name.into(), ignore.into()))
+    if (ignore.is_not_nil() && string_equal(name, ignore))
         || get_buffer(LispBufferOrName::Name(name.into())).is_none()
     {
         return name;
@@ -1144,7 +1144,7 @@ pub fn generate_new_buffer_name(name: LispStringRef, ignore: LispObject) -> Lisp
         let mut s = format!("<{}>", suffix_count);
         local_unibyte_string!(suffix, s);
         let candidate = unsafe { concat2(basename, suffix) };
-        if string_equal(candidate.into(), ignore.into())
+        if string_equal(candidate, ignore)
             || get_buffer(LispBufferOrName::Name(candidate)).is_none()
         {
             return candidate.into();

--- a/rust_src/src/buffers.rs
+++ b/rust_src/src/buffers.rs
@@ -1143,11 +1143,11 @@ pub fn generate_new_buffer_name(name: LispStringRef, ignore: LispObject) -> Lisp
     loop {
         let mut s = format!("<{}>", suffix_count);
         local_unibyte_string!(suffix, s);
-        let candidate = unsafe { concat2(basename, suffix) };
+        let candidate = unsafe { concat2(basename, suffix) }.force_string();
         if string_equal(candidate, ignore)
-            || get_buffer(LispBufferOrName::Name(candidate)).is_none()
+            || get_buffer(LispBufferOrName::Name(candidate.into())).is_none()
         {
-            return candidate.into();
+            return candidate;
         }
         suffix_count += 1;
     }

--- a/rust_src/src/dired.rs
+++ b/rust_src/src/dired.rs
@@ -109,7 +109,7 @@ pub fn file_attributes(filename: LispStringRef, id_format: LispObject) -> LispOb
 /// Comparison is in lexicographic order and case is significant.
 #[lisp_fn]
 pub fn file_attributes_lessp(f1: LispObject, f2: LispObject) -> bool {
-    string_lessp(car(f1), car(f2))
+    string_lessp(car(f1).into(), car(f2).into())
 }
 
 /// Return a list of user names currently registered in the system.

--- a/rust_src/src/dired.rs
+++ b/rust_src/src/dired.rs
@@ -109,7 +109,7 @@ pub fn file_attributes(filename: LispStringRef, id_format: LispObject) -> LispOb
 /// Comparison is in lexicographic order and case is significant.
 #[lisp_fn]
 pub fn file_attributes_lessp(f1: LispObject, f2: LispObject) -> bool {
-    string_lessp(car(f1).into(), car(f2).into())
+    string_lessp(car(f1), car(f2))
 }
 
 /// Return a list of user names currently registered in the system.

--- a/rust_src/src/dired_unix.rs
+++ b/rust_src/src/dired_unix.rs
@@ -15,7 +15,7 @@ use crate::{
     fileio::{expand_file_name, find_file_name_handler},
     lisp::LispObject,
     lists::list,
-    multibyte::LispStringRef,
+    multibyte::{LispStringRef, LispSymbolOrString},
     remacs_sys::{
         build_string, compile_pattern, decode_file_name, file_attributes_c_internal,
         filemode_string, globals, re_pattern_buffer, re_search,
@@ -108,7 +108,7 @@ impl LispObjectExt for LispObject {
         if self.is_nil() {
             "NOTstring".to_string()
         } else {
-            let idf_sym_s = self.symbol_or_string_as_string();
+            let idf_sym_s: LispStringRef = LispSymbolOrString::from(*self).into();
             idf_sym_s.to_string().to_lowercase()
         }
     }

--- a/rust_src/src/dired_unix.rs
+++ b/rust_src/src/dired_unix.rs
@@ -15,7 +15,7 @@ use crate::{
     fileio::{expand_file_name, find_file_name_handler},
     lisp::LispObject,
     lists::list,
-    multibyte::{LispStringRef, LispSymbolOrString},
+    multibyte::LispStringRef,
     remacs_sys::{
         build_string, compile_pattern, decode_file_name, file_attributes_c_internal,
         filemode_string, globals, re_pattern_buffer, re_search,
@@ -108,7 +108,7 @@ impl LispObjectExt for LispObject {
         if self.is_nil() {
             "NOTstring".to_string()
         } else {
-            let idf_sym_s: LispStringRef = LispSymbolOrString::from(*self).into();
+            let idf_sym_s: LispStringRef = self.as_symbol_or_string().into();
             idf_sym_s.to_string().to_lowercase()
         }
     }

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -18,6 +18,7 @@
 #![feature(slice_patterns)]
 #![feature(specialization)]
 #![feature(stmt_expr_attributes)]
+#![feature(type_alias_enum_variants)]
 #![feature(untagged_unions)]
 
 extern crate errno;

--- a/rust_src/src/multibyte.rs
+++ b/rust_src/src/multibyte.rs
@@ -371,6 +371,12 @@ impl From<LispObject> for LispSymbolOrString {
     }
 }
 
+impl PartialEq<LispObject> for LispSymbolOrString {
+    fn eq(&self, other: &LispObject) -> bool {
+        self.0.eq(*other)
+    }
+}
+
 pub fn is_ascii(c: Codepoint) -> bool {
     c < 0x80
 }

--- a/rust_src/src/multibyte.rs
+++ b/rust_src/src/multibyte.rs
@@ -311,6 +311,11 @@ impl LispObject {
     pub fn empty_unibyte_string() -> LispStringRef {
         LispStringRef::from(unsafe { empty_unibyte_string })
     }
+
+    // We can excuse not using an option here because extracting the value checks the type
+    pub fn as_symbol_or_string(self) -> LispSymbolOrString {
+        LispSymbolOrString(self)
+    }
 }
 
 #[derive(Copy, Clone, PartialEq)]

--- a/rust_src/src/multibyte.rs
+++ b/rust_src/src/multibyte.rs
@@ -41,9 +41,10 @@ use libc::{c_char, c_int, c_uchar, c_uint, c_void, memset, ptrdiff_t, size_t};
 use crate::{
     hashtable::LispHashTableRef,
     lisp::{ExternalPtr, LispObject, LispStructuralEqual},
+    obarray::LispObarrayRef,
+    remacs_sys::Qstringp,
     remacs_sys::{char_bits, equal_kind, EmacsDouble, EmacsInt, Lisp_String, Lisp_Type},
     remacs_sys::{compare_string_intervals, empty_unibyte_string, lisp_string_width},
-    remacs_sys::{Qstringp, Qsymbolp},
     symbols::LispSymbolRef,
 };
 
@@ -356,7 +357,7 @@ impl From<LispSymbolOrString> for LispSymbolRef {
     fn from(s: LispSymbolOrString) -> Self {
         match s.0.as_symbol() {
             Some(symbol) => symbol,
-            None => wrong_type!(s, Qsymbolp),
+            None => LispObarrayRef::global().intern(s).into(),
         }
     }
 }

--- a/rust_src/src/multibyte.rs
+++ b/rust_src/src/multibyte.rs
@@ -313,7 +313,18 @@ impl LispObject {
     }
 }
 
+#[derive(Copy, Clone, PartialEq)]
 pub struct LispSymbolOrString(LispObject);
+
+impl LispSymbolOrString {
+    pub fn is_string(self) -> bool {
+        self.0.is_string()
+    }
+
+    pub fn is_symbol(self) -> bool {
+        self.0.is_symbol()
+    }
+}
 
 impl From<LispSymbolOrString> for LispObject {
     fn from(s: LispSymbolOrString) -> Self {
@@ -327,6 +338,12 @@ impl From<LispSymbolOrString> for LispStringRef {
             Some(symbol) => symbol.symbol_name().into(),
             None => s.0.into(),
         }
+    }
+}
+
+impl From<LispStringRef> for LispSymbolOrString {
+    fn from(s: LispStringRef) -> Self {
+        Self(s.into())
     }
 }
 

--- a/rust_src/src/multibyte.rs
+++ b/rust_src/src/multibyte.rs
@@ -314,58 +314,79 @@ impl LispObject {
     }
 
     // We can excuse not using an option here because extracting the value checks the type
+    // TODO: this is false with the enum model, change this
     pub fn as_symbol_or_string(self) -> LispSymbolOrString {
-        LispSymbolOrString(self)
+        self.into()
     }
 }
 
 #[derive(Copy, Clone, PartialEq)]
-pub struct LispSymbolOrString(LispObject);
+pub enum LispSymbolOrString {
+    String(LispStringRef),
+    Symbol(LispSymbolRef),
+}
 
 impl LispSymbolOrString {
     pub fn is_string(self) -> bool {
-        self.0.is_string()
+        match self {
+            LispSymbolOrString::String(_) => true,
+            _ => false,
+        }
     }
 
     pub fn is_symbol(self) -> bool {
-        self.0.is_symbol()
+        match self {
+            LispSymbolOrString::Symbol(_) => true,
+            _ => false,
+        }
     }
 }
 
 impl From<LispSymbolOrString> for LispObject {
     fn from(s: LispSymbolOrString) -> Self {
-        s.0
+        match s {
+            LispSymbolOrString::String(s) => s.into(),
+            LispSymbolOrString::Symbol(sym) => sym.into(),
+        }
     }
 }
 
 impl From<LispSymbolOrString> for LispStringRef {
     fn from(s: LispSymbolOrString) -> Self {
-        match s.0.as_symbol() {
-            Some(symbol) => symbol.symbol_name().into(),
-            None => s.0.into(),
+        match s {
+            LispSymbolOrString::String(s) => s,
+            LispSymbolOrString::Symbol(sym) => sym.symbol_name().into(),
         }
     }
 }
 
 impl From<LispStringRef> for LispSymbolOrString {
     fn from(s: LispStringRef) -> Self {
-        Self(s.into())
+        Self::String(s)
     }
 }
 
 impl From<LispSymbolOrString> for LispSymbolRef {
     fn from(s: LispSymbolOrString) -> Self {
-        match s.0.as_symbol() {
-            Some(symbol) => symbol,
-            None => LispObarrayRef::global().intern(s).into(),
+        match s {
+            LispSymbolOrString::String(s) => LispObarrayRef::global().intern(s).into(),
+            LispSymbolOrString::Symbol(sym) => sym,
         }
+    }
+}
+
+impl From<LispSymbolRef> for LispSymbolOrString {
+    fn from(s: LispSymbolRef) -> Self {
+        Self::Symbol(s)
     }
 }
 
 impl From<LispObject> for LispSymbolOrString {
     fn from(o: LispObject) -> Self {
-        if o.is_string() || o.is_symbol() {
-            Self(o)
+        if let Some(s) = o.as_string() {
+            Self::String(s)
+        } else if let Some(sym) = o.as_symbol() {
+            Self::Symbol(sym)
         } else {
             wrong_type!(Qstringp, o)
         }
@@ -374,7 +395,7 @@ impl From<LispObject> for LispSymbolOrString {
 
 impl PartialEq<LispObject> for LispSymbolOrString {
     fn eq(&self, other: &LispObject) -> bool {
-        self.0.eq(*other)
+        (*other).eq(LispObject::from(*self))
     }
 }
 

--- a/rust_src/src/obarray.rs
+++ b/rust_src/src/obarray.rs
@@ -208,9 +208,8 @@ pub extern "C" fn intern_driver(
 pub fn intern_soft(name: LispSymbolOrString, obarray: Option<LispObarrayRef>) -> LispObject {
     let obarray = obarray.unwrap_or_else(LispObarrayRef::global);
     let tem = obarray.lookup(name);
-    let name: LispObject = name.into();
 
-    if tem.is_integer() || (name.is_symbol() && !name.eq(tem)) {
+    if tem.is_integer() || (name.is_symbol() && !name.eq(&tem)) {
         Qnil
     } else {
         tem

--- a/rust_src/src/obarray.rs
+++ b/rust_src/src/obarray.rs
@@ -63,15 +63,17 @@ impl LispObarrayRef {
     pub fn intern(&self, string: impl Into<LispSymbolOrString>) -> LispObject {
         let string = string.into();
         let tem = self.lookup(string);
-        let string: LispObject = string.into();
         if tem.is_symbol() {
             tem
-        } else if unsafe { globals.Vpurify_flag }.is_not_nil() {
-            // When Emacs is running lisp code to dump to an executable, make
-            // use of pure storage.
-            intern_driver(unsafe { Fpurecopy(string) }, self.into(), tem)
         } else {
-            intern_driver(string, self.into(), tem)
+            let string_copy: LispObject = if unsafe { globals.Vpurify_flag }.is_not_nil() {
+                // When Emacs is running lisp code to dump to an executable, make
+                // use of pure storage.
+                unsafe { Fpurecopy(string.into()) }
+            } else {
+                string.into()
+            };
+            intern_driver(string_copy, self.into(), tem)
         }
     }
 }

--- a/rust_src/src/strings.rs
+++ b/rust_src/src/strings.rs
@@ -30,17 +30,21 @@ pub fn string_bytes(string: LispStringRef) -> EmacsInt {
     string.len_bytes() as EmacsInt
 }
 
-/// Return t if two strings have identical contents.
-/// Case is significant, but text properties are ignored.
-/// Symbols are also allowed; their print names are used instead.
-#[lisp_fn]
-pub fn string_equal(s1: LispSymbolOrString, s2: LispSymbolOrString) -> bool {
-    let s1: LispStringRef = s1.into();
-    let s2: LispStringRef = s2.into();
+pub fn string_equal(s1: impl Into<LispSymbolOrString>, s2: impl Into<LispSymbolOrString>) -> bool {
+    let s1 = LispStringRef::from(s1.into());
+    let s2 = LispStringRef::from(s2.into());
 
     s1.len_chars() == s2.len_chars()
         && s1.len_bytes() == s2.len_bytes()
         && s1.as_slice() == s2.as_slice()
+}
+
+/// Return t if two strings have identical contents.
+/// Case is significant, but text properties are ignored.
+/// Symbols are also allowed; their print names are used instead.
+#[lisp_fn(name = "string-equal", c_name = "string_equal")]
+pub fn string_equal_lisp(s1: LispSymbolOrString, s2: LispSymbolOrString) -> bool {
+    string_equal(s1, s2)
 }
 
 /// Return a multibyte string with the same individual bytes as STRING.
@@ -136,14 +140,21 @@ pub fn string_to_unibyte(string: LispStringRef) -> LispObject {
     }
 }
 
-/// Return non-nil if STRING1 is less than STRING2 in lexicographic order.
-/// Case is significant.
-#[lisp_fn]
-pub fn string_lessp(string1: LispSymbolOrString, string2: LispSymbolOrString) -> bool {
-    let s1: LispStringRef = string1.into();
-    let s2: LispStringRef = string2.into();
+pub fn string_lessp(
+    string1: impl Into<LispSymbolOrString>,
+    string2: impl Into<LispSymbolOrString>,
+) -> bool {
+    let s1 = LispStringRef::from(string1.into());
+    let s2 = LispStringRef::from(string2.into());
 
     s1.as_slice() < s2.as_slice()
+}
+
+/// Return non-nil if STRING1 is less than STRING2 in lexicographic order.
+/// Case is significant.
+#[lisp_fn(name = "string-lessp", c_name = "string_lessp")]
+pub fn string_lessp_lisp(string1: LispSymbolOrString, string2: LispSymbolOrString) -> bool {
+    string_lessp(string1, string2)
 }
 
 /// Return t if OBJECT is a multibyte string.

--- a/rust_src/src/strings.rs
+++ b/rust_src/src/strings.rs
@@ -9,7 +9,7 @@ use remacs_macros::lisp_fn;
 use crate::{
     lisp::LispObject,
     multibyte,
-    multibyte::LispStringRef,
+    multibyte::{LispStringRef, LispSymbolOrString},
     remacs_sys::EmacsInt,
     remacs_sys::{
         make_unibyte_string, make_uninit_multibyte_string,
@@ -34,9 +34,9 @@ pub fn string_bytes(string: LispStringRef) -> EmacsInt {
 /// Case is significant, but text properties are ignored.
 /// Symbols are also allowed; their print names are used instead.
 #[lisp_fn]
-pub fn string_equal(s1: LispObject, s2: LispObject) -> bool {
-    let s1 = LispObject::symbol_or_string_as_string(s1);
-    let s2 = LispObject::symbol_or_string_as_string(s2);
+pub fn string_equal(s1: LispSymbolOrString, s2: LispSymbolOrString) -> bool {
+    let s1: LispStringRef = s1.into();
+    let s2: LispStringRef = s2.into();
 
     s1.len_chars() == s2.len_chars()
         && s1.len_bytes() == s2.len_bytes()
@@ -139,9 +139,9 @@ pub fn string_to_unibyte(string: LispStringRef) -> LispObject {
 /// Return non-nil if STRING1 is less than STRING2 in lexicographic order.
 /// Case is significant.
 #[lisp_fn]
-pub fn string_lessp(string1: LispObject, string2: LispObject) -> bool {
-    let s1 = LispObject::symbol_or_string_as_string(string1);
-    let s2 = LispObject::symbol_or_string_as_string(string2);
+pub fn string_lessp(string1: LispSymbolOrString, string2: LispSymbolOrString) -> bool {
+    let s1: LispStringRef = string1.into();
+    let s2: LispStringRef = string2.into();
 
     s1.as_slice() < s2.as_slice()
 }

--- a/rust_src/src/symbols.rs
+++ b/rust_src/src/symbols.rs
@@ -206,16 +206,6 @@ impl LispObject {
         self.into()
     }
 
-    pub fn symbol_or_string_as_string(self) -> LispStringRef {
-        match self.as_symbol() {
-            Some(sym) => sym
-                .symbol_name()
-                .as_string()
-                .expect("Expected a symbol name?"),
-            None => self.into(),
-        }
-    }
-
     fn symbol_ptr_value(self) -> EmacsInt {
         let ptr_value = if USE_LSB_TAG {
             self.to_C()


### PR DESCRIPTION
Making a draft to make sure I get the type right before I make functions use it. I'm not exactly sure which conversions should do the type check and which should skip them.

Also, when converting this to a LispSymbolRef, should I throw an error if the value is a string or something else?

EDIT: Just discovered `Fmake_sym` exists. Should I use that for converting strings to symbols?

Will close #1209.