### PR TITLE
Refactor buffer_objfwd support.

### DIFF
--- a/rust_src/Cargo.lock
+++ b/rust_src/Cargo.lock
@@ -209,11 +209,6 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "if_chain"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "lazy_static"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,7 +367,6 @@ dependencies = [
  "errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "field-offset 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "if_chain 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.47 (registry+https://github.com/rust-lang/crates.io-index)",
  "line-wrap 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -575,7 +569,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 "checksum generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c0f28c2f5bfb5960175af447a2da7c18900693738343dc896ffbcabd9839592"
 "checksum ident_case 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c9826188e666f2ed92071d2dadef6edc430b11b158b5b2b3f4babbcc891eaaa"
-"checksum if_chain 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4bac95d9aa0624e7b78187d6fb8ab012b41d9f6f54b1bcb61e61c4845f8357ec"
 "checksum lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"
 "checksum libc 0.2.47 (registry+https://github.com/rust-lang/crates.io-index)" = "48450664a984b25d5b479554c29cc04e3150c97aa4c01da5604a2d4ed9151476"
 "checksum line-wrap 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f30344350a2a51da54c1d53be93fade8a237e545dbcc4bdbe635413f2117cab9"

--- a/rust_src/Cargo.toml.in
+++ b/rust_src/Cargo.toml.in
@@ -22,7 +22,6 @@ cfg-if = "0.1"
 errno = "0.2"
 field-offset = "0.1"
 flate2 = { version = "1.0", features = ["rust_backend"], default-features = false }
-if_chain = "0.1"
 lazy_static = "1.2"
 libc = "0.2"
 line-wrap = "0.1.1"

--- a/rust_src/src/buffers.rs
+++ b/rust_src/src/buffers.rs
@@ -3,6 +3,7 @@
 use std::sync::Mutex;
 use std::{self, mem, ptr};
 
+use field_offset::FieldOffset;
 use libc::{self, c_char, c_int, c_uchar, c_void, ptrdiff_t};
 
 use rand::{Rng, StdRng};
@@ -1153,10 +1154,16 @@ pub fn generate_new_buffer_name(name: LispStringRef, ignore: LispObject) -> Lisp
     }
 }
 
+pub unsafe fn per_buffer_idx_from_field_offset(
+    offset: FieldOffset<Lisp_Buffer, LispObject>,
+) -> isize {
+    unsafe { *offset.apply_ptr_mut(&mut buffer_local_flags) }.to_fixnum_unchecked() as isize
+}
+
 pub unsafe fn per_buffer_idx(offset: isize) -> isize {
     let flags = &mut buffer_local_flags as *mut Lisp_Buffer as *mut LispObject;
     let obj = flags.offset(offset);
-    (*obj).as_fixnum_or_error() as isize
+    (*obj).to_fixnum_unchecked() as isize
 }
 
 /// Return a list of overlays which is a copy of the overlay list

--- a/rust_src/src/buffers.rs
+++ b/rust_src/src/buffers.rs
@@ -1157,7 +1157,8 @@ pub fn generate_new_buffer_name(name: LispStringRef, ignore: LispObject) -> Lisp
 pub unsafe fn per_buffer_idx_from_field_offset(
     offset: FieldOffset<Lisp_Buffer, LispObject>,
 ) -> isize {
-    unsafe { *offset.apply_ptr_mut(&mut buffer_local_flags) }.to_fixnum_unchecked() as isize
+    let obj = *offset.apply_ptr_mut(&mut buffer_local_flags);
+    obj.to_fixnum_unchecked() as isize
 }
 
 pub unsafe fn per_buffer_idx(offset: isize) -> isize {

--- a/rust_src/src/buffers.rs
+++ b/rust_src/src/buffers.rs
@@ -1161,9 +1161,9 @@ pub unsafe fn per_buffer_idx_from_field_offset(
     obj.to_fixnum_unchecked() as isize
 }
 
-pub unsafe fn per_buffer_idx(offset: isize) -> isize {
+pub unsafe fn per_buffer_idx(count: isize) -> isize {
     let flags = &mut buffer_local_flags as *mut Lisp_Buffer as *mut LispObject;
-    let obj = flags.offset(offset);
+    let obj = flags.offset(count);
     (*obj).to_fixnum_unchecked() as isize
 }
 

--- a/rust_src/src/data.rs
+++ b/rust_src/src/data.rs
@@ -6,7 +6,7 @@ use libc::{c_char, c_int};
 use remacs_macros::lisp_fn;
 
 use crate::{
-    buffers::per_buffer_idx,
+    buffers::{per_buffer_idx, per_buffer_idx_from_field_offset},
     frames::selected_frame,
     keymap::get_keymap,
     lisp::is_autoload,
@@ -23,7 +23,7 @@ use crate::{
         symbol_trapped_write, valid_lisp_object_p, wrong_choice, wrong_range, CHAR_TABLE_SET,
         CHECK_IMPURE,
     },
-    remacs_sys::{buffer_local_flags, per_buffer_default, symbol_redirect},
+    remacs_sys::{per_buffer_default, symbol_redirect},
     remacs_sys::{pvec_type, BoolVectorOp, EmacsInt, Lisp_Misc_Type, Lisp_Type, Set_Internal_Bind},
     remacs_sys::{Fdelete, Fpurecopy},
     remacs_sys::{Lisp_Buffer, Lisp_Subr_Lang},
@@ -40,14 +40,25 @@ use crate::{
 };
 
 // Lisp_Fwd predicates which can go away as the callers are ported to Rust
+
 #[no_mangle]
 pub unsafe extern "C" fn KBOARD_OBJFWDP(a: *const Lisp_Fwd) -> bool {
+    is_kboard_objfwd(a)
+}
+
+pub unsafe fn is_kboard_objfwd(a: *const Lisp_Fwd) -> bool {
     (*a).u_intfwd.ty == Lisp_Fwd_Kboard_Obj
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn OBJFWDP(a: *const Lisp_Fwd) -> bool {
+pub unsafe fn is_objfwd(a: *const Lisp_Fwd) -> bool {
     (*a).u_intfwd.ty == Lisp_Fwd_Obj
+}
+
+pub unsafe fn as_buffer_objfwd(a: *const Lisp_Fwd) -> Option<Lisp_Buffer_Objfwd> {
+    match (*a).u_intfwd.ty {
+        Lisp_Fwd_Buffer_Obj => Some((*a).u_buffer_objfwd),
+        _ => None,
+    }
 }
 
 /// Find the function at the end of a chain of symbol function indirections.
@@ -376,28 +387,21 @@ fn default_value(mut symbol: LispSymbolRef) -> LispObject {
                 d
             }
         }
-        symbol_redirect::SYMBOL_FORWARDED => {
-            let valcontents = unsafe { symbol.get_fwd() };
+        symbol_redirect::SYMBOL_FORWARDED => unsafe {
+            let valcontents = symbol.get_fwd();
 
             // For a built-in buffer-local variable, get the default value
             // rather than letting do_symval_forwarding get the current value.
-            if_chain! {
-                // if_chain! builds up a series of conditions and contitional assignments into one
-                // big pair of then/else arms. This should be converted into idiomatic Option-based
-                // code eventually.
-                if unsafe { (*valcontents).u_intfwd.ty } == Lisp_Fwd_Buffer_Obj;
-                let offset = unsafe { (*valcontents).u_buffer_objfwd.offset };
-                if unsafe {
-                    *offset.apply_ptr_mut(&mut buffer_local_flags)
-                }.as_fixnum_or_error() != 0;
-                then {
-                    unsafe { per_buffer_default(offset.get_byte_offset() as i32) }
-                } else {
-                    // For other variables, get the current value.
-                    unsafe { do_symval_forwarding(valcontents) }
+            if let Some(buffer_objfwd) = as_buffer_objfwd(valcontents) {
+                let offset = buffer_objfwd.offset;
+
+                if per_buffer_idx_from_field_offset(offset) != 0 {
+                    return per_buffer_default(offset.get_byte_offset() as i32);
                 }
             }
-        }
+            // For other variables, get the current value.
+            do_symval_forwarding(valcontents)
+        },
         _ => panic!("Symbol type has no default value"),
     }
 }

--- a/rust_src/src/data.rs
+++ b/rust_src/src/data.rs
@@ -50,10 +50,6 @@ pub unsafe fn is_kboard_objfwd(a: *const Lisp_Fwd) -> bool {
     (*a).u_intfwd.ty == Lisp_Fwd_Kboard_Obj
 }
 
-pub unsafe fn is_objfwd(a: *const Lisp_Fwd) -> bool {
-    (*a).u_intfwd.ty == Lisp_Fwd_Obj
-}
-
 pub unsafe fn as_buffer_objfwd(a: *const Lisp_Fwd) -> Option<Lisp_Buffer_Objfwd> {
     match (*a).u_intfwd.ty {
         Lisp_Fwd_Buffer_Obj => Some((*a).u_buffer_objfwd),

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -22,8 +22,6 @@
 
 extern crate errno;
 #[macro_use]
-extern crate if_chain;
-#[macro_use]
 extern crate lazy_static;
 
 extern crate base64 as base64_crate;

--- a/rust_src/src/symbols.rs
+++ b/rust_src/src/symbols.rs
@@ -6,9 +6,10 @@ use std::fmt::{Debug, Formatter};
 use remacs_macros::lisp_fn;
 
 use crate::{
-    buffers::LispBufferLocalValueRef,
+    buffers::per_buffer_idx_from_field_offset,
+    buffers::{LispBufferLocalValueRef, LispBufferOrCurrent, LispBufferRef},
     data::Lisp_Fwd,
-    data::{indirect_function, set},
+    data::{as_buffer_objfwd, indirect_function, set},
     hashtable::LispHashTableRef,
     lisp::{ExternalPtr, LispObject, LispStructuralEqual},
     multibyte::LispStringRef,

--- a/rust_src/src/symbols.rs
+++ b/rust_src/src/symbols.rs
@@ -6,10 +6,9 @@ use std::fmt::{Debug, Formatter};
 use remacs_macros::lisp_fn;
 
 use crate::{
-    buffers::per_buffer_idx_from_field_offset,
-    buffers::{LispBufferLocalValueRef, LispBufferOrCurrent, LispBufferRef},
+    buffers::LispBufferLocalValueRef,
     data::Lisp_Fwd,
-    data::{as_buffer_objfwd, indirect_function, set},
+    data::{indirect_function, set},
     hashtable::LispHashTableRef,
     lisp::{ExternalPtr, LispObject, LispStructuralEqual},
     multibyte::LispStringRef,


### PR DESCRIPTION
Adds `as_buffer_objfwd()` which returns an `Option<Lisp_Buffer_Objfwd>`.
This simplifies the common use of the object. Remove `if_chain` now
that the code is simpler.