### PR TITLE
Fix error on describe-function for adviced builtin function

### DIFF
--- a/lisp/help-fns.el
+++ b/lisp/help-fns.el
@@ -677,7 +677,7 @@ Returns a list of the form (REAL-FUNCTION DEF ALIASED REAL-DEF)."
 	;; but that's completely wrong when the user used load-file.
 	(princ (format-message " in `%s'"
                                (if (eq file-name 'C-source)
-                                   (concat (subr-lang (indirect-function function)) " source code")
+                                   (concat (subr-lang def) " source code")
                                  (help-fns-short-filename file-name))))
 	;; Make a hyperlink to the library.
 	(with-current-buffer standard-output

--- a/test/rust_src/src/data-tests.el
+++ b/test/rust_src/src/data-tests.el
@@ -112,10 +112,10 @@
   :expected-result :failed
   (should (equal "C" (subr-lang (symbol-function 'rename-buffer)))))
 
-(ert-deftest data-test--describe-function-smoke-fail ()
+(ert-deftest data-test--describe-function ()
   ;; `describe-function' relies on `subr-lang' in its implementation,
   ;; so run it here to make sure that it works.
-  :expected-result :failed
+  (describe-function 'car)
   (describe-function 'rename-buffer))
 
 (ert-deftest data-test--get-variable-documentation ()


### PR DESCRIPTION
The aim of this PR is to resolve #822.

As pointed out in comments on previous issues, `subr-lang` gets `wrong-type-argument` for adviced builtin function because `subr-lang` expects an argument is a subroutine but adviced function is no longer regarded as subroutine.

This small patch tries to fix this error giving to `subr-lang` the real function definition being detached from advice part. This seems already prepared in the function concerned using `help-fns--analyze-function`.