### PR TITLE
Add transformation methods to ExternalPtr

### DIFF
--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -125,17 +125,17 @@ impl<T> ExternalPtr<T> {
         self.0 = ptr;
     }
 
-    pub fn ptr_offset(&mut self, size: isize) {
+    pub unsafe fn ptr_offset(&mut self, size: isize) {
         let ptr = self.0.offset(size);
         self.replace_ptr(ptr);
     }
 
-    pub fn ptr_add(&mut self, size: usize) {
+    pub unsafe fn ptr_add(&mut self, size: usize) {
         let ptr = self.0.add(size);
         self.replace_ptr(ptr);
     }
 
-    pub fn ptr_sub(&mut self, size: usize) {
+    pub unsafe fn ptr_sub(&mut self, size: usize) {
         let ptr = self.0.sub(size);
         self.replace_ptr(ptr);
     }

--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -124,6 +124,21 @@ impl<T> ExternalPtr<T> {
     pub fn replace_ptr(&mut self, ptr: *mut T) {
         self.0 = ptr;
     }
+
+    pub fn ptr_offset(&mut self, size: isize) {
+        let ptr = self.0.offset(size);
+        self.replace_ptr(ptr);
+    }
+
+    pub fn ptr_add(&mut self, size: usize) {
+        let ptr = self.0.add(size);
+        self.replace_ptr(ptr);
+    }
+
+    pub fn ptr_sub(&mut self, size: usize) {
+        let ptr = self.0.sub(size);
+        self.replace_ptr(ptr);
+    }
 }
 
 impl<T> Deref for ExternalPtr<T> {

--- a/rust_src/src/windows.rs
+++ b/rust_src/src/windows.rs
@@ -1728,8 +1728,7 @@ pub fn window_lines_pixel_dimensions(
             }
         };
         rows = ((width, row.y + row.height - subtract), rows).into();
-        let ptr = unsafe { row.as_mut().add(1) };
-        row.replace_ptr(ptr);
+        row.ptr_add(1);
     }
     unsafe { Fnreverse(rows) }
 }

--- a/rust_src/src/windows.rs
+++ b/rust_src/src/windows.rs
@@ -1728,7 +1728,7 @@ pub fn window_lines_pixel_dimensions(
             }
         };
         rows = ((width, row.y + row.height - subtract), rows).into();
-        row.ptr_add(1);
+        unsafe { row.ptr_add(1) };
     }
     unsafe { Fnreverse(rows) }
 }


### PR DESCRIPTION
This makes it simpler to modify the underlying pointer of an `ExternalPtr`. Instances of `replace_ptr` have been replaced with the new methods where appropriate.

Closes #1317.