### PR TITLE
Port get-file-char

### DIFF
--- a/rust_src/src/lread.rs
+++ b/rust_src/src/lread.rs
@@ -5,6 +5,8 @@ use libc;
 use std::ffi::CString;
 use std::ptr;
 
+use errno::errno;
+
 use remacs_macros::lisp_fn;
 
 use crate::{
@@ -17,8 +19,10 @@ use crate::{
     lisp::LispObject,
     obarray::{intern, intern_c_string_1},
     remacs_sys,
+    remacs_sys::infile,
     remacs_sys::{
-        build_string, read_internal_start, readevalloop, specbind, staticpro, symbol_redirect,
+        block_input, build_string, clearerr_unlocked, ferror_unlocked, getc_unlocked, maybe_quit,
+        read_internal_start, readevalloop, specbind, staticpro, symbol_redirect, unblock_input,
     },
     remacs_sys::{globals, EmacsInt},
     remacs_sys::{Qeval_buffer_list, Qnil, Qread_char, Qstandard_output, Qsymbolp},
@@ -155,6 +159,41 @@ pub unsafe fn defvar_per_buffer_offset(
     }
 }
 
+/// Read a byte from stdio. If it has lookahead, use the stored value.
+/// If read over network is interrupted, keep trying until read succeeds.
+#[no_mangle]
+pub unsafe extern "C" fn readbyte_from_stdio() -> i32 {
+    // If infile has lookahead, use stored value
+    if (*infile).lookahead > 0 {
+        let idx = (*infile.sub(1)).lookahead as usize;
+        return (*infile).buf[idx].into();
+    }
+
+    let instream = (*infile).stream;
+
+    block_input();
+
+    // Interrupted read have been observed while reading over the network.
+    let mut c;
+    while {
+        c = getc_unlocked(instream);
+        c == libc::EOF && errno().0 == libc::EINTR && ferror_unlocked(instream) > 0
+    } {
+        unblock_input();
+        maybe_quit();
+        block_input();
+        clearerr_unlocked(instream);
+    }
+
+    unblock_input();
+
+    if c != libc::EOF {
+        c
+    } else {
+        -1
+    }
+}
+
 /// Read one Lisp expression as text from STREAM, return as Lisp object.
 /// If STREAM is nil, use the value of `standard-input' (which see).
 /// STREAM or the value of `standard-input' may be:
@@ -190,6 +229,15 @@ pub fn read(stream: LispObject) -> LispObject {
     } else {
         unsafe { read_internal_start(input, Qnil, Qnil) }
     }
+}
+
+/// Don't use this yourself
+#[lisp_fn]
+pub fn get_file_char() -> EmacsInt {
+    if unsafe { infile }.is_null() {
+        error!("get-file-char misused");
+    }
+    unsafe { readbyte_from_stdio().into() }
 }
 
 /// Execute the region as Lisp code.

--- a/rust_src/src/lread.rs
+++ b/rust_src/src/lread.rs
@@ -234,7 +234,7 @@ pub fn read(stream: LispObject) -> LispObject {
     }
 }
 
-/// Don't use this yourself
+/// Don't use this yourself.
 #[lisp_fn]
 pub fn get_file_char() -> EmacsInt {
     if unsafe { infile }.is_null() {

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -1442,6 +1442,7 @@ extern struct infile* infile;
 extern void readevalloop (Lisp_Object, struct infile *, Lisp_Object, bool,
                           Lisp_Object, Lisp_Object,
                           Lisp_Object, Lisp_Object);
+extern int readbyte_from_stdio(void);
 
 INLINE_HEADER_END
 

--- a/src/lread.c
+++ b/src/lread.c
@@ -447,32 +447,6 @@ readbyte_for_lambda (int c, Lisp_Object readcharfun)
 
 
 static int
-readbyte_from_stdio (void)
-{
-  if (infile->lookahead)
-    return infile->buf[--infile->lookahead];
-
-  int c;
-  FILE *instream = infile->stream;
-
-  block_input ();
-
-  /* Interrupted reads have been observed while reading over the network.  */
-  while ((c = getc_unlocked (instream)) == EOF && errno == EINTR
-	 && ferror_unlocked (instream))
-    {
-      unblock_input ();
-      maybe_quit ();
-      block_input ();
-      clearerr_unlocked (instream);
-    }
-
-  unblock_input ();
-
-  return (c == EOF ? -1 : c);
-}
-
-static int
 readbyte_from_file (int c, Lisp_Object readcharfun)
 {
   if (c >= 0)
@@ -782,15 +756,6 @@ floating-point value.  */)
 
   return (NILP (val) ? Qnil
 	  : make_number (char_resolve_modifier_mask (XINT (val))));
-}
-
-DEFUN ("get-file-char", Fget_file_char, Sget_file_char, 0, 0, 0,
-       doc: /* Don't use this yourself.  */)
-  (void)
-{
-  if (!infile)
-    error ("get-file-char misused");
-  return make_number (readbyte_from_stdio ());
 }
 
 
@@ -4462,7 +4427,6 @@ syms_of_lread (void)
   defsubr (&Sread_char);
   defsubr (&Sread_char_exclusive);
   defsubr (&Sread_event);
-  defsubr (&Sget_file_char);
   defsubr (&Slocate_file_internal);
 
   DEFVAR_LISP ("obarray", Vobarray,


### PR DESCRIPTION
I was on the fence on whether or not to port `readbyte_from_stdio`, as it relies on a lot of behaviour that's expressed much more elegantly in c than rust, but I think i managed to get it right.

Closes #1300.