### PR TITLE
Added necessary libraries for fedora

### DIFF
--- a/docker/fedora/Dockerfile
+++ b/docker/fedora/Dockerfile
@@ -1,6 +1,6 @@
 FROM fedora:latest
 
-RUN yum install -y \
+RUN dnf install -y \
     git \
     gcc gcc-c++ \
     kernel-devel \
@@ -14,6 +14,8 @@ RUN yum install -y \
     libxml2-devel \
     libXpm-devel \
     gnutls-devel \
+    clang-devel \
+    libXt-devel \
     curl \
     texinfo
 

--- a/docker/fedora/config.yaml
+++ b/docker/fedora/config.yaml
@@ -2,7 +2,7 @@
 arch: x86_64
 distro: fedora:latest
 base_config: |
-    RUN yum install -y \
+    RUN dnf install -y \
         git \
         gcc gcc-c++ \
         kernel-devel \
@@ -16,5 +16,7 @@ base_config: |
         libxml2-devel \
         libXpm-devel \
         gnutls-devel \
+        clang-devel \
+        libXt-devel \
         curl \
         texinfo


### PR DESCRIPTION
Also, yum is deprecated and may be removed in Fedora 30, so change to
dnf.

Closes #1327