### PR TITLE
Port text-properties-at

### DIFF
--- a/rust_src/src/textprop.rs
+++ b/rust_src/src/textprop.rs
@@ -47,8 +47,9 @@ pub fn text_properties_at(mut position: LispObject, mut object: LispObject) -> L
         object = ThreadState::current_buffer().into();
     }
 
+    let position_pointer = &mut position as *mut LispObject;
     let i: *mut Lisp_Interval =
-        unsafe { validate_interval_range(object, &mut position, &mut position, false) };
+        unsafe { validate_interval_range(object, position_pointer, position_pointer, false) };
 
     if ptr::eq(i, ptr::null_mut()) {
         return Qnil;
@@ -59,12 +60,11 @@ pub fn text_properties_at(mut position: LispObject, mut object: LispObject) -> L
         // it means it's the end of OBJECT.
         // There are no properties at the very end,
         // since no character follows.
-        let position_isize = EmacsInt::from(position) as isize;
-        if position_isize == ((*i).total_length + (*i).position) {
-            return Qnil;
+        if EmacsInt::from(position) == (((*i).total_length + (*i).position) as EmacsInt) {
+            Qnil
+        } else {
+            (*i).plist
         }
-
-        (*i).plist
     }
 }
 

--- a/rust_src/src/textprop.rs
+++ b/rust_src/src/textprop.rs
@@ -65,11 +65,24 @@ pub fn text_properties_at(mut position: LispObject, mut object: LispObject) -> L
         // it means it's the end of OBJECT.
         // There are no properties at the very end,
         // since no character follows.
-        if EmacsInt::from(position) == (((*i).total_length + (*i).position) as EmacsInt) {
+        let interval_length = total_length(i) - total_length((*i).right) - total_length((*i).left);
+        if EmacsInt::from(position) == (interval_length + (*i).position) as EmacsInt {
             Qnil
         } else {
             (*i).plist
         }
+    }
+}
+
+// A temporary replacement for the TOTAL_LENGTH macro from intervals.h
+// Ideally we would implement a LispIntervalRef type to house this
+// logic, but this function is here for the moment to keep the scope
+// of these changes manageable.
+unsafe fn total_length(interval: *mut Lisp_Interval) -> isize {
+    if interval.is_null() {
+        0
+    } else {
+        (*interval).total_length
     }
 }
 

--- a/rust_src/src/textprop.rs
+++ b/rust_src/src/textprop.rs
@@ -55,10 +55,10 @@ pub fn text_properties_at(mut position: LispObject, mut object: LispObject) -> L
     }
 
     unsafe {
-        /* If POSITION is at the end of the interval,
-        it means it's the end of OBJECT.
-        There are no properties at the very end,
-        since no character follows.  */
+        // If POSITION is at the end of the interval,
+        // it means it's the end of OBJECT.
+        // There are no properties at the very end,
+        // since no character follows.
         let position_isize = EmacsInt::from(position) as isize;
         if position_isize == ((*i).total_length + (*i).position) {
             return Qnil;

--- a/rust_src/src/textprop.rs
+++ b/rust_src/src/textprop.rs
@@ -7,11 +7,11 @@ use remacs_macros::lisp_fn;
 use crate::{
     lisp::LispObject,
     numbers::LispNumber,
-    remacs_sys::Ftext_properties_at,
     remacs_sys::{
         get_char_property_and_overlay, set_text_properties, textget, validate_interval_range,
     },
-    remacs_sys::{EmacsInt, Lisp_Interval, Qnil, Qt, ThreadState},
+    remacs_sys::{EmacsInt, Lisp_Interval, Qnil, Qt},
+    threads::ThreadState,
 };
 
 /// Return the value of POSITION's property PROP, in OBJECT.

--- a/rust_src/src/textprop.rs
+++ b/rust_src/src/textprop.rs
@@ -51,7 +51,7 @@ pub fn text_properties_at(mut position: LispObject, mut object: LispObject) -> L
     let i: *mut Lisp_Interval =
         unsafe { validate_interval_range(object, position_pointer, position_pointer, false) };
 
-    if ptr::eq(i, ptr::null_mut()) {
+    if i.is_null() {
         return Qnil;
     }
 

--- a/rust_src/src/textprop.rs
+++ b/rust_src/src/textprop.rs
@@ -47,9 +47,14 @@ pub fn text_properties_at(mut position: LispObject, mut object: LispObject) -> L
         object = ThreadState::current_buffer().into();
     }
 
-    let position_pointer = &mut position as *mut LispObject;
-    let i: *mut Lisp_Interval =
-        unsafe { validate_interval_range(object, position_pointer, position_pointer, false) };
+    let i: *mut Lisp_Interval = unsafe {
+        validate_interval_range(
+            object,
+            &mut position as *mut LispObject,
+            &mut position as *mut LispObject,
+            false,
+        )
+    };
 
     if i.is_null() {
         return Qnil;

--- a/src/textprop.c
+++ b/src/textprop.c
@@ -550,33 +550,6 @@ interval_of (ptrdiff_t position, Lisp_Object object)
 
   return find_interval (i, position);
 }
-
-DEFUN ("text-properties-at", Ftext_properties_at,
-       Stext_properties_at, 1, 2, 0,
-       doc: /* Return the list of properties of the character at POSITION in OBJECT.
-If the optional second argument OBJECT is a buffer (or nil, which means
-the current buffer), POSITION is a buffer position (integer or marker).
-If OBJECT is a string, POSITION is a 0-based index into it.
-If POSITION is at the end of OBJECT, the value is nil.  */)
-  (Lisp_Object position, Lisp_Object object)
-{
-  register INTERVAL i;
-
-  if (NILP (object))
-    XSETBUFFER (object, current_buffer);
-
-  i = validate_interval_range (object, &position, &position, soft);
-  if (!i)
-    return Qnil;
-  /* If POSITION is at the end of the interval,
-     it means it's the end of OBJECT.
-     There are no properties at the very end,
-     since no character follows.  */
-  if (XINT (position) == LENGTH (i) + i->position)
-    return Qnil;
-
-  return i->plist;
-}
 
 /* Return the value of char's property PROP, in OBJECT at POSITION.
    OBJECT is optional and defaults to the current buffer.
@@ -2327,7 +2300,6 @@ inherits it if NONSTICKINESS is nil.  The `front-sticky' and
   DEFSYM (Qpoint_left, "point-left");
   DEFSYM (Qpoint_entered, "point-entered");
 
-  defsubr (&Stext_properties_at);
   defsubr (&Sget_char_property_and_overlay);
   defsubr (&Snext_char_property_change);
   defsubr (&Sprevious_char_property_change);


### PR DESCRIPTION
This is my initial attempt at porting the text-properties-at function. 

The code as it is right now causes a failure in `test/lisp/emacs-lisp/ert-x-tests.el`, in the tests for `propertized-string`:

```
Test ert-propertized-string condition:
    (args-out-of-range
     #("abcd" 1 2
       (a b)
       2 4
       (c t))
     4 5)
   FAILED  2/9  ert-propertized-string
```

I'm pretty sure I'm doing something wrong in the call to validate_interval_range, but unfortunately my knowledge isn't great enough to figure out what the right way to call it would be. Any help on that would be appreciated :).

Also, is there a way to run a single lisp test file? 