### PR TITLE
WIP keymap functions

### DIFF
--- a/rust_src/src/buffers.rs
+++ b/rust_src/src/buffers.rs
@@ -251,6 +251,10 @@ impl LispBufferRef {
         self.zv_marker_
     }
 
+    pub fn get_zv(self) -> isize{
+        self.zv
+    }
+
     pub fn mark(self) -> LispObject {
         self.mark_
     }
@@ -284,6 +288,10 @@ impl LispBufferRef {
     pub fn set_pt_both(&mut self, charpos: ptrdiff_t, byte: ptrdiff_t) {
         self.pt = charpos;
         self.pt_byte = byte;
+    }
+
+    pub fn get_pt(self) -> isize {
+        self.pt
     }
 
     pub fn set_begv_both(&mut self, charpos: ptrdiff_t, byte: ptrdiff_t) {

--- a/rust_src/src/buffers.rs
+++ b/rust_src/src/buffers.rs
@@ -251,7 +251,7 @@ impl LispBufferRef {
         self.zv_marker_
     }
 
-    pub fn get_zv(self) -> isize{
+    pub fn get_zv(self) -> isize {
         self.zv
     }
 

--- a/rust_src/src/keymap.rs
+++ b/rust_src/src/keymap.rs
@@ -25,12 +25,12 @@ use crate::{
         access_keymap, apropos_accum, apropos_accumulate, apropos_predicate, copy_keymap_item,
         describe_vector, make_save_funcptr_ptr_obj, map_char_table, map_keymap_call,
         map_keymap_char_table_item, map_keymap_function_t, map_keymap_item, map_obarray,
-        maybe_quit, specbind, call2, safe_call1, list2, menu_item_eval_property,
+        maybe_quit, specbind, call2, safe_call1, list2, menu_item_eval_property, 
     },
     remacs_sys::{char_bits, current_global_map as _current_global_map, globals, EmacsInt,},
     remacs_sys::{
         Fcommand_remapping, Fcurrent_active_maps, Fevent_convert_list, Fmake_char_table,
-        Fset_char_table_range, Fterpri, Fcons, 
+        Fset_char_table_range, Fterpri, Fcons, Flength,
     },
     remacs_sys::{
         Qautoload, Qkeymap, Qkeymapp, Qmouse_click, Qnil, Qstandard_output, Qstring_lessp, Qt,
@@ -186,6 +186,29 @@ pub extern "C" fn _copy_keymap_item(elt: LispObject) -> LispObject {
         }
     }
     res.into()
+}
+
+// TODO Finish this
+#[no_mangle]
+pub extern "C" fn _preferred_sequence_p(seq: LispObject) -> i64 {
+    unsafe{
+        let mut i: i64 = 0;
+        let len:EmacsInt = Flength(seq).as_fixnum_coerce_marker_or_error();
+        let result: i8 = 1;
+        for i in 0..len {
+            unsafe{
+                let elt:LispObject = aref(seq, i);
+                if elt.is_not_integer() {
+                    0 as i64;
+                }
+                else {
+                    let modifiers = & (char_bits::CHAR_MODIFIER_MASK & !char_bits::CHAR_META);
+                }
+            }
+        }
+    }
+    // Make compiler shut up for now
+    0 as i64
 }
 
 // Which keymaps are reverse-stored in the cache.

--- a/rust_src/src/keymap.rs
+++ b/rust_src/src/keymap.rs
@@ -1,7 +1,6 @@
 //! Keymap support
 
 use std;
-use std::convert::TryInto;
 use std::ptr;
 
 use libc::{c_void, ptrdiff_t};

--- a/rust_src/src/keymap.rs
+++ b/rust_src/src/keymap.rs
@@ -22,19 +22,19 @@ use crate::{
     multibyte::LispStringRef,
     obarray::intern,
     remacs_sys::{
-        access_keymap, apropos_accum, apropos_accumulate, apropos_predicate, copy_keymap_item,
-        describe_vector, make_save_funcptr_ptr_obj, map_char_table, map_keymap_call,
-        map_keymap_char_table_item, map_keymap_function_t, map_keymap_item, map_obarray,
-        maybe_quit, specbind, call2, safe_call1, list2, menu_item_eval_property, 
+        access_keymap, apropos_accum, apropos_accumulate, apropos_predicate, call2,
+        copy_keymap_item, describe_vector, list2, make_save_funcptr_ptr_obj, map_char_table,
+        map_keymap_call, map_keymap_char_table_item, map_keymap_function_t, map_keymap_item,
+        map_obarray, maybe_quit, menu_item_eval_property, safe_call1, specbind,
     },
-    remacs_sys::{char_bits, current_global_map as _current_global_map, globals, EmacsInt,},
+    remacs_sys::{char_bits, current_global_map as _current_global_map, globals, EmacsInt},
     remacs_sys::{
-        Fcommand_remapping, Fcurrent_active_maps, Fevent_convert_list, Fmake_char_table,
-        Fset_char_table_range, Fterpri, Fcons, Flength,
+        Fcommand_remapping, Fcons, Fcurrent_active_maps, Fevent_convert_list, Flength,
+        Fmake_char_table, Fset_char_table_range, Fterpri,
     },
     remacs_sys::{
-        Qautoload, Qkeymap, Qkeymapp, Qmouse_click, Qnil, Qstandard_output, Qstring_lessp, Qt,
-        Qvector_or_char_table_p, Qkeymap_canonicalize, Qmenu_item, QCfilter, Qquote,
+        QCfilter, Qautoload, Qkeymap, Qkeymap_canonicalize, Qkeymapp, Qmenu_item, Qmouse_click,
+        Qnil, Qquote, Qstandard_output, Qstring_lessp, Qt, Qvector_or_char_table_p,
     },
     symbols::LispSymbolRef,
     threads::{c_specpdl_index, ThreadState},
@@ -63,14 +63,15 @@ pub extern "C" fn set_where_is_cache(val: LispObject) {
 }
 
 // TODO Change this wherever it is used in rust to this implementation
+// TODO: Is this function used anywhere? ripgrep cannot seem to find it
+
 // This function has an extra argument called dummy but it is not used.
 // original signature is :
 // map_keymap_call (Lisp_Object key, Lisp_Object val, Lisp_Object fun, void *dummy)
-// Is this function used anywhere? ripgrep cannot seem to find it
 // For now, this is simply ported and the dummy argument is ommitted
 #[no_mangle]
 pub extern "C" fn _map_keymap_call(key: LispObject, val: LispObject, fun: LispObject) {
-    unsafe{
+    unsafe {
         call2(fun, key, val);
     }
 }
@@ -79,69 +80,91 @@ pub extern "C" fn _map_keymap_call(key: LispObject, val: LispObject, fun: LispOb
 // Same as map_keymap, but does it right, properly eliminating duplicate
 // bindings due to inheritance.
 #[no_mangle]
-pub extern "C" fn _map_keymap_canonical(map: LispObject, fun: map_keymap_function_t, args: LispObject, data: *mut c_void){
-    unsafe{
+pub extern "C" fn _map_keymap_canonical(
+    map: LispObject,
+    fun: map_keymap_function_t,
+    args: LispObject,
+    data: *mut c_void,
+) {
+    unsafe {
         let map = safe_call1(Qkeymap_canonicalize, map);
         map_keymap_internal(map, fun, args, data);
     }
 }
 
 // Scopes are all messed up. Double check those
+
+/* Given OBJECT which was found in a slot in a keymap,
+   trace indirect definitions to get the actual definition of that slot.
+   An indirect definition is a list of the form
+   (KEYMAP . INDEX), where KEYMAP is a keymap or a symbol defined as one
+   and INDEX is the object to look up in KEYMAP to yield the definition.
+
+   Also if OBJECT has a menu string as the first element,
+   remove that.  Also remove a menu help string as second element.
+
+   If AUTOLOAD, load autoloadable keymaps
+   that are referred to with indirection.
+
+   This can GC because menu_item_eval_property calls Feval.  */
 #[no_mangle]
 pub extern "C" fn _get_keyelt(object: LispObject, autoload: bool) -> LispObject {
     loop {
-        
-        if object.is_not_cons(){
-           break object;
+        if object.is_not_cons() {
+            break object;
         }
 
-        // Store the lisp object as a lisp cons type to check its members
+        // Convert the lisp object to a cons-cell in order to manipulate it
         let consObject = object.as_cons().unwrap();
-        // TODO Perhaps check if this is indeed a lisp cons(check if as_cons returns nil/none)
-        // rather than trusting it
 
-        if consObject.car().eq(Qmenu_item){
-            if consObject.cdr().is_cons(){
+        // Local mutable copy of object since we cannot modify the object
+        // variable passed to the function
+        let mut localObject = object;
+
+        if consObject.car().eq(Qmenu_item) {
+            if consObject.cdr().is_cons() {
                 // set object to (cdr (cdr object))
-                let object = consObject.cdr().as_cons().unwrap().cdr();
+                localObject = consObject.cdr().as_cons().unwrap().cdr();
 
-                if object.is_cons() {
-                    let object = object.as_cons().unwrap().car();
-                    let object_iter = object.iter_cars(LispConsEndChecks::off, LispConsCircularChecks::on);
+                if localObject.is_cons() {
+                    localObject = localObject.as_cons().unwrap().car();
+                }
+                    let object_iter =
+                        localObject.iter_cars(LispConsEndChecks::on, LispConsCircularChecks::on);
 
                     // Iterate over every element in the list
-                    for val in object_iter{
-                       if val.eq(QCfilter) && autoload {
-                           // Get the next object in the list
-                           let filter = val.as_cons().unwrap().cdr();
+                    for val in object_iter {
+                        if val.eq(QCfilter) && autoload {
+                            // Get the next object in the list
+                            let mut filter = val.as_cons().unwrap().cdr();
 
-                           unsafe{
-                             let filter_list = list2(filter, list2(Qquote, object));
-                             let object = menu_item_eval_property(filter);
-                           }
-                           break;
-                       } 
+                            unsafe {
+                                filter = list2(filter, list2(Qquote, localObject));
+                                localObject = menu_item_eval_property(filter);
+                            }
+                            break;
+                        }
                     }
-                   
-                    
-                }
             }
             else {
-                break object;
+                // Return since object must be an invalid keymap
+                break localObject;
             }
         }
+        /* If the keymap contents looks like (STRING . DEFN), use DEFN.
+	Keymap alist elements like (CHAR MENUSTRING . DEFN)
+	will be used by HierarKey menus.  */
         else if consObject.cdr().is_string() {
-            let object = consObject;
-        }
-        else{
-            break object;
+            localObject = consObject.into();
+        } else {
+            break localObject;
         }
     }
 }
 
 #[no_mangle]
 pub extern "C" fn _copy_keymap_item(elt: LispObject) -> LispObject {
-    if elt.is_not_cons(){
+    if elt.is_not_cons() {
         elt;
     }
 
@@ -150,36 +173,34 @@ pub extern "C" fn _copy_keymap_item(elt: LispObject) -> LispObject {
     let mut tem = elt;
 
     // Check if this is a new format menu item
-    if tem.car().eq(Qmenu_item){
+    if tem.car().eq(Qmenu_item) {
         // Copy the cell with menu-item marker
-        unsafe{
+        unsafe {
             res = Fcons(tem.car(), tem.cdr()).as_cons().unwrap();
             elt = Fcons(tem.car(), tem.cdr()).as_cons().unwrap();
 
             // Check if the next cell is a cons
-            if elt.cdr().is_cons(){
-               // Copy the cell with menu-item name 
-               elt.set_cdr(Fcons(tem.car(), tem.cdr()));
-               elt = elt.cdr().as_cons().unwrap();
-               tem = elt.cdr().as_cons().unwrap();
+            if elt.cdr().is_cons() {
+                // Copy the cell with menu-item name
+                elt.set_cdr(Fcons(tem.car(), tem.cdr()));
+                elt = elt.cdr().as_cons().unwrap();
+                tem = elt.cdr().as_cons().unwrap();
             }
         }
-    }
-    else{
-        if tem.car().is_string(){
-            unsafe{
+    } else {
+        if tem.car().is_string() {
+            unsafe {
                 res = Fcons(tem.car(), tem.cdr()).as_cons().unwrap();
                 elt = Fcons(tem.car(), tem.cdr()).as_cons().unwrap();
                 // Copy the cell since copy-alist iddn't go this deep
-                if tem.car().is_string(){
+                if tem.car().is_string() {
                     elt.set_cdr(Fcons(tem.car(), tem.cdr()));
                     elt = elt.cdr().as_cons().unwrap();
                     tem = elt.cdr().as_cons().unwrap();
                 }
-                if tem.car().eq(Qkeymap){
+                if tem.car().eq(Qkeymap) {
                     elt.set_cdr(copy_keymap(tem.into()));
-                }
-                else if tem.car().eq(Qkeymap){
+                } else if tem.car().eq(Qkeymap) {
                     res = copy_keymap(elt.into()).as_cons().unwrap();
                 }
             }
@@ -191,18 +212,17 @@ pub extern "C" fn _copy_keymap_item(elt: LispObject) -> LispObject {
 // TODO Finish this
 #[no_mangle]
 pub extern "C" fn _preferred_sequence_p(seq: LispObject) -> i64 {
-    unsafe{
+    unsafe {
         let mut i: i64 = 0;
-        let len:EmacsInt = Flength(seq).as_fixnum_coerce_marker_or_error();
+        let len: EmacsInt = Flength(seq).as_fixnum_coerce_marker_or_error();
         let result: i8 = 1;
         for i in 0..len {
-            unsafe{
-                let elt:LispObject = aref(seq, i);
+            unsafe {
+                let elt: LispObject = aref(seq, i);
                 if elt.is_not_integer() {
                     0 as i64;
-                }
-                else {
-                    let modifiers = & (char_bits::CHAR_MODIFIER_MASK & !char_bits::CHAR_META);
+                } else {
+                    let modifiers = &(char_bits::CHAR_MODIFIER_MASK & !char_bits::CHAR_META);
                 }
             }
         }

--- a/rust_src/src/keymap.rs
+++ b/rust_src/src/keymap.rs
@@ -241,8 +241,6 @@ pub extern "C" fn _click_position(position: LispObject) -> ptrdiff_t {
     args_out_of_range!(ThreadState::current_buffer_unchecked(), position);
 }
 
-//pub unsafe fn _store_in_keymap(keymap: LispObject, idx: LispObject, def: LispObject){
-
 // Help functions for describing and documenting keymaps
 struct _accessible_keymaps_data {
     maps: LispObject,

--- a/rust_src/src/keymap.rs
+++ b/rust_src/src/keymap.rs
@@ -29,7 +29,8 @@ use crate::{
         map_keymap_call, map_keymap_char_table_item, map_keymap_function_t, map_keymap_item,
         map_obarray, maybe_quit, menu_item_eval_property, safe_call1, specbind,
     },
-    remacs_sys::{char_bits, current_global_map as _current_global_map, globals, EmacsInt},
+    remacs_sys::{char_bits, current_global_map as _current_global_map,
+    globals, EmacsInt, PURE_P},
     remacs_sys::{
         Fcommand_remapping, Fcons, Fcurrent_active_maps, Fevent_convert_list, Flength,
         Fmake_char_table, Fset_char_table_range, Fterpri,
@@ -64,6 +65,8 @@ pub extern "C" fn set_where_is_cache(val: LispObject) {
     }
 }
 
+// Start here **************************
+
 // TODO Change this wherever it is used in rust to this implementation
 // TODO: Is this function used anywhere? ripgrep cannot seem to find it
 
@@ -79,8 +82,9 @@ pub extern "C" fn _map_keymap_call(key: LispObject, val: LispObject, fun: LispOb
 }
 
 // TODO Change this wherever it is used in rust to this implementation
-// Same as map_keymap, but does it right, properly eliminating duplicate
-// bindings due to inheritance.
+//
+/// Same as map_keymap, but does it right, properly eliminating duplicate
+/// bindings due to inheritance.
 #[no_mangle]
 pub extern "C" fn _map_keymap_canonical(
     map: LispObject,
@@ -163,7 +167,7 @@ pub extern "C" fn _get_keyelt(object: LispObject, autoload: bool) -> LispObject 
     }
 }
 
-// TODO: Fix this mess with all the unwrap
+// TODO: Fix this mess with all the unwrap but how?
 // TODO: Avoid using FCONS?
 #[no_mangle]
 pub extern "C" fn _copy_keymap_item(elt: LispObject) -> LispObject {
@@ -213,28 +217,6 @@ pub extern "C" fn _copy_keymap_item(elt: LispObject) -> LispObject {
     res.into()
 }
 
-// TODO Finish this
-#[no_mangle]
-pub extern "C" fn _preferred_sequence_p(seq: LispObject) -> i64 {
-    unsafe {
-        let mut i: i64 = 0;
-        let len: EmacsInt = Flength(seq).as_fixnum_coerce_marker_or_error();
-        let result: i8 = 1;
-        for i in 0..len {
-            unsafe {
-                let elt: LispObject = aref(seq, i);
-                if elt.is_not_integer() {
-                    0 as i64;
-                } else {
-                    let modifiers = &(char_bits::CHAR_MODIFIER_MASK & !char_bits::CHAR_META);
-                }
-            }
-        }
-    }
-    // Make compiler shut up for now
-    0 as i64
-}
-
 /* Return the offset of POSITION, a click position, in the style of
 the respective argument of Fkey_binding.  */
 pub extern "C" fn _click_position(position: LispObject) -> ptrdiff_t {
@@ -259,6 +241,8 @@ pub extern "C" fn _click_position(position: LispObject) -> ptrdiff_t {
     args_out_of_range!(ThreadState::current_buffer_unchecked(), position);
 }
 
+//pub unsafe fn _store_in_keymap(keymap: LispObject, idx: LispObject, def: LispObject){
+
 // Help functions for describing and documenting keymaps
 struct _accessible_keymaps_data {
     maps: LispObject,
@@ -267,6 +251,8 @@ struct _accessible_keymaps_data {
     // Does the current sequence end in the meta-prefix-char?
     is_metized: bool,
 }
+
+// End here *************************************
 
 // Which keymaps are reverse-stored in the cache.
 declare_GC_protected_static!(where_is_cache_keymaps, Qt);

--- a/rust_src/src/keymap.rs
+++ b/rust_src/src/keymap.rs
@@ -25,16 +25,16 @@ use crate::{
         access_keymap, apropos_accum, apropos_accumulate, apropos_predicate, copy_keymap_item,
         describe_vector, make_save_funcptr_ptr_obj, map_char_table, map_keymap_call,
         map_keymap_char_table_item, map_keymap_function_t, map_keymap_item, map_obarray,
-        maybe_quit, specbind, call2, safe_call1,
+        maybe_quit, specbind, call2, safe_call1, 
     },
     remacs_sys::{char_bits, current_global_map as _current_global_map, globals, EmacsInt,},
     remacs_sys::{
         Fcommand_remapping, Fcurrent_active_maps, Fevent_convert_list, Fmake_char_table,
-        Fset_char_table_range, Fterpri,
+        Fset_char_table_range, Fterpri, 
     },
     remacs_sys::{
         Qautoload, Qkeymap, Qkeymapp, Qmouse_click, Qnil, Qstandard_output, Qstring_lessp, Qt,
-        Qvector_or_char_table_p, Qkeymap_canonicalize,
+        Qvector_or_char_table_p, Qkeymap_canonicalize, Qmenu_item
     },
     symbols::LispSymbolRef,
     threads::{c_specpdl_index, ThreadState},
@@ -62,6 +62,7 @@ pub extern "C" fn set_where_is_cache(val: LispObject) {
     }
 }
 
+// TODO Change this wherever it is used in rust to this implementation
 // This function has an extra argument called dummy but it is not used.
 // original signature is :
 // map_keymap_call (Lisp_Object key, Lisp_Object val, Lisp_Object fun, void *dummy)
@@ -74,13 +75,42 @@ pub extern "C" fn _map_keymap_call(key: LispObject, val: LispObject, fun: LispOb
     }
 }
 
+// TODO Change this wherever it is used in rust to this implementation
 // Same as map_keymap, but does it right, properly eliminating duplicate
 // bindings due to inheritance.
-//#[no_mangle]
+#[no_mangle]
 pub extern "C" fn _map_keymap_canonical(map: LispObject, fun: map_keymap_function_t, args: LispObject, data: *mut c_void){
     unsafe{
         let map = safe_call1(Qkeymap_canonicalize, map);
         map_keymap_internal(map, fun, args, data);
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn _get_keyelt(object: LispObject, autoload: bool) -> LispObject {
+    loop {
+        
+        if object.is_not_cons(){
+           break object;
+        }
+        // Store the lisp object as a lisp cons type to check its members
+        let consObject = object.as_cons().unwrap();
+
+        if consObject.car().eq(Qmenu_item){
+
+            if consObject.cdr().is_cons(){
+                let object = consObject
+            }
+            else {
+                break object;
+            }
+        }
+        else if consObject.cdr().is_string() {
+            let object = consObject;
+        }
+        else{
+            break object;
+        }
     }
 }
 

--- a/rust_src/src/lists.rs
+++ b/rust_src/src/lists.rs
@@ -41,6 +41,10 @@ impl LispObject {
         self.get_type() == Lisp_Type::Lisp_Cons
     }
 
+    pub fn is_not_cons(self) -> bool {
+        self.get_type() != Lisp_Type::Lisp_Cons
+    }
+
     pub const fn force_cons(self) -> LispCons {
         LispCons(self)
     }

--- a/rust_src/src/numbers.rs
+++ b/rust_src/src/numbers.rs
@@ -145,6 +145,11 @@ impl LispObject {
     pub fn is_integer(self) -> bool {
         self.is_fixnum()
     }
+
+    /// TODO: Bignum support? (Current Emacs doesn't have it)
+    pub fn is_not_integer(self) -> bool {
+        !self.is_fixnum()
+    }
 }
 
 /// lisp_fn allows markers for LispNumber arguments


### PR DESCRIPTION
I have done some rough work on porting some keymap functions but I would love some feedback on the work so far. Right now, none of them have been tested but I am wondering if I am on the right track in terms of it being a faithful port(good rust practices) and any other general tips. I am quite new to rust so I am still trying to get comfortable with it.

There are some comments in the code which indicate what I would like to have looked at. One of the most troublesome functions is the `_copy_keymap_item` which is a mess of `unwrap` and `as_cons()`. I am hoping that there is a cleaner way or at the very least know that this is the most optimal way currently. Thanks in advance.